### PR TITLE
feat: add compilation option to pretrain

### DIFF
--- a/src/maou/infra/console/pretrain_cli.py
+++ b/src/maou/infra/console/pretrain_cli.py
@@ -81,6 +81,12 @@ from maou.interface.pretrain import (
     help="Explicit device identifier (e.g. 'cpu' or 'cuda').",
 )
 @click.option(
+    "--compilation/--no-compilation",
+    default=False,
+    show_default=True,
+    help="Enable PyTorch compilation of the masked autoencoder.",
+)
+@click.option(
     "--dataloader-workers",
     "--num-workers",
     type=int,
@@ -123,6 +129,7 @@ def pretrain(
     learning_rate: float,
     mask_ratio: float,
     device: Optional[str],
+    compilation: bool,
     dataloader_workers: Optional[int],
     prefetch_factor: Optional[int],
     pin_memory: Optional[bool],
@@ -167,6 +174,7 @@ def pretrain(
         learning_rate=learning_rate,
         mask_ratio=mask_ratio,
         device=device,
+        compilation=compilation,
         num_workers=resolved_workers,
         pin_memory=pin_memory,
         prefetch_factor=resolved_prefetch,

--- a/src/maou/interface/pretrain.py
+++ b/src/maou/interface/pretrain.py
@@ -19,6 +19,7 @@ def pretrain(
     learning_rate: float = 1e-3,
     mask_ratio: float = 0.75,
     device: Optional[str] = None,
+    compilation: bool = False,
     num_workers: Optional[int] = None,
     pin_memory: Optional[bool] = None,
     prefetch_factor: Optional[int] = None,
@@ -35,6 +36,7 @@ def pretrain(
         learning_rate: Optimiser learning rate.
         mask_ratio: Fraction of feature elements that will be masked.
         device: Optional explicit device identifier (e.g. "cpu" or "cuda").
+        compilation: Enable PyTorch compilation for the autoencoder model.
         num_workers: Number of DataLoader workers. Defaults to 0 when omitted.
         pin_memory: Explicit pin_memory setting. Defaults based on device when None.
         prefetch_factor: Prefetch batches per worker. Defaults to 2 when omitted.
@@ -56,6 +58,7 @@ def pretrain(
         learning_rate=learning_rate,
         mask_ratio=mask_ratio,
         device=device,
+        compilation=compilation,
         num_workers=resolved_num_workers,
         pin_memory=pin_memory,
         prefetch_factor=resolved_prefetch_factor,


### PR DESCRIPTION
## Summary
- add a --compilation flag to the `maou pretrain` CLI and propagate the option through the interface layer
- compile the masked autoencoder model when requested and persist encoder weights as before
- cover the new option with interface and CLI tests that stub out `torch.compile`

## Testing
- poetry run pytest tests/maou/infra/console/test_pretrain_cli.py tests/maou/interface/test_pretrain_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68f5d2fe39a48327a7e4230867248626