### PR TITLE
feat: add adamw optimizer support

### DIFF
--- a/docs/TRAINING_INVESTIGATION_REPORT.md
+++ b/docs/TRAINING_INVESTIGATION_REPORT.md
@@ -153,6 +153,14 @@ loss_fn_value = torch.nn.SmoothL1Loss()
 
 ## 推奨される修正コマンド
 
+### オプティマイザ選択の指針
+- `--optimizer adamw`（デフォルト）
+  - 既定のAdamWは学習率0.001前後で安定しており，重み減衰グループ分けと相性が良い．
+  - ベータやepsilonは `--optimizer-beta1`（既定0.9），`--optimizer-beta2`（既定0.999），`--optimizer-eps`（既定1e-8）で調整できる．
+- `--optimizer sgd`
+  - 既存のSGDベース実験を再現したい場合に使用する．
+  - `--momentum` でモーメントを指定する（デフォルト0.9）．
+
 ### 最小限の修正（即効性重視）
 ```bash
 poetry run maou learn-model \

--- a/src/maou/app/learning/dl.py
+++ b/src/maou/app/learning/dl.py
@@ -66,6 +66,10 @@ class Learning:
         value_loss_ratio: float
         learning_ratio: float
         momentum: float
+        optimizer_name: str
+        optimizer_beta1: float
+        optimizer_beta2: float
+        optimizer_eps: float
         resume_from: Optional[Path] = None
         start_epoch: int = 0
         log_dir: Path
@@ -103,6 +107,10 @@ class Learning:
                 gce_parameter=config.gce_parameter,
                 learning_ratio=config.learning_ratio,
                 momentum=config.momentum,
+                optimizer_name=config.optimizer_name,
+                optimizer_beta1=config.optimizer_beta1,
+                optimizer_beta2=config.optimizer_beta2,
+                optimizer_eps=config.optimizer_eps,
             )
         )
 

--- a/src/maou/app/utility/training_benchmark.py
+++ b/src/maou/app/utility/training_benchmark.py
@@ -389,6 +389,10 @@ class TrainingBenchmarkConfig:
     value_loss_ratio: float = 1.0
     learning_ratio: float = 0.01
     momentum: float = 0.9
+    optimizer_name: str = "adamw"
+    optimizer_beta1: float = 0.9
+    optimizer_beta2: float = 0.999
+    optimizer_eps: float = 1e-8
     warmup_batches: int = 5
     max_batches: Optional[int] = None
     enable_profiling: bool = False
@@ -431,6 +435,10 @@ class TrainingBenchmarkUseCase:
                 gce_parameter=config.gce_parameter,
                 learning_ratio=config.learning_ratio,
                 momentum=config.momentum,
+                optimizer_name=config.optimizer_name,
+                optimizer_beta1=config.optimizer_beta1,
+                optimizer_beta2=config.optimizer_beta2,
+                optimizer_eps=config.optimizer_eps,
             )
         )
 

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -258,6 +258,38 @@ S3DataSource: S3DataSourceType | None = getattr(
     required=False,
 )
 @click.option(
+    "--optimizer",
+    type=click.Choice(["adamw", "sgd"], case_sensitive=False),
+    help="Optimizer to use (default: adamw).",
+    required=False,
+    default="adamw",
+    show_default=True,
+)
+@click.option(
+    "--optimizer-beta1",
+    type=float,
+    help="AdamW beta1 parameter.",
+    required=False,
+    default=0.9,
+    show_default=True,
+)
+@click.option(
+    "--optimizer-beta2",
+    type=float,
+    help="AdamW beta2 parameter.",
+    required=False,
+    default=0.999,
+    show_default=True,
+)
+@click.option(
+    "--optimizer-eps",
+    type=float,
+    help="AdamW epsilon parameter.",
+    required=False,
+    default=1e-8,
+    show_default=True,
+)
+@click.option(
     "--resume-from",
     type=click.Path(path_type=Path),
     help="Checkpoint file to resume training.",
@@ -356,6 +388,10 @@ def learn_model(
     value_loss_ratio: Optional[float],
     learning_ratio: Optional[float],
     momentum: Optional[float],
+    optimizer: str,
+    optimizer_beta1: float,
+    optimizer_beta2: float,
+    optimizer_eps: float,
     resume_from: Optional[Path],
     start_epoch: Optional[int],
     log_dir: Optional[Path],
@@ -614,6 +650,10 @@ def learn_model(
             value_loss_ratio=value_loss_ratio,
             learning_ratio=learning_ratio,
             momentum=momentum,
+            optimizer_name=optimizer,
+            optimizer_beta1=optimizer_beta1,
+            optimizer_beta2=optimizer_beta2,
+            optimizer_eps=optimizer_eps,
             resume_from=resume_from,
             start_epoch=start_epoch,
             log_dir=log_dir,

--- a/src/maou/infra/console/utility.py
+++ b/src/maou/infra/console/utility.py
@@ -618,6 +618,38 @@ def benchmark_dataloader(
     default=0.9,
 )
 @click.option(
+    "--optimizer",
+    type=click.Choice(["adamw", "sgd"], case_sensitive=False),
+    help="Optimizer to use (default: adamw).",
+    required=False,
+    default="adamw",
+    show_default=True,
+)
+@click.option(
+    "--optimizer-beta1",
+    type=float,
+    help="AdamW beta1 parameter (default: 0.9).",
+    required=False,
+    default=0.9,
+    show_default=True,
+)
+@click.option(
+    "--optimizer-beta2",
+    type=float,
+    help="AdamW beta2 parameter (default: 0.999).",
+    required=False,
+    default=0.999,
+    show_default=True,
+)
+@click.option(
+    "--optimizer-eps",
+    type=float,
+    help="AdamW epsilon parameter (default: 1e-08).",
+    required=False,
+    default=1e-8,
+    show_default=True,
+)
+@click.option(
     "--warmup-batches",
     type=int,
     help="Number of warmup batches to exclude from timing (default: 5).",
@@ -691,6 +723,10 @@ def benchmark_training(
     value_loss_ratio: float,
     learning_ratio: float,
     momentum: float,
+    optimizer: str,
+    optimizer_beta1: float,
+    optimizer_beta2: float,
+    optimizer_eps: float,
     warmup_batches: int,
     max_batches: int,
     enable_profiling: Optional[bool],
@@ -899,6 +935,10 @@ def benchmark_training(
         value_loss_ratio=value_loss_ratio,
         learning_ratio=learning_ratio,
         momentum=momentum,
+        optimizer_name=optimizer,
+        optimizer_beta1=optimizer_beta1,
+        optimizer_beta2=optimizer_beta2,
+        optimizer_eps=optimizer_eps,
         warmup_batches=warmup_batches,
         max_batches=max_batches,
         enable_profiling=enable_profiling,

--- a/tests/maou/app/learning/test_setup.py
+++ b/tests/maou/app/learning/test_setup.py
@@ -1,0 +1,52 @@
+import numpy as np
+import torch
+
+from maou.app.learning.dataset import DataSource
+from maou.app.learning.setup import TrainingSetup
+from maou.app.pre_process.label import MOVE_LABELS_NUM
+from maou.domain.board.shogi import FEATURES_NUM
+
+
+class DummyPreprocessedDataSource(DataSource):
+    def __init__(self, length: int = 4) -> None:
+        dtype = np.dtype(
+            [
+                ("features", np.float32, (FEATURES_NUM, 9, 9)),
+                ("legalMoveMask", np.float32, (MOVE_LABELS_NUM,)),
+                ("moveLabel", np.float32, (MOVE_LABELS_NUM,)),
+                ("resultValue", np.float32),
+            ]
+        )
+        self._data = np.zeros(length, dtype=dtype)
+        self._data["legalMoveMask"] = 1.0
+        self._data["moveLabel"] = 1.0
+
+    def __getitem__(self, idx: int) -> np.ndarray:
+        return self._data[idx]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+def test_training_setup_uses_adamw_optimizer() -> None:
+    datasource = DummyPreprocessedDataSource(length=4)
+
+    _, _, model_components = TrainingSetup.setup_training_components(
+        training_datasource=datasource,
+        validation_datasource=datasource,
+        datasource_type="preprocess",
+        gpu="cpu",
+        batch_size=2,
+        dataloader_workers=0,
+        pin_memory=False,
+        prefetch_factor=2,
+        optimizer_name="adamw",
+        optimizer_beta1=0.85,
+        optimizer_beta2=0.98,
+        optimizer_eps=1e-7,
+    )
+
+    optimizer = model_components.optimizer
+    assert isinstance(optimizer, torch.optim.AdamW)
+    assert optimizer.defaults["betas"] == (0.85, 0.98)
+    assert optimizer.defaults["eps"] == 1e-07


### PR DESCRIPTION
## Summary
- allow selecting AdamW or SGD through training setup, interface options, and CLI
- thread optimizer hyperparameters across learning and benchmarking workflows and update documentation
- add regression test covering AdamW wiring

## Testing
- poetry run pytest tests/maou/app/learning/test_setup.py

------
https://chatgpt.com/codex/tasks/task_e_69087eec410c832796f91e1a9cbd579a