### PR TITLE
Update MLP-Mixer to sweet-spot configuration

### DIFF
--- a/src/maou/app/learning/network.py
+++ b/src/maou/app/learning/network.py
@@ -18,20 +18,24 @@ class HeadlessNetwork(nn.Module):
         *,
         num_channels: int = FEATURES_NUM,
         num_tokens: int = 81,
-        token_dim: int = 64,
-        channel_dim: int = 256,
-        depth: int = 4,
+        embed_dim: int = 256,
+        token_dim: int = 128,
+        channel_dim: int = 1024,
+        depth: int = 16,
+        dropout_rate: float = 0.15,
     ) -> None:
         super().__init__()
         self.backbone: LightweightMLPMixer = LightweightMLPMixer(
             num_classes=None,
             num_channels=num_channels,
             num_tokens=num_tokens,
+            embed_dim=embed_dim,
             token_dim=token_dim,
             channel_dim=channel_dim,
             depth=depth,
+            dropout_rate=dropout_rate,
         )
-        self._embedding_dim = num_channels
+        self._embedding_dim = embed_dim
 
     @property
     def embedding_dim(self) -> int:
@@ -132,18 +136,22 @@ class Network(HeadlessNetwork):
         num_policy_classes: int = MOVE_LABELS_NUM,
         num_channels: int = FEATURES_NUM,
         num_tokens: int = 81,
-        token_dim: int = 64,
-        channel_dim: int = 256,
-        depth: int = 4,
+        embed_dim: int = 256,
+        token_dim: int = 128,
+        channel_dim: int = 1024,
+        depth: int = 16,
+        dropout_rate: float = 0.15,
         policy_hidden_dim: int | None = None,
         value_hidden_dim: int | None = None,
     ) -> None:
         super().__init__(
             num_channels=num_channels,
             num_tokens=num_tokens,
+            embed_dim=embed_dim,
             token_dim=token_dim,
             channel_dim=channel_dim,
             depth=depth,
+            dropout_rate=dropout_rate,
         )
         self.policy_head = PolicyHead(
             input_dim=self.embedding_dim,

--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -202,9 +202,11 @@ class ModelFactory:
         backbone = HeadlessNetwork(
             num_channels=FEATURES_NUM,
             num_tokens=81,
-            token_dim=64,
-            channel_dim=256,
-            depth=4,
+            embed_dim=256,
+            token_dim=128,
+            channel_dim=1024,
+            depth=16,
+            dropout_rate=0.15,
         )
 
         backbone.to(device)
@@ -225,9 +227,11 @@ class ModelFactory:
             num_policy_classes=MOVE_LABELS_NUM,
             num_channels=FEATURES_NUM,
             num_tokens=81,
-            token_dim=64,
-            channel_dim=256,
-            depth=4,
+            embed_dim=256,
+            token_dim=128,
+            channel_dim=1024,
+            depth=16,
+            dropout_rate=0.15,
         )
 
         model.to(device)
@@ -259,7 +263,7 @@ class LossOptimizerFactory:
         model: torch.nn.Module,
         learning_ratio: float = 0.01,
         momentum: float = 0.9,
-        weight_decay: float = 0.0001,
+        weight_decay: float = 0.01,
     ) -> optim.SGD:
         """SGDオプティマイザを作成."""
         return optim.SGD(


### PR DESCRIPTION
## Summary
- rework the MLP-Mixer backbone around the sweet-spot 256-dim configuration with dropout and pre-norm blocks
- expose a lightweight model summary helper and add tests covering shape, parameter count, and summary output
- align network setup defaults and optimizer weight decay with the new regularized backbone

## Testing
- poetry run pytest tests/maou/domain/model/test_mlp_mixer.py

------
https://chatgpt.com/codex/tasks/task_e_68f5fe477b648327a772580846e2684b