### PR TITLE
Document masked autoencoder pretraining usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,20 @@ aws configure sso --use-device-code --profile default
 ```bash
 TEST_AWS=true poetry run pytest
 ```
+
+## Masked Autoencoderの事前学習コマンド例
+
+`maou pretrain`コマンドでMasked Autoencoderの事前学習を行う．
+事前学習で保存したstate_dictは`maou learn-model --resume-from`オプションで読み込める．
+
+```bash
+poetry run maou pretrain \
+  --input-dir data/preprocessed \
+  --input-format preprocess \
+  --output-path artifacts/masked-autoencoder.pt \
+  --epochs 10 \
+  --batch-size 128 \
+  --learning-rate 1e-3 \
+  --mask-ratio 0.75 \
+  --hidden-dim 512
+```

--- a/src/maou/app/learning/masked_autoencoder.py
+++ b/src/maou/app/learning/masked_autoencoder.py
@@ -1,11 +1,108 @@
+from __future__ import annotations
+
+import dataclasses
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset
+
+from maou.app.learning.dl import LearningDataSource
+from maou.app.learning.setup import DataLoaderFactory, ModelFactory
+
+
+class _FeatureDataset(Dataset):
+    """Dataset that returns flattened feature tensors from a data source."""
+
+    def __init__(self, datasource: LearningDataSource) -> None:
+        if len(datasource) == 0:
+            msg = "Datasource contains no samples"
+            raise ValueError(msg)
+        first_record = datasource[0]
+        first_features = self._extract_features(first_record)
+        if first_features.ndim != 3:
+            msg = "features must be 3-dimensional (channels, height, width)"
+            raise ValueError(msg)
+
+        self.original_shape: tuple[int, ...] = tuple(first_features.shape)
+        self._num_features = int(first_features.size)
+        self._datasource = datasource
+
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        return len(self._datasource)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        record = self._datasource[idx]
+        features = self._extract_features(record)
+        flattened = np.ascontiguousarray(features.reshape(-1))
+        return torch.from_numpy(flattened)
+
+    @property
+    def num_features(self) -> int:
+        return self._num_features
+
+    @property
+    def feature_shape(self) -> tuple[int, int, int]:
+        channels, height, width = self.original_shape
+        return int(channels), int(height), int(width)
+
+    def _extract_features(self, record: np.ndarray) -> np.ndarray:
+        if record.dtype.names is None or "features" not in record.dtype.names:
+            msg = "Record does not contain 'features' field"
+            raise ValueError(msg)
+        features = np.asarray(record["features"], dtype=np.float32)
+        if features.ndim < 2:
+            msg = "features must be at least 2-dimensional"
+            raise ValueError(msg)
+        return features
+
+
+class _MaskedAutoencoder(nn.Module):
+    """Masked autoencoder that reuses the shogi mixer backbone as encoder."""
+
+    def __init__(
+        self,
+        *,
+        feature_shape: tuple[int, int, int],
+        hidden_dim: int,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        if hidden_dim <= 0:
+            msg = "hidden_dim must be a positive integer"
+            raise ValueError(msg)
+
+        self._feature_shape = feature_shape
+        self._flattened_size = int(np.prod(feature_shape))
+        channels = feature_shape[0]
+
+        self.encoder = ModelFactory.create_shogi_model(device)
+        self.decoder = nn.Sequential(
+            nn.Linear(channels, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, self._flattened_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.size(0)
+        reshaped = x.view(batch_size, *self._feature_shape)
+        encoded = self.encoder.backbone.forward_features(reshaped)
+        decoded = self.decoder(encoded)
+        return decoded.view(batch_size, -1)
+
+    def encoder_state_dict(self) -> Dict[str, Any]:
+        """Return the underlying encoder state for downstream training."""
+
+        return self.encoder.state_dict()
 
 
 class MaskedAutoencoderPretraining:
-    """Placeholder use case for masked autoencoder pretraining."""
+    """Masked autoencoder pretraining workflow."""
 
     logger: logging.Logger = logging.getLogger(__name__)
 
@@ -13,8 +110,18 @@ class MaskedAutoencoderPretraining:
     class Options:
         """Configuration options for masked autoencoder pretraining."""
 
-        input_dir: Optional[Path]
-        config_path: Optional[Path]
+        datasource: LearningDataSource.DataSourceSpliter
+        config_path: Optional[Path] = None
+        output_path: Optional[Path] = None
+        epochs: int = 5
+        batch_size: int = 64
+        learning_rate: float = 1e-3
+        mask_ratio: float = 0.75
+        device: Optional[str] = None
+        num_workers: int = 0
+        hidden_dim: int = 512
+        pin_memory: Optional[bool] = None
+        prefetch_factor: int = 2
 
     def run(
         self, options: "MaskedAutoencoderPretraining.Options"
@@ -25,16 +132,236 @@ class MaskedAutoencoderPretraining:
             options: Pretraining configuration options.
 
         Returns:
-            Placeholder message indicating the feature is not implemented.
+            Description of the completed training job including the
+            checkpoint path.
         """
+
+        resolved_options = self._apply_config_overrides(options)
+        training_datasource, _ = resolved_options.datasource.train_test_split(
+            test_ratio=0.0
+        )
+
+        if resolved_options.epochs <= 0:
+            msg = "epochs must be greater than zero"
+            raise ValueError(msg)
+        if resolved_options.batch_size <= 0:
+            msg = "batch_size must be greater than zero"
+            raise ValueError(msg)
+        if not 0.0 <= resolved_options.mask_ratio <= 1.0:
+            msg = "mask_ratio must be in the range [0.0, 1.0]"
+            raise ValueError(msg)
+        if resolved_options.prefetch_factor <= 0:
+            msg = "prefetch_factor must be greater than zero"
+            raise ValueError(msg)
+
+        dataset = _FeatureDataset(training_datasource)
+        output_path = self._resolve_output_path(resolved_options.output_path)
+        device = self._resolve_device(resolved_options.device)
+        pin_memory = self._resolve_pin_memory(
+            resolved_options.pin_memory, device
+        )
+
+        dataloader, _ = DataLoaderFactory.create_dataloaders(
+            dataset_train=dataset,
+            dataset_validation=dataset,
+            batch_size=resolved_options.batch_size,
+            dataloader_workers=resolved_options.num_workers,
+            pin_memory=pin_memory,
+            prefetch_factor=resolved_options.prefetch_factor,
+            drop_last_train=False,
+        )
+
+        model = _MaskedAutoencoder(
+            feature_shape=dataset.feature_shape,
+            hidden_dim=resolved_options.hidden_dim,
+            device=device,
+        ).to(device)
+        optimizer = torch.optim.Adam(
+            model.parameters(), lr=resolved_options.learning_rate
+        )
+
         self.logger.info(
-            "Masked autoencoder pretraining invoked (stub). Options: %s",
-            options,
+            "Starting masked autoencoder pretraining with %s samples",
+            len(dataset),
         )
-        return (
-            "Masked autoencoder pretraining is not implemented yet. "
-            f"Received options: {options}"
+
+        for epoch in range(resolved_options.epochs):
+            epoch_loss = self._run_epoch(
+                model=model,
+                dataloader=dataloader,
+                optimizer=optimizer,
+                device=device,
+                mask_ratio=resolved_options.mask_ratio,
+            )
+            self.logger.info(
+                "Epoch %d/%d - loss: %.6f",
+                epoch + 1,
+                resolved_options.epochs,
+                epoch_loss,
+            )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._persist_encoder_state_dict(model, output_path)
+        message = (
+            "Masked autoencoder pretraining finished. Saved state_dict to "
+            f"{output_path}"
         )
+        self.logger.info(message)
+        return message
+
+    def _apply_config_overrides(
+        self, options: "MaskedAutoencoderPretraining.Options"
+    ) -> "MaskedAutoencoderPretraining.Options":
+        if options.config_path is None:
+            return options
+        overrides = self._load_config(options.config_path)
+        option_dict = dataclasses.asdict(options)
+        for key, value in overrides.items():
+            if key == "config_path":
+                continue
+            if key == "datasource":
+                msg = "datasource cannot be overridden via configuration"
+                raise ValueError(msg)
+            if key not in option_dict:
+                msg = f"Unknown configuration option: {key}"
+                raise ValueError(msg)
+            option_dict[key] = self._coerce_option_value(key, value)
+        return MaskedAutoencoderPretraining.Options(**option_dict)
+
+    def _load_config(self, path: Path) -> Dict[str, Any]:
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            with path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        elif suffix == ".toml":
+            import tomllib  # Python 3.11+
+
+            with path.open("rb") as handle:
+                data = tomllib.load(handle)
+        else:
+            msg = (
+                "Unsupported configuration format. Use JSON or TOML: "
+                f"{path}"
+            )
+            raise ValueError(msg)
+        if not isinstance(data, dict):
+            msg = "Configuration file must define a mapping"
+            raise ValueError(msg)
+        return data
+
+    def _coerce_option_value(self, key: str, value: Any) -> Any:
+        path_keys = {"output_path"}
+        int_keys = {
+            "epochs",
+            "batch_size",
+            "num_workers",
+            "hidden_dim",
+            "prefetch_factor",
+        }
+        float_keys = {"learning_rate", "mask_ratio"}
+        if key in path_keys and value is not None:
+            return Path(value)
+        if key in int_keys and value is not None:
+            return int(value)
+        if key in float_keys and value is not None:
+            return float(value)
+        if key == "device" and value is not None:
+            return str(value)
+        if key == "pin_memory" and value is not None:
+            return bool(value)
+        return value
+
+    def _resolve_output_path(
+        self, output_path: Optional[Path]
+    ) -> Path:
+        if output_path is not None:
+            return output_path
+        return Path.cwd() / "masked_autoencoder_state.pt"
+
+    def _resolve_device(self, device_str: Optional[str]) -> torch.device:
+        if device_str is not None:
+            return torch.device(device_str)
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
+    def _resolve_pin_memory(
+        self, option: Optional[bool], device: torch.device
+    ) -> bool:
+        if option is not None:
+            return option
+        return device.type == "cuda"
+
+    def _run_epoch(
+        self,
+        *,
+        model: _MaskedAutoencoder,
+        dataloader: DataLoader,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        mask_ratio: float,
+    ) -> float:
+        model.train()
+        total_loss = 0.0
+        sample_count = 0
+        for batch in dataloader:
+            inputs = batch.to(device)
+            mask = self._generate_mask(inputs, mask_ratio)
+            masked_inputs = inputs.clone()
+            masked_inputs[mask] = 0.0
+
+            optimizer.zero_grad()
+            reconstructions = model(masked_inputs)
+            loss = self._compute_loss(
+                reconstructions, inputs, mask, device
+            )
+            loss.backward()
+            optimizer.step()
+
+            batch_size = inputs.size(0)
+            total_loss += float(loss.item()) * batch_size
+            sample_count += batch_size
+
+        if sample_count == 0:
+            msg = "Dataloader returned zero samples"
+            raise ValueError(msg)
+        return total_loss / sample_count
+
+    def _generate_mask(
+        self, inputs: torch.Tensor, mask_ratio: float
+    ) -> torch.Tensor:
+        if mask_ratio <= 0.0:
+            return torch.zeros_like(inputs, dtype=torch.bool)
+        if mask_ratio >= 1.0:
+            return torch.ones_like(inputs, dtype=torch.bool)
+        probabilities = torch.rand_like(inputs, dtype=torch.float32)
+        return probabilities < mask_ratio
+
+    def _compute_loss(
+        self,
+        reconstructions: torch.Tensor,
+        targets: torch.Tensor,
+        mask: torch.Tensor,
+        device: torch.device,
+    ) -> torch.Tensor:
+        mse = (reconstructions - targets) ** 2
+        mask_float = mask.to(device=device, dtype=targets.dtype)
+        if mask_float.sum().item() > 0:
+            loss = (mse * mask_float).sum() / mask_float.sum()
+        else:
+            loss = mse.mean()
+        return loss
+
+    def _persist_encoder_state_dict(
+        self, model: _MaskedAutoencoder, output_path: Path
+    ) -> None:
+        """Persist only the encoder parameters for downstream training."""
+
+        encoder_state = {
+            key: tensor.detach().cpu()
+            for key, tensor in model.encoder.state_dict().items()
+        }
+        torch.save(encoder_state, output_path)
 
 
 __all__ = ["MaskedAutoencoderPretraining"]

--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -135,6 +135,7 @@ class DataLoaderFactory:
         dataloader_workers: int,
         pin_memory: bool,
         prefetch_factor: int = 2,
+        drop_last_train: bool = True,
     ) -> Tuple[DataLoader, DataLoader]:
         """学習・検証用DataLoaderの作成."""
 
@@ -156,7 +157,7 @@ class DataLoaderFactory:
             prefetch_factor=prefetch_factor
             if dataloader_workers > 0
             else None,
-            drop_last=True,
+            drop_last=drop_last_train,
             timeout=120 if dataloader_workers > 0 else 0,
             worker_init_fn=worker_init_fn,
         )

--- a/src/maou/interface/pretrain.py
+++ b/src/maou/interface/pretrain.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional
 
+from maou.app.learning.dl import LearningDataSource
 from maou.app.learning.masked_autoencoder import (
     MaskedAutoencoderPretraining,
 )
@@ -10,20 +11,44 @@ __all__ = ["pretrain"]
 
 def pretrain(
     *,
-    input_dir: Optional[Path],
+    datasource: LearningDataSource.DataSourceSpliter,
     config_path: Optional[Path],
+    output_path: Optional[Path] = None,
+    epochs: int = 5,
+    batch_size: int = 64,
+    learning_rate: float = 1e-3,
+    mask_ratio: float = 0.75,
+    device: Optional[str] = None,
+    num_workers: int = 0,
+    hidden_dim: int = 512,
 ) -> str:
     """Execute the masked autoencoder pretraining workflow.
 
     Args:
-        input_dir: Optional path to the training data source.
+        datasource: Data source factory providing access to training data.
         config_path: Optional configuration file path.
+        output_path: Optional location to store the resulting state_dict.
+        epochs: Number of optimisation epochs.
+        batch_size: Mini-batch size for training.
+        learning_rate: Optimiser learning rate.
+        mask_ratio: Fraction of feature elements that will be masked.
+        device: Optional explicit device identifier (e.g. "cpu" or "cuda").
+        num_workers: Number of DataLoader workers.
+        hidden_dim: Hidden dimension size of the autoencoder MLP.
 
     Returns:
-        Placeholder message describing the stub status.
+        A message describing where the trained state_dict was saved.
     """
     options = MaskedAutoencoderPretraining.Options(
-        input_dir=input_dir,
+        datasource=datasource,
         config_path=config_path,
+        output_path=output_path,
+        epochs=epochs,
+        batch_size=batch_size,
+        learning_rate=learning_rate,
+        mask_ratio=mask_ratio,
+        device=device,
+        num_workers=num_workers,
+        hidden_dim=hidden_dim,
     )
     return MaskedAutoencoderPretraining().run(options)

--- a/tests/maou/infra/console/test_pretrain_cli.py
+++ b/tests/maou/infra/console/test_pretrain_cli.py
@@ -1,20 +1,56 @@
 from pathlib import Path
 
+import numpy as np
+import torch
 from click.testing import CliRunner
 
+from maou.domain.data.schema import create_empty_preprocessing_array
+from maou.interface.data_io import save_array
 from maou.infra.console.pretrain_cli import pretrain
+from maou.app.learning.setup import ModelFactory
+
+
+def _write_preprocessing_file(directory: Path, samples: int) -> None:
+    array = create_empty_preprocessing_array(samples)
+    rng = np.random.default_rng(321)
+    array["features"] = (
+        (rng.random((samples, 104, 9, 9)) > 0.5).astype(np.uint8)
+    )
+    save_array(
+        array,
+        directory / "preprocessing.npy",
+        array_type="preprocessing",
+        bit_pack=False,
+    )
 
 
 def test_pretrain_cli(tmp_path: Path) -> None:
+    _write_preprocessing_file(tmp_path, samples=6)
+    output_path = tmp_path / "weights.pt"
+
     runner = CliRunner()
     result = runner.invoke(
         pretrain,
         [
             "--input-dir",
             str(tmp_path),
+            "--output-path",
+            str(output_path),
+            "--epochs",
+            "1",
+            "--batch-size",
+            "2",
+            "--hidden-dim",
+            "32",
         ],
     )
 
     assert result.exit_code == 0
-    # App layer implementation is still a stub, so the CLI should surface the placeholder message.
-    assert "not implemented" in result.output.lower()
+    assert output_path.exists()
+    state_dict = torch.load(output_path, map_location="cpu")
+    assert isinstance(state_dict, dict)
+    assert state_dict
+    assert not any(key.startswith("decoder") for key in state_dict)
+    model = ModelFactory.create_shogi_model(torch.device("cpu"))
+    model.load_state_dict(state_dict)
+    assert "saved state_dict" in result.output.lower()

--- a/tests/maou/interface/test_pretrain_interface.py
+++ b/tests/maou/interface/test_pretrain_interface.py
@@ -1,16 +1,57 @@
 from pathlib import Path
 
+import numpy as np
+import torch
+
+from maou.app.learning.setup import ModelFactory
+
+from maou.domain.data.schema import create_empty_preprocessing_array
+from maou.interface.data_io import save_array
+from maou.infra.file_system.file_data_source import FileDataSource
 from maou.interface.pretrain import pretrain
 
 
-def test_pretrain_returns_placeholder(
-    tmp_path: Path,
-) -> None:
+def _create_dummy_datasource(
+    directory: Path, samples: int
+) -> FileDataSource.FileDataSourceSpliter:
+    array = create_empty_preprocessing_array(samples)
+    rng = np.random.default_rng(123)
+    array["features"] = (
+        (rng.random((samples, 104, 9, 9)) > 0.5).astype(np.uint8)
+    )
+    file_path = directory / "preprocessing.npy"
+    save_array(
+        array,
+        file_path,
+        array_type="preprocessing",
+        bit_pack=False,
+    )
+    return FileDataSource.FileDataSourceSpliter(
+        file_paths=[file_path],
+        array_type="preprocessing",
+        bit_pack=False,
+    )
+
+
+def test_pretrain_persists_state_dict(tmp_path: Path) -> None:
+    output_path = tmp_path / "state.pt"
+    datasource = _create_dummy_datasource(tmp_path, samples=8)
+
     result = pretrain(
-        input_dir=tmp_path,
+        datasource=datasource,
         config_path=None,
+        output_path=output_path,
+        epochs=1,
+        batch_size=4,
+        hidden_dim=32,
     )
 
     assert isinstance(result, str)
-    # App layer pretraining logic remains unimplemented for now, so the stub should emit this marker.
-    assert "not implemented" in result.lower()
+    assert output_path.exists()
+    state_dict = torch.load(output_path, map_location="cpu")
+    assert isinstance(state_dict, dict)
+    assert state_dict
+    assert not any(key.startswith("decoder") for key in state_dict)
+    model = ModelFactory.create_shogi_model(torch.device("cpu"))
+    model.load_state_dict(state_dict)
+    assert "saved state_dict" in result.lower()


### PR DESCRIPTION
## Summary
- document a concrete example command for running masked autoencoder pretraining with poetry and describe how to reuse the saved state_dict for fine-tuning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f59c96daa48327aaf7383e1ac17de6