### PR TITLE
Fix preprocess storage to avoid bit packing

### DIFF
--- a/src/maou/app/pre_process/hcpe_transform.py
+++ b/src/maou/app/pre_process/hcpe_transform.py
@@ -274,7 +274,7 @@ class PreProcess:
                     chunk_path = output_dir / chunk_filename
 
                     save_preprocessing_array(
-                        chunk_data, chunk_path, bit_pack=True
+                        chunk_data, chunk_path, bit_pack=False
                     )
 
                     self.logger.debug(
@@ -493,7 +493,7 @@ class PreProcess:
                             array,
                             option.output_dir
                             / f"{base_name}.npy",
-                            bit_pack=True,
+                            bit_pack=False,
                         )
             else:
                 # 並列処理（メモリ効率化版）
@@ -688,7 +688,7 @@ class PreProcess:
                             array,
                             option.output_dir
                             / f"{base_name}.npy",
-                            bit_pack=True,
+                            bit_pack=False,
                         )
 
         # クリーンアップ: ディスクストアを閉じて削除

--- a/src/maou/infra/object_storage/data_source.py
+++ b/src/maou/infra/object_storage/data_source.py
@@ -392,7 +392,7 @@ class ObjectStorageDataSource(
                                 array = load_array_from_bytes(
                                     data=byte_data,
                                     array_type=self.array_type,
-                                    bit_pack=True,
+                                    bit_pack=False,
                                 )
                                 bundler.bundle(array)
                         except Exception as exc:

--- a/src/maou/infra/object_storage/feature_store.py
+++ b/src/maou/infra/object_storage/feature_store.py
@@ -157,7 +157,7 @@ class ObjectStorageFeatureStore(
             byte_data = save_array_to_bytes(
                 array=array,
                 array_type=self.array_type,
-                bit_pack=True,
+                bit_pack=False,
             )
             self.queue.put((object_path, byte_data))
             self.bundle_id += 1

--- a/tests/maou/app/pre_process/test_hcpe_transform.py
+++ b/tests/maou/app/pre_process/test_hcpe_transform.py
@@ -160,7 +160,7 @@ class TestHCPEConverter:
 
             # 実際の前処理済みデータを取得
             preprocessed_array = load_preprocessing_array(
-                output_path / "test.npy", bit_pack=True
+                output_path / "test.npy", bit_pack=False
             )
 
             # 3. 基本整合性検証


### PR DESCRIPTION
## Summary
- store preprocessing output files without bit packing so downstream consumers receive unpacked arrays
- send uncompressed preprocessing batches to object storage and adjust downloads accordingly
- update preprocess integration test expectations for unpacked data

## Testing
- `poetry run pytest tests/maou/app/pre_process/test_hcpe_transform.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eaf91c76c83279f40afcccd12ac7f)