### PR TITLE
fix: migrate sdpa kernel context manager

### DIFF
--- a/src/maou/domain/model/vision_transformer.py
+++ b/src/maou/domain/model/vision_transformer.py
@@ -126,8 +126,7 @@ class _FlashSelfAttention(nn.Module):
                     SDPBackend.FLASH_ATTENTION,
                     SDPBackend.EFFICIENT_ATTENTION,
                     SDPBackend.MATH,
-                ],
-                set_priority=True,
+                ]
             )
         elif use_cuda and has_legacy_sdpa:
             kernel_context = torch.backends.cuda.sdp_kernel(
@@ -151,8 +150,7 @@ class _FlashSelfAttention(nn.Module):
                 raise
             if has_new_sdpa:
                 fallback_context = torch_sdpa_kernel(
-                    [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH],
-                    set_priority=True,
+                    [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
                 )
             else:
                 fallback_context = torch.backends.cuda.sdp_kernel(


### PR DESCRIPTION
## Summary
- replace the deprecated torch.backends.cuda.sdp_kernel context manager with torch.nn.attention.sdpa_kernel when available
- preserve legacy fallback support for older PyTorch releases and runtime flash attention disablement

## Testing
- poetry run pytest tests/maou/domain/model/test_vision_transformer.py

------
https://chatgpt.com/codex/tasks/task_e_68f7ad11757c8327acfdfb0ff4d3b824