### PR TITLE
feat: separate network heads for pretraining

### DIFF
--- a/src/maou/app/learning/masked_autoencoder.py
+++ b/src/maou/app/learning/masked_autoencoder.py
@@ -96,7 +96,7 @@ class _MaskedAutoencoder(nn.Module):
         self._flattened_size = int(np.prod(feature_shape))
         channels = feature_shape[0]
 
-        self.encoder = ModelFactory.create_shogi_model(device)
+        self.encoder = ModelFactory.create_shogi_backbone(device)
         self.decoder = nn.Sequential(
             nn.Linear(channels, hidden_dim),
             nn.GELU(),
@@ -106,9 +106,7 @@ class _MaskedAutoencoder(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         batch_size = x.size(0)
         reshaped = x.view(batch_size, *self._feature_shape)
-        encoded = self.encoder.backbone.forward_features(
-            reshaped
-        )
+        encoded = self.encoder.forward_features(reshaped)
         decoded = self.decoder(encoded)
         return decoded.view(batch_size, -1)
 

--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -12,7 +12,7 @@ from torch import optim
 from torch.utils.data import DataLoader
 
 from maou.app.learning.dataset import DataSource, KifDataset
-from maou.app.learning.network import Network
+from maou.app.learning.network import HeadlessNetwork, Network
 from maou.app.pre_process.label import MOVE_LABELS_NUM
 from maou.app.pre_process.transform import Transform
 from maou.domain.board.shogi import FEATURES_NUM
@@ -192,6 +192,28 @@ class ModelFactory:
     """モデル作成の共通化."""
 
     logger: logging.Logger = logging.getLogger(__name__)
+
+    @classmethod
+    def create_shogi_backbone(
+        cls, device: torch.device
+    ) -> HeadlessNetwork:
+        """方策・価値ヘッドを含まないMixerバックボーンを作成."""
+
+        backbone = HeadlessNetwork(
+            num_channels=FEATURES_NUM,
+            num_tokens=81,
+            token_dim=64,
+            channel_dim=256,
+            depth=4,
+        )
+
+        backbone.to(device)
+        cls.logger.info(
+            "Created shogi-optimized Lightweight MLP-Mixer backbone (%s)",
+            str(device),
+        )
+
+        return backbone
 
     @classmethod
     def create_shogi_model(

--- a/tests/maou/infra/console/test_pretrain_cli.py
+++ b/tests/maou/infra/console/test_pretrain_cli.py
@@ -70,7 +70,7 @@ def test_pretrain_cli(
     assert isinstance(state_dict, dict)
     assert state_dict
     assert not any(key.startswith("decoder") for key in state_dict)
-    model = ModelFactory.create_shogi_model(torch.device("cpu"))
-    model.load_state_dict(state_dict)
+    backbone = ModelFactory.create_shogi_backbone(torch.device("cpu"))
+    backbone.load_state_dict(state_dict)
     assert "saved state_dict" in result.output.lower()
     assert compile_called

--- a/tests/maou/interface/test_pretrain_interface.py
+++ b/tests/maou/interface/test_pretrain_interface.py
@@ -57,8 +57,8 @@ def test_pretrain_persists_state_dict(tmp_path: Path) -> None:
     assert isinstance(state_dict, dict)
     assert state_dict
     assert not any(key.startswith("decoder") for key in state_dict)
-    model = ModelFactory.create_shogi_model(torch.device("cpu"))
-    model.load_state_dict(state_dict)
+    backbone = ModelFactory.create_shogi_backbone(torch.device("cpu"))
+    backbone.load_state_dict(state_dict)
     assert "saved state_dict" in result.lower()
 
 


### PR DESCRIPTION
## Summary
- extract dedicated policy and value head modules from the shared mixer backbone
- add a headless shogi backbone factory for pretraining workflows and update the masked autoencoder to use it
- adjust pretraining tests to validate backbone-only checkpoints

## Testing
- poetry run pytest tests/maou/infra/console/test_pretrain_cli.py tests/maou/interface/test_pretrain_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68f5e853dcdc8327b175806f24e4decd