### PR TITLE
Switch HeadlessNetwork backbone to ResNet

### DIFF
--- a/tests/maou/app/learning/test_network.py
+++ b/tests/maou/app/learning/test_network.py
@@ -1,4 +1,4 @@
-"""Tests for the shogi Vision Transformer based Network."""
+"""Tests for the shogi ResNet based Network."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ def test_backbone_feature_dimension_matches_channels() -> None:
     network = Network()
     inputs = torch.randn(3, FEATURES_NUM, 9, 9)
 
-    features = network.backbone.forward_features(inputs)
+    features = network.forward_features(inputs)
 
     assert features.shape == (3, network.embedding_dim)
 

--- a/tests/maou/app/learning/test_vision_transformer.py
+++ b/tests/maou/app/learning/test_vision_transformer.py
@@ -1,4 +1,4 @@
-"""Tests for the VisionTransformer evaluation network."""
+"""Tests for the ResNet-based evaluation network."""
 
 from __future__ import annotations
 
@@ -9,20 +9,20 @@ from torchinfo import summary
 
 from maou.app.learning.network import HeadlessNetwork
 from maou.domain.board.shogi import FEATURES_NUM
+from maou.domain.model.resnet import ResNet as DomainResNet
 from maou.domain.model.vision_transformer import (
     VisionTransformer as DomainVisionTransformer,
     VisionTransformerConfig,
 )
 
 
-def test_headless_network_wraps_domain_vit() -> None:
-    """HeadlessNetwork should compose the domain VisionTransformer."""
+def test_headless_network_wraps_domain_resnet() -> None:
+    """HeadlessNetwork should compose the domain ResNet."""
 
     model = HeadlessNetwork()
 
-    assert isinstance(model.backbone, DomainVisionTransformer)
-    assert model.backbone.head is None
-    assert model.embedding_dim == model.backbone.embedding_dim
+    assert isinstance(model.backbone, DomainResNet)
+    assert model.embedding_dim == 2048
 
 
 def test_headless_network_forward_returns_embeddings() -> None:


### PR DESCRIPTION
## Summary
- replace the HeadlessNetwork/Network Vision Transformer backbone with a configurable ResNet implementation
- update the model factory helpers to instantiate the new ResNet defaults
- refresh the learning network tests to cover the ResNet backbone while keeping the domain ViT regression check

## Testing
- poetry run pytest tests/maou/app/learning/test_vision_transformer.py
- poetry run pytest tests/maou/app/learning/test_network.py

------
https://chatgpt.com/codex/tasks/task_e_6907fb40dccc832790bacdfbd12926ec