### PR TITLE
fix: avoid recreating model during save

### DIFF
--- a/src/maou/app/learning/model_io.py
+++ b/src/maou/app/learning/model_io.py
@@ -5,7 +5,6 @@ from typing import Optional
 import torch
 
 from maou.app.learning.network import Network
-from maou.app.learning.setup import ModelFactory
 from maou.domain.cloud_storage import CloudStorage
 from maou.domain.data.schema import (
     create_empty_preprocessing_array,
@@ -36,7 +35,13 @@ class ModelIO:
                 "`poetry install -E cpu-infer` to enable model export."
             ) from exc
 
-        model = ModelFactory.create_shogi_model(device)
+        model_for_export = getattr(trained_model, "_orig_mod", trained_model)
+        if not isinstance(model_for_export, torch.nn.Module):
+            model_for_export = trained_model
+
+        model_for_export = model_for_export.to(device)
+        trained_model_was_training = trained_model.training
+        model_for_export_was_training = model_for_export.training
 
         # torch.compile()で生成されたモデルのstate_dictは_orig_mod.プレフィックス付き
         # そのプレフィックスを除去して通常のモデルと互換性を保つ
@@ -46,7 +51,7 @@ class ModelIO:
             for key in state_dict.keys()
         ):
             # _orig_mod.プレフィックスを削除
-            clean_state_dict = {}
+            clean_state_dict: dict[str, torch.Tensor] = {}
             for key, value in state_dict.items():
                 if key.startswith("_orig_mod."):
                     clean_key = key[len("_orig_mod.") :]
@@ -55,12 +60,9 @@ class ModelIO:
                     clean_state_dict[key] = value
             state_dict = clean_state_dict
 
-        model.load_state_dict(state_dict)
-        # Training modeを確実に解除しておく
-        model.train(False)
         model_path = dir / "model_{}_{}.pt".format(id, epoch)
         logger.info("Saving model to {}".format(model_path))
-        torch.save(model.state_dict(), model_path)
+        torch.save(state_dict, model_path)
         if cloud_storage is not None:
             logger.info(
                 f"Uploading model to cloud storage ({model_path})"
@@ -72,80 +74,87 @@ class ModelIO:
         # AMPのような高速化をしたいので一部FP16にする
         # TensorRTに変換するときはONNXのFP32を利用してBuilderFlag.FP16を指定する
 
-        # torch.onnx.export
-        onnx_model_path = model_path.with_suffix(".onnx")
-        logger.info(
-            "Saving model to {}".format(onnx_model_path)
-        )
-        dummy_data = create_empty_preprocessing_array(1)
-        dummy_input = (
-            torch.from_numpy(dummy_data["features"].copy())
-            .to(torch.float32)
-            .to(device)
-        )
-        torch.onnx.export(
-            model=model,
-            args=(dummy_input,),
-            f=onnx_model_path,
-            export_params=True,
-            input_names=["input"],
-            output_names=["policy", "value"],
-            opset_version=20,
-            dynamic_axes={
-                "input": {0: "batch_size"},
-                "policy": {0: "batch_size"},
-                "value": {0: "batch_size"},
-            },
-        )
-
-        # ONNX最適化
-        onnx_model = onnx.load(f=onnx_model_path)
-        onnx_model = onnx.shape_inference.infer_shapes(
-            onnx_model
-        )
-        onnx_model_simp, check = onnxsim.simplify(onnx_model)
-        if not check:
-            raise RuntimeError("onnxsim.simplify failed")
-        onnx.save(onnx_model_simp, onnx_model_path)
-        if cloud_storage is not None:
+        try:
+            # torch.onnx.export
+            onnx_model_path = model_path.with_suffix(".onnx")
             logger.info(
-                f"Uploading model to cloud storage ({onnx_model_path})"
+                "Saving model to {}".format(onnx_model_path)
             )
-            cloud_storage.upload_from_local(
-                local_path=onnx_model_path,
-                cloud_path=str(onnx_model_path),
+            dummy_data = create_empty_preprocessing_array(1)
+            dummy_input = (
+                torch.from_numpy(dummy_data["features"].copy())
+                .to(torch.float32)
+                .to(device)
+            )
+            model_for_export.train(False)
+            torch.onnx.export(
+                model=model_for_export,
+                args=(dummy_input,),
+                f=onnx_model_path,
+                export_params=True,
+                input_names=["input"],
+                output_names=["policy", "value"],
+                opset_version=20,
+                dynamic_axes={
+                    "input": {0: "batch_size"},
+                    "policy": {0: "batch_size"},
+                    "value": {0: "batch_size"},
+                },
             )
 
-        # ONNX FP16バージョン作成
-        onnx_model_fp16_path = (
-            dir / (model_path.stem + "_fp16")
-        ).with_suffix(".onnx")
-        logger.info(
-            "Saving model to {}".format(onnx_model_fp16_path)
-        )
-        onnx_model_fp16 = float16.convert_float_to_float16(
-            model=onnx_model_simp,
-            keep_io_types=True,
-            op_block_list=[
-                "Gemm",
-                "GlobalAveragePool",
-                "Flatten",
-            ],  # FP16にしたくない演算 (出力層とか)
-        )
-        onnx.save(onnx_model_fp16, onnx_model_fp16_path)
-        # simplifyを挟もうとしたらエラーになったので一旦やめておく
-        # onnx_model_fp16 = onnx.shape_inference.infer_shapes(
-        #     onnx_model_fp16
-        # )
-        # onnx_model_simp_fp16, check = onnxsim.simplify(onnx_model_fp16)
-        # if not check:
-        #     raise RuntimeError("onnxsim.simplify failed")
-        # onnx.save(onnx_model_simp_fp16, onnx_model_fp16_path)
-        if cloud_storage is not None:
+            # ONNX最適化
+            onnx_model = onnx.load(f=onnx_model_path)
+            onnx_model = onnx.shape_inference.infer_shapes(
+                onnx_model
+            )
+            onnx_model_simp, check = onnxsim.simplify(onnx_model)
+            if not check:
+                raise RuntimeError("onnxsim.simplify failed")
+            onnx.save(onnx_model_simp, onnx_model_path)
+            if cloud_storage is not None:
+                logger.info(
+                    f"Uploading model to cloud storage ({onnx_model_path})"
+                )
+                cloud_storage.upload_from_local(
+                    local_path=onnx_model_path,
+                    cloud_path=str(onnx_model_path),
+                )
+
+            # ONNX FP16バージョン作成
+            onnx_model_fp16_path = (
+                dir / (model_path.stem + "_fp16")
+            ).with_suffix(".onnx")
             logger.info(
-                f"Uploading model to cloud storage ({onnx_model_fp16_path})"
+                "Saving model to {}".format(onnx_model_fp16_path)
             )
-            cloud_storage.upload_from_local(
-                local_path=onnx_model_fp16_path,
-                cloud_path=str(onnx_model_fp16_path),
+            onnx_model_fp16 = float16.convert_float_to_float16(
+                model=onnx_model_simp,
+                keep_io_types=True,
+                op_block_list=[
+                    "Gemm",
+                    "GlobalAveragePool",
+                    "Flatten",
+                ],  # FP16にしたくない演算 (出力層とか)
             )
+            onnx.save(onnx_model_fp16, onnx_model_fp16_path)
+            # simplifyを挟もうとしたらエラーになったので一旦やめておく
+            # onnx_model_fp16 = onnx.shape_inference.infer_shapes(
+            #     onnx_model_fp16
+            # )
+            # onnx_model_simp_fp16, check = onnxsim.simplify(onnx_model_fp16)
+            # if not check:
+            #     raise RuntimeError("onnxsim.simplify failed")
+            # onnx.save(onnx_model_simp_fp16, onnx_model_fp16_path)
+            if cloud_storage is not None:
+                logger.info(
+                    f"Uploading model to cloud storage ({onnx_model_fp16_path})"
+                )
+                cloud_storage.upload_from_local(
+                    local_path=onnx_model_fp16_path,
+                    cloud_path=str(onnx_model_fp16_path),
+                )
+        finally:
+            model_for_export.train(model_for_export_was_training)
+            if model_for_export is not trained_model:
+                trained_model.train(trained_model_was_training)
+

--- a/tests/maou/app/learning/test_model_io.py
+++ b/tests/maou/app/learning/test_model_io.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from maou.app.learning.model_io import ModelIO
+from maou.app.learning.network import Network
+
+
+class DummyOnnxModule(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("onnx")
+        self.shape_inference = types.SimpleNamespace(
+            infer_shapes=lambda model: model,
+        )
+
+    @staticmethod
+    def load(*, f: Path) -> str:
+        return str(f)
+
+    @staticmethod
+    def save(model: object, f: Path) -> None:
+        Path(f).write_bytes(b"onnx")
+
+
+class DummyOnnxSimModule(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("onnxsim")
+
+    @staticmethod
+    def simplify(model: object) -> tuple[object, bool]:
+        return model, True
+
+
+class DummyFloat16Module(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("onnxruntime.transformers.float16")
+
+    @staticmethod
+    def convert_float_to_float16(
+        *, model: object, keep_io_types: bool, op_block_list: list[str],
+    ) -> object:
+        return model
+
+
+def _install_onnx_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+
+    dummy_onnx = DummyOnnxModule()
+    dummy_onnxsim = DummyOnnxSimModule()
+    dummy_float16 = DummyFloat16Module()
+    dummy_transformers = types.ModuleType("onnxruntime.transformers")
+    dummy_transformers.float16 = dummy_float16
+    dummy_onnxruntime = types.ModuleType("onnxruntime")
+    dummy_onnxruntime.transformers = dummy_transformers
+    monkeypatch.setitem(sys.modules, "onnx", dummy_onnx)
+    monkeypatch.setitem(sys.modules, "onnxsim", dummy_onnxsim)
+    monkeypatch.setitem(sys.modules, "onnxruntime", dummy_onnxruntime)
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime.transformers",
+        dummy_transformers,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime.transformers.float16",
+        dummy_float16,
+    )
+
+
+def test_save_model_preserves_trained_model_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+
+    _install_onnx_stubs(monkeypatch)
+
+    def fake_export(*args: object, **kwargs: object) -> None:
+        onnx_path = Path(kwargs["f"])
+        onnx_path.write_bytes(b"exported")
+
+    monkeypatch.setattr(torch.onnx, "export", fake_export)
+
+    device = torch.device("cpu")
+    model = Network().to(device)
+    model.train(True)
+
+    original_state = {
+        key: value.clone()
+        for key, value in model.state_dict().items()
+    }
+
+    ModelIO.save_model(
+        trained_model=model,
+        dir=tmp_path,
+        id="test",
+        epoch=1,
+        device=device,
+    )
+
+    assert model.training is True
+    for key, value in original_state.items():
+        assert torch.equal(model.state_dict()[key], value)
+
+    saved_state = torch.load(tmp_path / "model_test_1.pt")
+    for key, value in original_state.items():
+        assert key in saved_state
+        assert torch.equal(saved_state[key], value)
+


### PR DESCRIPTION
## Summary
- reuse the trained model instance when exporting parameters to prevent unintended reinitialization
- clean `_orig_mod` prefixes before persisting weights and restore the model's training mode after ONNX export
- add a regression test that stubs ONNX dependencies and verifies that saving preserves the trained weights

## Testing
- poetry run pytest tests/maou/app/learning/test_model_io.py

------
https://chatgpt.com/codex/tasks/task_e_6908c72ae0a883278a4a94a1ca0e2876