### PR TITLE
fix: align warmup scheduler with first epoch

### DIFF
--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -411,6 +411,20 @@ class WarmupCosineDecayScheduler(LRScheduler):
 
         super().__init__(optimizer)
 
+        # Ensure the optimizer starts with the warmup-adjusted learning rate
+        # before the first training iteration runs. Without this adjustment the
+        # first epoch would use the unscaled base learning rate and the warmup
+        # schedule would be shifted by one epoch. By explicitly setting
+        # ``last_epoch`` to the initial epoch and synchronising the parameter
+        # groups, we align the scheduler's state with the intended warm start.
+        self.last_epoch = 0
+        initial_lrs = self.get_lr()
+        for param_group, lr in zip(
+            self.optimizer.param_groups, initial_lrs
+        ):
+            param_group["lr"] = lr
+        self._last_lr = initial_lrs
+
     def get_lr(self) -> List[float]:
         """Return the learning rate for the current epoch."""
 


### PR DESCRIPTION
## Summary
- apply the warmup-adjusted learning rate before training begins so epoch zero uses the expected scale
- keep the scheduler state in sync with the optimizer by updating parameter groups immediately after construction

## Testing
- `poetry run pytest tests/maou/app/learning/test_setup.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eb7352e288327ac6fc2bce5b7d66e)