### PR TITLE
feat: add configurable learning backbones

### DIFF
--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -180,6 +180,20 @@ S3DataSource: S3DataSourceType | None = getattr(
     required=False,
 )
 @click.option(
+    "--model-architecture",
+    type=click.Choice(
+        list(learn.SUPPORTED_MODEL_ARCHITECTURES),
+        case_sensitive=False,
+    ),
+    help=(
+        "Backbone architecture to use. Supported values: "
+        + ", ".join(learn.SUPPORTED_MODEL_ARCHITECTURES)
+    ),
+    required=False,
+    default="resnet",
+    show_default=True,
+)
+@click.option(
     "--compilation",
     type=bool,
     help="Enable PyTorch compilation.",
@@ -376,6 +390,7 @@ def learn_model(
     input_data_name: Optional[str],
     input_max_workers: int,
     gpu: Optional[str],
+    model_architecture: str,
     compilation: bool,
     test_ratio: Optional[float],
     epoch: Optional[int],
@@ -633,11 +648,13 @@ def learn_model(
             "Please specify an input directory, a BigQuery table, "
             "a GCS bucket, or an S3 bucket."
         )
+    architecture_key = model_architecture.lower()
     click.echo(
         learn.learn(
             datasource=datasource,
             datasource_type=input_format,
             gpu=gpu,
+            model_architecture=architecture_key,
             compilation=compilation,
             test_ratio=test_ratio,
             epoch=epoch,

--- a/src/maou/interface/learn.py
+++ b/src/maou/interface/learn.py
@@ -9,6 +9,12 @@ from maou.app.learning.dl import (
     Learning,
     LearningDataSource,
 )
+from maou.app.learning.network import (
+    BACKBONE_ARCHITECTURES,
+    BackboneArchitecture,
+)
+
+SUPPORTED_MODEL_ARCHITECTURES = BACKBONE_ARCHITECTURES
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -64,6 +70,7 @@ def learn(
     datasource_type: str,
     *,
     gpu: Optional[str] = None,
+    model_architecture: BackboneArchitecture = "resnet",
     compilation: bool = False,
     test_ratio: Optional[float] = None,
     epoch: Optional[int] = None,
@@ -92,6 +99,7 @@ def learn(
         datasource: Training data source
         datasource_type: Type of data source ('hcpe' or 'preprocess')
         gpu: GPU device to use for training
+        model_architecture: Backbone architecture ('resnet', 'mlp-mixer', 'vit')
         compilation: Whether to compile the model
         test_ratio: Ratio of data to use for testing
         epoch: Number of training epochs
@@ -121,6 +129,13 @@ def learn(
     if datasource_type not in ("hcpe", "preprocess"):
         raise ValueError(
             f"Data source type `{datasource_type}` is invalid."
+        )
+
+    if model_architecture not in BACKBONE_ARCHITECTURES:
+        valid_options = ", ".join(BACKBONE_ARCHITECTURES)
+        raise ValueError(
+            f"model_architecture must be one of {valid_options}, "
+            f"got {model_architecture}"
         )
 
     # テスト割合設定 (デフォルト0.2)
@@ -298,6 +313,7 @@ def learn(
         start_epoch=start_epoch,
         log_dir=log_dir,
         model_dir=model_dir,
+        model_architecture=model_architecture,
     )
 
     learning_result = Learning(

--- a/tests/maou/app/learning/test_dl.py
+++ b/tests/maou/app/learning/test_dl.py
@@ -78,3 +78,12 @@ def test_load_resume_state_dict_requires_complete_state() -> None:
 
     with pytest.raises(RuntimeError):
         learning._load_resume_state_dict(state_dict)
+
+
+def test_format_parameter_count_generates_human_readable_labels() -> None:
+    """Learning._format_parameter_count should generate readable suffixes."""
+
+    assert Learning._format_parameter_count(4_000_000) == "4m"
+    assert Learning._format_parameter_count(1_250_000) == "1.2m"
+    assert Learning._format_parameter_count(125_000) == "125k"
+    assert Learning._format_parameter_count(512) == "512"

--- a/tests/maou/app/learning/test_setup.py
+++ b/tests/maou/app/learning/test_setup.py
@@ -5,6 +5,7 @@ from maou.app.learning.dataset import DataSource
 from maou.app.learning.setup import TrainingSetup
 from maou.app.pre_process.label import MOVE_LABELS_NUM
 from maou.domain.board.shogi import FEATURES_NUM
+from maou.domain.model.mlp_mixer import ShogiMLPMixer
 
 
 class DummyPreprocessedDataSource(DataSource):
@@ -50,3 +51,25 @@ def test_training_setup_uses_adamw_optimizer() -> None:
     assert isinstance(optimizer, torch.optim.AdamW)
     assert optimizer.defaults["betas"] == (0.85, 0.98)
     assert optimizer.defaults["eps"] == 1e-07
+
+
+def test_training_setup_supports_mlp_mixer_backbone() -> None:
+    datasource = DummyPreprocessedDataSource(length=4)
+
+    _, _, model_components = TrainingSetup.setup_training_components(
+        training_datasource=datasource,
+        validation_datasource=datasource,
+        datasource_type="preprocess",
+        gpu="cpu",
+        batch_size=2,
+        dataloader_workers=0,
+        pin_memory=False,
+        prefetch_factor=2,
+        optimizer_name="adamw",
+        optimizer_beta1=0.85,
+        optimizer_beta2=0.98,
+        optimizer_eps=1e-7,
+        model_architecture="mlp-mixer",
+    )
+
+    assert isinstance(model_components.model.backbone, ShogiMLPMixer)

--- a/tests/maou/app/learning/test_vision_transformer.py
+++ b/tests/maou/app/learning/test_vision_transformer.py
@@ -10,6 +10,7 @@ from torchinfo import summary
 from maou.app.learning.network import HeadlessNetwork
 from maou.domain.board.shogi import FEATURES_NUM
 from maou.domain.model.resnet import ResNet as DomainResNet
+from maou.domain.model.mlp_mixer import ShogiMLPMixer
 from maou.domain.model.vision_transformer import (
     VisionTransformer as DomainVisionTransformer,
     VisionTransformerConfig,
@@ -37,6 +38,32 @@ def test_headless_network_forward_returns_embeddings() -> None:
     assert outputs.shape == (batch_size, model.embedding_dim)
 
 
+def test_headless_network_supports_mlp_mixer_backbone() -> None:
+    """HeadlessNetwork should construct an MLP-Mixer backbone."""
+
+    model = HeadlessNetwork(architecture="mlp-mixer")
+    batch_size = 2
+    inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
+
+    outputs = model(inputs)
+
+    assert isinstance(model.backbone, ShogiMLPMixer)
+    assert outputs.shape == (batch_size, model.embedding_dim)
+
+
+def test_headless_network_supports_vit_backbone() -> None:
+    """HeadlessNetwork should construct a Vision Transformer backbone."""
+
+    model = HeadlessNetwork(architecture="vit")
+    batch_size = 2
+    inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
+
+    outputs = model(inputs)
+
+    assert isinstance(model.backbone, DomainVisionTransformer)
+    assert outputs.shape == (batch_size, model.embedding_dim)
+
+
 def test_headless_network_rejects_invalid_shape() -> None:
     """Invalid spatial dimensions should raise a descriptive error."""
 
@@ -45,6 +72,13 @@ def test_headless_network_rejects_invalid_shape() -> None:
 
     with pytest.raises(ValueError):
         model(bad_inputs)
+
+
+def test_headless_network_rejects_unknown_architecture() -> None:
+    """Unsupported architecture names should raise a clear error."""
+
+    with pytest.raises(ValueError):
+        HeadlessNetwork(architecture="unknown")  # type: ignore[arg-type]
 
 
 def test_domain_vit_summary_has_expected_layout() -> None:


### PR DESCRIPTION
## Summary
- add CLI and interface support for selecting ResNet, MLP-Mixer, or ViT learning backbones
- include the chosen model and approximate parameter count in tensorboard log directories
- cover the new behavior with unit tests for networks, setup, and logging utilities

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_6908aa1a38bc8327a3aacaa861d90e07