### PR TITLE
Fix masked autoencoder decoder input dimension

### DIFF
--- a/src/maou/app/learning/masked_autoencoder.py
+++ b/src/maou/app/learning/masked_autoencoder.py
@@ -94,11 +94,14 @@ class _MaskedAutoencoder(nn.Module):
 
         self._feature_shape = feature_shape
         self._flattened_size = int(np.prod(feature_shape))
-        channels = feature_shape[0]
-
         self.encoder = ModelFactory.create_shogi_backbone(device)
+        encoder_output_dim = getattr(self.encoder, "embedding_dim", None)
+        if not isinstance(encoder_output_dim, int):
+            msg = "Encoder must expose integer embedding_dim"
+            raise TypeError(msg)
+
         self.decoder = nn.Sequential(
-            nn.Linear(channels, hidden_dim),
+            nn.Linear(encoder_output_dim, hidden_dim),
             nn.GELU(),
             nn.Linear(hidden_dim, self._flattened_size),
         )

--- a/tests/maou/app/learning/test_masked_autoencoder.py
+++ b/tests/maou/app/learning/test_masked_autoencoder.py
@@ -1,7 +1,3 @@
-"""Tests for masked autoencoder pretraining utilities."""
-
-from __future__ import annotations
-
 from typing import List
 
 import pytest
@@ -9,13 +5,31 @@ import torch
 
 from maou.app.learning.masked_autoencoder import (
     MaskedAutoencoderPretraining,
+    ModelFactory,
+    _MaskedAutoencoder,
 )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA support is required for this test"
-)
-def test_resolve_device_enables_tensorfloat32_for_cuda(monkeypatch: "pytest.MonkeyPatch") -> None:
+class _DummyBackbone(torch.nn.Module):
+    """Lightweight encoder stub returning a fixed embedding."""
+
+    def __init__(self, embedding_dim: int) -> None:
+        super().__init__()
+        self._embedding_dim = embedding_dim
+
+    @property
+    def embedding_dim(self) -> int:
+        return self._embedding_dim
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.size(0)
+        device = x.device
+        return torch.ones((batch_size, self._embedding_dim), device=device)
+
+
+def test_resolve_device_enables_tensorfloat32_for_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """TensorFloat32 matmul precision should be enabled when using CUDA devices."""
 
     calls: List[str] = []
@@ -29,7 +43,9 @@ def test_resolve_device_enables_tensorfloat32_for_cuda(monkeypatch: "pytest.Monk
     assert calls == ["high"]
 
 
-def test_resolve_device_skips_tensorfloat32_on_cpu(monkeypatch: "pytest.MonkeyPatch") -> None:
+def test_resolve_device_skips_tensorfloat32_on_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """TensorFloat32 matmul precision should remain disabled on CPU devices."""
 
     calls: List[str] = []
@@ -42,3 +58,35 @@ def test_resolve_device_skips_tensorfloat32_on_cpu(monkeypatch: "pytest.MonkeyPa
 
     assert device.type == "cpu"
     assert calls == []
+
+
+def test_masked_autoencoder_uses_encoder_embedding_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The decoder input dimension must match the encoder embedding size."""
+
+    embedding_dim = 32
+
+    def _create_backbone(cls, device: torch.device) -> _DummyBackbone:
+        return _DummyBackbone(embedding_dim=embedding_dim).to(device)
+
+    monkeypatch.setattr(
+        ModelFactory,
+        "create_shogi_backbone",
+        classmethod(_create_backbone),
+    )
+
+    feature_shape = (3, 4, 5)
+    model = _MaskedAutoencoder(
+        feature_shape=feature_shape,
+        hidden_dim=16,
+        device=torch.device("cpu"),
+    )
+
+    decoder_linear = model.decoder[0]
+    assert isinstance(decoder_linear, torch.nn.Linear)
+    assert decoder_linear.in_features == embedding_dim
+    flattened_size = feature_shape[0] * feature_shape[1] * feature_shape[2]
+    inputs = torch.randn(2, flattened_size)
+    outputs = model(inputs)
+    assert outputs.shape == (2, flattened_size)


### PR DESCRIPTION
## Summary
- ensure the masked autoencoder decoder projects from the encoder embedding size
- validate the decoder shape handling with a regression test while keeping existing device resolution checks

## Testing
- poetry run pytest tests/maou/app/learning/test_masked_autoencoder.py

------
https://chatgpt.com/codex/tasks/task_e_68f6180c724083278f00c2d894487e0e