### PR TITLE
Implement forward chunking for MAE pretraining

### DIFF
--- a/src/maou/infra/console/pretrain_cli.py
+++ b/src/maou/infra/console/pretrain_cli.py
@@ -117,6 +117,15 @@ from maou.interface.pretrain import (
     show_default=True,
     help="Hidden dimension of the autoencoder MLP.",
 )
+@click.option(
+    "--forward-chunk-size",
+    type=int,
+    default=None,
+    help=(
+        "Maximum number of samples processed per forward pass. "
+        "Defaults to an adaptive value."
+    ),
+)
 @handle_exception
 def pretrain(
     input_dir: Optional[Path],
@@ -134,6 +143,7 @@ def pretrain(
     prefetch_factor: Optional[int],
     pin_memory: Optional[bool],
     hidden_dim: int,
+    forward_chunk_size: Optional[int],
 ) -> None:
     """CLI entry point for masked autoencoder pretraining."""
     app_logger.info(
@@ -179,5 +189,6 @@ def pretrain(
         pin_memory=pin_memory,
         prefetch_factor=resolved_prefetch,
         hidden_dim=hidden_dim,
+        forward_chunk_size=forward_chunk_size,
     )
     click.echo(message)

--- a/src/maou/interface/pretrain.py
+++ b/src/maou/interface/pretrain.py
@@ -24,6 +24,7 @@ def pretrain(
     pin_memory: Optional[bool] = None,
     prefetch_factor: Optional[int] = None,
     hidden_dim: int = 512,
+    forward_chunk_size: Optional[int] = None,
 ) -> str:
     """Execute the masked autoencoder pretraining workflow.
 
@@ -41,6 +42,7 @@ def pretrain(
         pin_memory: Explicit pin_memory setting. Defaults based on device when None.
         prefetch_factor: Prefetch batches per worker. Defaults to 2 when omitted.
         hidden_dim: Hidden dimension size of the autoencoder MLP.
+        forward_chunk_size: Optional limit for forward micro-batch size.
 
     Returns:
         A message describing where the trained state_dict was saved.
@@ -49,7 +51,7 @@ def pretrain(
     resolved_prefetch_factor = (
         prefetch_factor if prefetch_factor is not None else 2
     )
-    options = MaskedAutoencoderPretraining.Options(
+    option_kwargs = dict(
         datasource=datasource,
         config_path=config_path,
         output_path=output_path,
@@ -64,4 +66,7 @@ def pretrain(
         prefetch_factor=resolved_prefetch_factor,
         hidden_dim=hidden_dim,
     )
+    if forward_chunk_size is not None:
+        option_kwargs["forward_chunk_size"] = forward_chunk_size
+    options = MaskedAutoencoderPretraining.Options(**option_kwargs)
     return MaskedAutoencoderPretraining().run(options)

--- a/tests/maou/app/learning/test_masked_autoencoder.py
+++ b/tests/maou/app/learning/test_masked_autoencoder.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 import torch
+from torch.utils.data import DataLoader
 
 from maou.app.learning.masked_autoencoder import (
     MaskedAutoencoderPretraining,
@@ -90,3 +91,55 @@ def test_masked_autoencoder_uses_encoder_embedding_dim(
     inputs = torch.randn(2, flattened_size)
     outputs = model(inputs)
     assert outputs.shape == (2, flattened_size)
+
+
+class _RecordingModel(torch.nn.Module):
+    """Model stub that records the maximum batch size seen during forward."""
+
+    def __init__(self, feature_dim: int) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(feature_dim, feature_dim)
+        self.max_batch_size = 0
+        self.forward_calls: List[int] = []
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.size(0)
+        self.max_batch_size = max(self.max_batch_size, batch_size)
+        self.forward_calls.append(batch_size)
+        return self.linear(x)
+
+
+def test_run_epoch_uses_forward_chunking() -> None:
+    """Batches should be split into micro-batches when a chunk size is set."""
+
+    batch_tensor = torch.randn(10, 4)
+    dataloader = DataLoader(batch_tensor, batch_size=10)
+    model = _RecordingModel(feature_dim=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    pretraining = MaskedAutoencoderPretraining()
+
+    loss = pretraining._run_epoch(
+        model=model,
+        dataloader=dataloader,
+        optimizer=optimizer,
+        device=torch.device("cpu"),
+        mask_ratio=0.0,
+        epoch_index=0,
+        total_epochs=1,
+        progress_bar=False,
+        forward_chunk_size=3,
+    )
+
+    assert loss >= 0.0
+    assert model.max_batch_size == 3
+    assert model.forward_calls == [3, 3, 3, 1]
+
+
+def test_forward_chunk_size_resolution() -> None:
+    """Requested chunk sizes should clamp to the dataloader batch size."""
+
+    pretraining = MaskedAutoencoderPretraining()
+
+    assert pretraining._resolve_forward_chunk_size(None, 32) == 32
+    assert pretraining._resolve_forward_chunk_size(16, 32) == 16
+    assert pretraining._resolve_forward_chunk_size(64, 32) == 32


### PR DESCRIPTION
## Summary
- add configurable forward chunk size and micro-batching to the masked autoencoder training loop to lower peak GPU memory usage
- surface the forward chunk size option through the interface and CLI, including validation and logging
- cover the new behaviour with unit tests for chunked execution and option resolution

## Testing
- poetry run pytest tests/maou/app/learning/test_masked_autoencoder.py

------
https://chatgpt.com/codex/tasks/task_e_68f61a3bcc7c83279c8c77f5027482c9