### PR TITLE
Add configurable learning rate schedulers to training CLI

### DIFF
--- a/src/maou/app/utility/training_benchmark.py
+++ b/src/maou/app/utility/training_benchmark.py
@@ -393,6 +393,7 @@ class TrainingBenchmarkConfig:
     optimizer_beta1: float = 0.9
     optimizer_beta2: float = 0.999
     optimizer_eps: float = 1e-8
+    lr_scheduler_name: Optional[str] = None
     warmup_batches: int = 5
     max_batches: Optional[int] = None
     enable_profiling: bool = False
@@ -439,6 +440,8 @@ class TrainingBenchmarkUseCase:
                 optimizer_beta1=config.optimizer_beta1,
                 optimizer_beta2=config.optimizer_beta2,
                 optimizer_eps=config.optimizer_eps,
+                lr_scheduler_name=config.lr_scheduler_name,
+                max_epochs=1,
             )
         )
 

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -45,6 +45,7 @@ S3DataSource: S3DataSourceType | None = getattr(
     common, "S3DataSource", None
 )
 
+
 @click.command("learn-model")
 @click.option(
     "--input-dir",
@@ -266,6 +267,19 @@ S3DataSource: S3DataSourceType | None = getattr(
     default=0.01,
 )
 @click.option(
+    "--lr-scheduler",
+    type=click.Choice(
+        list(learn.SUPPORTED_LR_SCHEDULERS.values()),
+        case_sensitive=False,
+    ),
+    help="Learning rate scheduler to apply.",
+    required=False,
+    default=learn.SUPPORTED_LR_SCHEDULERS[
+        "warmup_cosine_decay"
+    ],
+    show_default=True,
+)
+@click.option(
     "--momentum",
     type=float,
     help="Optimizer momentum.",
@@ -402,6 +416,7 @@ def learn_model(
     policy_loss_ratio: Optional[float],
     value_loss_ratio: Optional[float],
     learning_ratio: Optional[float],
+    lr_scheduler: str,
     momentum: Optional[float],
     optimizer: str,
     optimizer_beta1: float,
@@ -666,6 +681,7 @@ def learn_model(
             policy_loss_ratio=policy_loss_ratio,
             value_loss_ratio=value_loss_ratio,
             learning_ratio=learning_ratio,
+            lr_scheduler=lr_scheduler,
             momentum=momentum,
             optimizer_name=optimizer,
             optimizer_beta1=optimizer_beta1,

--- a/tests/maou/app/learning/test_compilation.py
+++ b/tests/maou/app/learning/test_compilation.py
@@ -11,7 +11,9 @@ from maou.app.learning.compilation import compile_module
 
 
 class _DummyModule(torch.nn.Module):
-    def forward(self, *inputs: torch.Tensor, **kwargs: Any) -> tuple[torch.Tensor, ...]:
+    def forward(
+        self, *inputs: torch.Tensor, **kwargs: Any
+    ) -> tuple[torch.Tensor, ...]:
         return tuple(inputs)
 
 
@@ -21,7 +23,9 @@ def test_compile_module_uses_static_shapes(monkeypatch) -> None:
     module = _DummyModule()
     compiled_module = torch.nn.Sequential(torch.nn.Identity())
 
-    def _fake_compile(target: torch.nn.Module, *, dynamic: bool) -> torch.nn.Module:
+    def _fake_compile(
+        target: torch.nn.Module, *, dynamic: bool
+    ) -> torch.nn.Module:
         assert target is module
         assert dynamic is False
         return compiled_module
@@ -33,22 +37,52 @@ def test_compile_module_uses_static_shapes(monkeypatch) -> None:
     assert result is compiled_module
 
 
-def test_compile_module_falls_back_on_failure(monkeypatch) -> None:
+def test_compile_module_allows_dynamic_override(
+    monkeypatch,
+) -> None:
+    """Callers can opt into dynamic shape compilation when required."""
+
+    module = _DummyModule()
+    compiled_module = torch.nn.Sequential(torch.nn.Identity())
+
+    def _fake_compile(
+        target: torch.nn.Module, *, dynamic: bool
+    ) -> torch.nn.Module:
+        assert target is module
+        assert dynamic is True
+        return compiled_module
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+
+    result = compile_module(module, dynamic=True)
+
+    assert result is compiled_module
+
+
+def test_compile_module_falls_back_on_failure(
+    monkeypatch,
+) -> None:
     """Errors from ``torch.compile`` should trigger a safe fallback."""
 
     module = _DummyModule()
     warnings: list[str] = []
 
-    def _raise_compile(*args: Any, **kwargs: Any) -> torch.nn.Module:
+    def _raise_compile(
+        *args: Any, **kwargs: Any
+    ) -> torch.nn.Module:
         raise RuntimeError("compilation failure")
 
-    def _collect_warning(message: str, *args: Any, **kwargs: Any) -> None:
+    def _collect_warning(
+        message: str, *args: Any, **kwargs: Any
+    ) -> None:
         formatted = message % args if args else message
         warnings.append(formatted)
 
     monkeypatch.setattr(torch, "compile", _raise_compile)
 
-    monkeypatch.setattr(compilation.logger, "warning", _collect_warning)
+    monkeypatch.setattr(
+        compilation.logger, "warning", _collect_warning
+    )
 
     result = compile_module(module)
 

--- a/tests/maou/app/learning/test_setup.py
+++ b/tests/maou/app/learning/test_setup.py
@@ -1,8 +1,12 @@
 import numpy as np
+import pytest
 import torch
 
 from maou.app.learning.dataset import DataSource
-from maou.app.learning.setup import TrainingSetup
+from maou.app.learning.setup import (
+    TrainingSetup,
+    WarmupCosineDecayScheduler,
+)
 from maou.app.pre_process.label import MOVE_LABELS_NUM
 from maou.domain.board.shogi import FEATURES_NUM
 from maou.domain.model.mlp_mixer import ShogiMLPMixer
@@ -13,7 +17,11 @@ class DummyPreprocessedDataSource(DataSource):
         dtype = np.dtype(
             [
                 ("features", np.float32, (FEATURES_NUM, 9, 9)),
-                ("legalMoveMask", np.float32, (MOVE_LABELS_NUM,)),
+                (
+                    "legalMoveMask",
+                    np.float32,
+                    (MOVE_LABELS_NUM,),
+                ),
                 ("moveLabel", np.float32, (MOVE_LABELS_NUM,)),
                 ("resultValue", np.float32),
             ]
@@ -32,44 +40,130 @@ class DummyPreprocessedDataSource(DataSource):
 def test_training_setup_uses_adamw_optimizer() -> None:
     datasource = DummyPreprocessedDataSource(length=4)
 
-    _, _, model_components = TrainingSetup.setup_training_components(
-        training_datasource=datasource,
-        validation_datasource=datasource,
-        datasource_type="preprocess",
-        gpu="cpu",
-        batch_size=2,
-        dataloader_workers=0,
-        pin_memory=False,
-        prefetch_factor=2,
-        optimizer_name="adamw",
-        optimizer_beta1=0.85,
-        optimizer_beta2=0.98,
-        optimizer_eps=1e-7,
+    _, _, model_components = (
+        TrainingSetup.setup_training_components(
+            training_datasource=datasource,
+            validation_datasource=datasource,
+            datasource_type="preprocess",
+            gpu="cpu",
+            batch_size=2,
+            dataloader_workers=0,
+            pin_memory=False,
+            prefetch_factor=2,
+            optimizer_name="adamw",
+            optimizer_beta1=0.85,
+            optimizer_beta2=0.98,
+            optimizer_eps=1e-7,
+        )
     )
 
     optimizer = model_components.optimizer
     assert isinstance(optimizer, torch.optim.AdamW)
     assert optimizer.defaults["betas"] == (0.85, 0.98)
     assert optimizer.defaults["eps"] == 1e-07
+    assert model_components.lr_scheduler is None
 
 
 def test_training_setup_supports_mlp_mixer_backbone() -> None:
     datasource = DummyPreprocessedDataSource(length=4)
 
-    _, _, model_components = TrainingSetup.setup_training_components(
-        training_datasource=datasource,
-        validation_datasource=datasource,
-        datasource_type="preprocess",
-        gpu="cpu",
-        batch_size=2,
-        dataloader_workers=0,
-        pin_memory=False,
-        prefetch_factor=2,
-        optimizer_name="adamw",
-        optimizer_beta1=0.85,
-        optimizer_beta2=0.98,
-        optimizer_eps=1e-7,
-        model_architecture="mlp-mixer",
+    _, _, model_components = (
+        TrainingSetup.setup_training_components(
+            training_datasource=datasource,
+            validation_datasource=datasource,
+            datasource_type="preprocess",
+            gpu="cpu",
+            batch_size=2,
+            dataloader_workers=0,
+            pin_memory=False,
+            prefetch_factor=2,
+            optimizer_name="adamw",
+            optimizer_beta1=0.85,
+            optimizer_beta2=0.98,
+            optimizer_eps=1e-7,
+            model_architecture="mlp-mixer",
+        )
     )
 
-    assert isinstance(model_components.model.backbone, ShogiMLPMixer)
+    assert isinstance(
+        model_components.model.backbone, ShogiMLPMixer
+    )
+    assert model_components.lr_scheduler is None
+
+
+def test_training_setup_creates_warmup_cosine_decay_scheduler() -> (
+    None
+):
+    datasource = DummyPreprocessedDataSource(length=8)
+
+    _, _, model_components = (
+        TrainingSetup.setup_training_components(
+            training_datasource=datasource,
+            validation_datasource=datasource,
+            datasource_type="preprocess",
+            gpu="cpu",
+            batch_size=2,
+            dataloader_workers=0,
+            pin_memory=False,
+            prefetch_factor=2,
+            optimizer_name="adamw",
+            optimizer_beta1=0.85,
+            optimizer_beta2=0.98,
+            optimizer_eps=1e-7,
+            lr_scheduler_name="warmup_cosine_decay",
+            max_epochs=20,
+        )
+    )
+
+    scheduler = model_components.lr_scheduler
+    assert isinstance(scheduler, WarmupCosineDecayScheduler)
+
+    optimizer = model_components.optimizer
+    base_lr = scheduler.base_lrs[0]
+    initial_lr = optimizer.param_groups[0]["lr"]
+
+    assert initial_lr == pytest.approx(base_lr * 0.5)
+
+    optimizer.step()
+    scheduler.step()
+    warmup_completed_lr = scheduler.get_last_lr()[0]
+
+    optimizer.step()
+    scheduler.step()
+    optimizer.step()
+    scheduler.step()
+    decay_lr = scheduler.get_last_lr()[0]
+
+    assert warmup_completed_lr == pytest.approx(base_lr)
+    assert decay_lr < base_lr
+
+
+def test_training_setup_creates_cosine_annealing_scheduler() -> (
+    None
+):
+    datasource = DummyPreprocessedDataSource(length=8)
+
+    _, _, model_components = (
+        TrainingSetup.setup_training_components(
+            training_datasource=datasource,
+            validation_datasource=datasource,
+            datasource_type="preprocess",
+            gpu="cpu",
+            batch_size=2,
+            dataloader_workers=0,
+            pin_memory=False,
+            prefetch_factor=2,
+            optimizer_name="adamw",
+            optimizer_beta1=0.85,
+            optimizer_beta2=0.98,
+            optimizer_eps=1e-7,
+            lr_scheduler_name="cosine_annealing_lr",
+            max_epochs=5,
+        )
+    )
+
+    scheduler = model_components.lr_scheduler
+    assert isinstance(
+        scheduler, torch.optim.lr_scheduler.CosineAnnealingLR
+    )
+    assert scheduler.T_max == 5

--- a/tests/maou/interface/test_learn.py
+++ b/tests/maou/interface/test_learn.py
@@ -1,0 +1,45 @@
+import pytest
+
+from maou.interface.learn import (
+    SUPPORTED_LR_SCHEDULERS,
+    normalize_lr_scheduler_name,
+)
+
+
+def test_normalize_lr_scheduler_name_accepts_display_names() -> (
+    None
+):
+    canonical = normalize_lr_scheduler_name(
+        "Warmup+CosineDecay"
+    )
+    assert canonical == "warmup_cosine_decay"
+
+    canonical = normalize_lr_scheduler_name("CosineAnnealingLR")
+    assert canonical == "cosine_annealing_lr"
+
+
+def test_normalize_lr_scheduler_name_accepts_underscored_alias() -> (
+    None
+):
+    canonical = normalize_lr_scheduler_name(
+        "cosine_annealing_lr"
+    )
+    assert canonical == "cosine_annealing_lr"
+
+
+def test_normalize_lr_scheduler_name_rejects_unknown_scheduler() -> (
+    None
+):
+    with pytest.raises(ValueError):
+        normalize_lr_scheduler_name("linear")
+
+
+def test_supported_lr_scheduler_labels_match_defaults() -> None:
+    assert (
+        SUPPORTED_LR_SCHEDULERS["warmup_cosine_decay"]
+        == "Warmup+CosineDecay"
+    )
+    assert (
+        SUPPORTED_LR_SCHEDULERS["cosine_annealing_lr"]
+        == "CosineAnnealingLR"
+    )


### PR DESCRIPTION
## Summary
- add a --lr-scheduler CLI flag and normalize scheduler names in the interface
- build scheduler factory support for Warmup+CosineDecay and CosineAnnealingLR and log learning rates during training
- allow compile_module callers to opt into dynamic shapes and update masked autoencoder compilation and tests

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_6908cb48dd288327affe62f23820782a