### PR TITLE
Replace policy loss with cross entropy

### DIFF
--- a/src/maou/app/learning/training_loop.py
+++ b/src/maou/app/learning/training_loop.py
@@ -11,7 +11,6 @@ from maou.app.learning.callbacks import (
     TrainingCallback,
     TrainingContext,
 )
-from maou.domain.loss.loss_fn import GCEwithNegativePenaltyLoss
 
 
 class TrainingLoop:
@@ -23,7 +22,7 @@ class TrainingLoop:
         model: torch.nn.Module,
         device: torch.device,
         optimizer: torch.optim.Optimizer,
-        loss_fn_policy: GCEwithNegativePenaltyLoss,
+        loss_fn_policy: torch.nn.Module,
         loss_fn_value: torch.nn.Module,
         policy_loss_ratio: float,
         value_loss_ratio: float,
@@ -221,12 +220,14 @@ class TrainingLoop:
             for callback in self.callbacks:
                 callback.on_loss_computation_start(context)
 
+            policy_targets = torch.argmax(
+                context.labels_policy, dim=1
+            )
             context.loss = (
                 self.policy_loss_ratio
                 * self.loss_fn_policy(
                     context.outputs_policy,
-                    context.labels_policy,
-                    context.legal_move_mask,
+                    policy_targets,
                 )
                 + self.value_loss_ratio
                 * self.loss_fn_value(
@@ -301,12 +302,12 @@ class TrainingLoop:
         for callback in self.callbacks:
             callback.on_loss_computation_start(context)
 
+        policy_targets = torch.argmax(context.labels_policy, dim=1)
         context.loss = (
             self.policy_loss_ratio
             * self.loss_fn_policy(
                 context.outputs_policy,
-                context.labels_policy,
-                context.legal_move_mask,
+                policy_targets,
             )
             + self.value_loss_ratio
             * self.loss_fn_value(
@@ -377,12 +378,14 @@ class TrainingLoop:
             for callback in self.callbacks:
                 callback.on_loss_computation_start(context)
 
+            policy_targets = torch.argmax(
+                context.labels_policy, dim=1
+            )
             context.loss = (
                 self.policy_loss_ratio
                 * self.loss_fn_policy(
                     context.outputs_policy,
-                    context.labels_policy,
-                    context.legal_move_mask,
+                    policy_targets,
                 )
                 + self.value_loss_ratio
                 * self.loss_fn_value(
@@ -428,12 +431,12 @@ class TrainingLoop:
         for callback in self.callbacks:
             callback.on_loss_computation_start(context)
 
+        policy_targets = torch.argmax(context.labels_policy, dim=1)
         context.loss = (
             self.policy_loss_ratio
             * self.loss_fn_policy(
                 context.outputs_policy,
-                context.labels_policy,
-                context.legal_move_mask,
+                policy_targets,
             )
             + self.value_loss_ratio
             * self.loss_fn_value(

--- a/src/maou/app/utility/training_benchmark.py
+++ b/src/maou/app/utility/training_benchmark.py
@@ -17,7 +17,6 @@ from maou.app.learning.resource_monitor import ResourceUsage
 from maou.app.learning.compilation import compile_module
 from maou.app.learning.setup import TrainingSetup
 from maou.app.learning.training_loop import TrainingLoop
-from maou.domain.loss.loss_fn import GCEwithNegativePenaltyLoss
 
 
 @dataclass(frozen=True)
@@ -93,7 +92,7 @@ class SingleEpochBenchmark:
         model: Network,
         device: torch.device,
         optimizer: torch.optim.Optimizer,
-        loss_fn_policy: GCEwithNegativePenaltyLoss,
+        loss_fn_policy: torch.nn.Module,
         loss_fn_value: torch.nn.Module,
         policy_loss_ratio: float,
         value_loss_ratio: float,


### PR DESCRIPTION
## Summary
- switch the policy loss to torch.nn.CrossEntropyLoss and drop the legal move mask parameter
- update training setup and benchmarking utilities to use the new loss configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906bc9b8fbc83278b3afafb32de5db0