### PR TITLE
fix: use mse loss for value head

### DIFF
--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -256,7 +256,7 @@ class LossOptimizerFactory:
         loss_fn_policy = GCEwithNegativePenaltyLoss(
             q=gce_parameter
         )
-        loss_fn_value = torch.nn.BCEWithLogitsLoss()
+        loss_fn_value = torch.nn.MSELoss()
         return loss_fn_policy, loss_fn_value
 
     @classmethod


### PR DESCRIPTION
## Summary
- update the training setup to use mean squared error for the value loss

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_6905a41d6ebc8327bfb2af8584b94f69