### PR TITLE
chore: enforce poetry run execution

### DIFF
--- a/.codex/AGENT_GUIDE.md
+++ b/.codex/AGENT_GUIDE.md
@@ -1,0 +1,22 @@
+# Codex Agent Guide (Short & Mandatory)
+
+**🚨 RULE ZERO:** Never run tools directly.  
+**Always** prefix commands with `poetry run`.
+
+✅ Correct:
+```bash
+poetry run pytest
+poetry run mypy src/
+poetry run ruff check src/
+poetry run maou --help
+```
+
+❌ Incorrect:
+```bash
+pytest
+mypy src/
+ruff check
+maou --help
+```
+
+**Scope:** tests, linters, type-checkers, formatters, project CLIs, CI examples, docs’ code blocks — **everything**.

--- a/.codex/COMMANDS.md
+++ b/.codex/COMMANDS.md
@@ -1,0 +1,14 @@
+# Allowed Commands (with Poetry Prefix)
+
+- Tests
+  - `poetry run pytest`
+  - `poetry run pytest --cov=src/maou`
+- Type-check
+  - `poetry run mypy src/`
+- Lint & Format
+  - `poetry run ruff format src/`
+  - `poetry run ruff check src/ --fix`
+  - `poetry run isort src/`
+  - `poetry run flake8 src/`
+- Project CLI
+  - `poetry run maou <subcommand> [options]`

--- a/.codex/SNIPPETS.md
+++ b/.codex/SNIPPETS.md
@@ -1,0 +1,20 @@
+# Common Snippets
+
+## Run unit tests quickly
+```bash
+poetry run pytest -q
+```
+
+## Run a single test file / node
+```bash
+poetry run pytest tests/app/test_converter.py::test_convert_basic -q
+```
+
+## Full QA before committing
+```bash
+poetry run ruff format src/
+poetry run ruff check src/ --fix
+poetry run isort src/
+poetry run mypy src/
+poetry run pytest -q
+```

--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,0 +1,27 @@
+version: 1
+policies:
+  shell:
+    run_prefix: "poetry run"
+    enforce_tools:
+      - pytest
+      - mypy
+      - ruff
+      - flake8
+      - isort
+      - coverage
+      - maou
+    deny_without_prefix: true
+  docs:
+    code_blocks:
+      languages: ["bash", "sh", "shell", "console"]
+      must_start_with_prefix: true
+defaults:
+  branch_naming: "feature/{ticket_or_topic}"
+  commit_convention: "conventional"
+  test_command: "poetry run pytest -q"
+  qa_pipeline:
+    - "poetry run ruff format src/"
+    - "poetry run ruff check src/ --fix"
+    - "poetry run isort src/"
+    - "poetry run mypy src/"
+    - "poetry run pytest -q"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to OpenAI Codex agents when working with code in this repository. Refer to it alongside `CLAUDE.md`, which remains available for Claude Code agents.
 
+> **For Codex agents:** Follow `.codex/config.yaml`, `.codex/AGENT_GUIDE.md`, and `.codex/COMMANDS.md`.
+> All shell commands **must** use `poetry run`.
+
 ## Development Guidelines
 
 When working on the Maou project, please follow these core principles:
@@ -63,13 +66,13 @@ poetry remove package-name
 
 ### Testing Requirements
 
-**Framework**: Use pytest
+**Framework**: Use `poetry run pytest`
 
 ```bash
-pytest                           # Run all tests
-pytest --cov=src/maou           # Run with coverage
-TEST_GCP=true pytest            # Test GCP features
-TEST_AWS=true pytest            # Test AWS features
+poetry run pytest                           # Run all tests
+poetry run pytest --cov=src/maou            # Run with coverage
+TEST_GCP=true poetry run pytest             # Test GCP features
+TEST_AWS=true poetry run pytest             # Test AWS features
 ```
 
 #### Test Requirements
@@ -101,7 +104,7 @@ poetry run ruff format src/ && poetry run ruff check src/ --fix && poetry run is
 ### Pre-commit Hooks
 ```bash
 poetry run bash scripts/pre-commit.sh    # Install hooks
-pre-commit run --all-files               # Run manually
+poetry run pre-commit run --all-files    # Run manually
 ```
 
 ## Environment Setup
@@ -204,7 +207,7 @@ poetry run maou --debug-mode hcpe-convert ...
 1. **Code Formatting**: `poetry run ruff format src/ && poetry run ruff check src/ --fix && poetry run isort src/`
 2. **Type Errors**: `poetry run mypy src/`
 3. **Linting Issues**: `poetry run flake8 src/`
-4. **Test Failures**: `pytest --tb=short`
+4. **Test Failures**: `poetry run pytest --tb=short`
 
 ## Commit Guidelines
 
@@ -215,7 +218,7 @@ poetry run ruff format src/
 poetry run ruff check src/ --fix
 poetry run isort src/
 poetry run mypy src/
-pytest
+poetry run pytest
 ```
 
 ### Commit Message Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ poetry remove package-name
 
 ### Testing Requirements
 
-**Framework**: Use pytest
+**Framework**: Use `poetry run pytest`
 
 ```bash
-pytest                           # Run all tests
-pytest --cov=src/maou           # Run with coverage
-TEST_GCP=true pytest            # Test GCP features
-TEST_AWS=true pytest            # Test AWS features
+poetry run pytest                           # Run all tests
+poetry run pytest --cov=src/maou            # Run with coverage
+TEST_GCP=true poetry run pytest             # Test GCP features
+TEST_AWS=true poetry run pytest             # Test AWS features
 ```
 
 #### Test Requirements
@@ -99,7 +99,7 @@ poetry run ruff format src/ && poetry run ruff check src/ --fix && poetry run is
 ### Pre-commit Hooks
 ```bash
 poetry run bash scripts/pre-commit.sh    # Install hooks
-pre-commit run --all-files               # Run manually
+poetry run pre-commit run --all-files    # Run manually
 ```
 
 ## Environment Setup
@@ -325,7 +325,7 @@ poetry run maou --debug-mode hcpe-convert ...
 1. **Code Formatting**: `poetry run ruff format src/ && poetry run ruff check src/ --fix && poetry run isort src/`
 2. **Type Errors**: `poetry run mypy src/`
 3. **Linting Issues**: `poetry run flake8 src/`
-4. **Test Failures**: `pytest --tb=short`
+4. **Test Failures**: `poetry run pytest --tb=short`
 
 ## Commit Guidelines
 
@@ -336,7 +336,7 @@ poetry run ruff format src/
 poetry run ruff check src/ --fix
 poetry run isort src/
 poetry run mypy src/
-pytest
+poetry run pytest
 ```
 
 ### Commit Message Format

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ gcloud auth application-default set-quota-project "your-project-id"
 なお，GCPを使ったテストをするときは以下のように行う．
 
 ```bash
-TEST_GCP=true pytest
+TEST_GCP=true poetry run pytest
 ```
 
 ### AWSを使う場合
@@ -70,5 +70,5 @@ aws configure sso --use-device-code --profile default
 なお，AWSを使ったテストをするときは以下のように行う．
 
 ```bash
-TEST_AWS=true pytest
+TEST_AWS=true poetry run pytest
 ```


### PR DESCRIPTION
## Summary
- add Codex configuration files documenting the required `poetry run` prefix
- update contributor guides to reference the new Codex resources and ensure command examples use `poetry run`
- refresh README instructions so test commands include the Poetry prefix

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f57c0ed8208327bc694df825ed680e