### PR TITLE
fix: wrap app vision transformer around domain model

### DIFF
--- a/src/maou/app/learning/masked_autoencoder.py
+++ b/src/maou/app/learning/masked_autoencoder.py
@@ -81,7 +81,7 @@ class _FeatureDataset(Dataset):
 
 
 class _MaskedAutoencoder(nn.Module):
-    """Masked autoencoder that reuses the shogi mixer backbone as encoder."""
+    """Masked autoencoder that reuses the shogi ViT backbone as encoder."""
 
     def __init__(
         self,

--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -197,21 +197,22 @@ class ModelFactory:
     def create_shogi_backbone(
         cls, device: torch.device
     ) -> HeadlessNetwork:
-        """方策・価値ヘッドを含まないMixerバックボーンを作成."""
+        """方策・価値ヘッドを含まないVision Transformerバックボーンを作成."""
 
         backbone = HeadlessNetwork(
             num_channels=FEATURES_NUM,
-            num_tokens=81,
-            embed_dim=256,
-            token_dim=128,
-            channel_dim=1024,
-            depth=16,
-            dropout_rate=0.15,
+            board_size=(9, 9),
+            embed_dim=512,
+            num_heads=8,
+            mlp_ratio=4.0,
+            depth=6,
+            dropout_rate=0.1,
+            attention_dropout_rate=0.1,
         )
 
         backbone.to(device)
         cls.logger.info(
-            "Created shogi-optimized Shogi MLP-Mixer backbone (%s)",
+            "Created shogi-optimized Vision Transformer backbone (%s)",
             str(device),
         )
 
@@ -221,22 +222,23 @@ class ModelFactory:
     def create_shogi_model(
         cls, device: torch.device
     ) -> Network:
-        """将棋特化のShogi MLP-Mixerモデルを作成."""
+        """将棋特化のVision Transformerモデルを作成."""
 
         model = Network(
             num_policy_classes=MOVE_LABELS_NUM,
             num_channels=FEATURES_NUM,
-            num_tokens=81,
-            embed_dim=256,
-            token_dim=128,
-            channel_dim=1024,
-            depth=16,
-            dropout_rate=0.15,
+            board_size=(9, 9),
+            embed_dim=512,
+            num_heads=8,
+            mlp_ratio=4.0,
+            depth=6,
+            dropout_rate=0.1,
+            attention_dropout_rate=0.1,
         )
 
         model.to(device)
         cls.logger.info(
-            f"Created shogi-optimized Shogi MLP-Mixer model ({str(device)})"
+            f"Created shogi-optimized Vision Transformer model ({str(device)})"
         )
 
         return model

--- a/tests/maou/app/learning/test_network.py
+++ b/tests/maou/app/learning/test_network.py
@@ -1,4 +1,4 @@
-"""Tests for the shogi MLP-Mixer based Network."""
+"""Tests for the shogi Vision Transformer based Network."""
 
 from __future__ import annotations
 

--- a/tests/maou/app/learning/test_vision_transformer.py
+++ b/tests/maou/app/learning/test_vision_transformer.py
@@ -7,42 +7,57 @@ import torch
 
 from torchinfo import summary
 
-from maou.app.learning.network import VisionTransformer
+from maou.app.learning.network import HeadlessNetwork
 from maou.domain.board.shogi import FEATURES_NUM
+from maou.domain.model.vision_transformer import (
+    VisionTransformer as DomainVisionTransformer,
+    VisionTransformerConfig,
+)
 
 
-def test_vision_transformer_returns_scalar_scores() -> None:
-    """The VisionTransformer should output a scalar per sample."""
+def test_headless_network_wraps_domain_vit() -> None:
+    """HeadlessNetwork should compose the domain VisionTransformer."""
 
-    model = VisionTransformer()
+    model = HeadlessNetwork()
+
+    assert isinstance(model.backbone, DomainVisionTransformer)
+    assert model.backbone.head is None
+    assert model.embedding_dim == model.backbone.embedding_dim
+
+
+def test_headless_network_forward_returns_embeddings() -> None:
+    """HeadlessNetwork.forward should yield pooled embeddings."""
+
+    model = HeadlessNetwork()
     batch_size = 4
     inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
 
     outputs = model(inputs)
 
-    assert outputs.shape == (batch_size,)
+    assert outputs.shape == (batch_size, model.embedding_dim)
 
 
-def test_vision_transformer_rejects_invalid_shape() -> None:
+def test_headless_network_rejects_invalid_shape() -> None:
     """Invalid spatial dimensions should raise a descriptive error."""
 
-    model = VisionTransformer()
+    model = HeadlessNetwork()
     bad_inputs = torch.randn(1, FEATURES_NUM, 8, 8)
 
     with pytest.raises(ValueError):
         model(bad_inputs)
 
 
-def test_vision_transformer_summary_has_expected_layout() -> None:
+def test_domain_vit_summary_has_expected_layout() -> None:
     """torchinfo summary should reflect the expected transformer layout."""
 
-    model = VisionTransformer()
+    config = VisionTransformerConfig()
+    model = DomainVisionTransformer(config)
     stats = summary(
         model,
-        input_size=(1, FEATURES_NUM, 9, 9),
+        input_size=(1, config.input_channels, config.board_size, config.board_size),
         verbose=0,
         depth=3,
     )
 
     assert stats.total_params == 19_011_073
-    assert len(model.encoder) == model.config.num_layers
+    assert len(model.encoder) == config.num_layers


### PR DESCRIPTION
## Summary
- refactor the app-level VisionTransformer to wrap the domain implementation
- keep the existing input validation while delegating to the shared domain model

## Testing
- poetry run pytest tests/maou/app/learning/test_vision_transformer.py

------
https://chatgpt.com/codex/tasks/task_e_68f78e9f348c83278d4e128ea716a70c