### PR TITLE
fix: disable dynamic shapes when compiling models

### DIFF
--- a/src/maou/app/learning/compilation.py
+++ b/src/maou/app/learning/compilation.py
@@ -7,10 +7,10 @@ from typing import Final
 import torch
 
 
-_DYNAMIC_COMPILATION: Final[bool] = True
+_DYNAMIC_COMPILATION: Final[bool] = False
 
 
 def compile_module(module: torch.nn.Module) -> torch.nn.Module:
-    """Return a ``torch.compile`` wrapped module using dynamic shapes."""
+    """Return a ``torch.compile`` wrapped module with static shapes."""
 
     return torch.compile(module, dynamic=_DYNAMIC_COMPILATION)

--- a/src/maou/app/learning/dl.py
+++ b/src/maou/app/learning/dl.py
@@ -133,7 +133,7 @@ class Learning:
 
         if config.compilation:
             self.logger.info(
-                "Compiling model with torch.compile (dynamic shapes enabled)"
+                "Compiling model with torch.compile (dynamic shapes disabled)"
             )
             self.model = cast(Network, compile_module(self.model))
         self.__train()

--- a/src/maou/app/utility/training_benchmark.py
+++ b/src/maou/app/utility/training_benchmark.py
@@ -437,7 +437,7 @@ class TrainingBenchmarkUseCase:
 
         if config.compilation:
             self.logger.info(
-                "Compiling model with torch.compile for benchmarking (dynamic shapes enabled)"
+                "Compiling model with torch.compile for benchmarking (dynamic shapes disabled)"
             )
             model_components.model = compile_module(
                 model_components.model


### PR DESCRIPTION
## Summary
- disable dynamic shapes for torch.compile generated modules
- update log messages to reflect static compilation behaviour

## Testing
- poetry run pytest tests/maou/app/learning/test_dl.py

------
https://chatgpt.com/codex/tasks/task_e_68f79d9473808327ac1d545dd0cfe5a7