### PR TITLE
Add alias for domain pytest suite

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package namespace."""

--- a/tests/domain/__init__.py
+++ b/tests/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility namespace for running domain tests via ``pytest tests/domain``."""

--- a/tests/domain/test_data.py
+++ b/tests/domain/test_data.py
@@ -1,0 +1,13 @@
+"""Proxy module re-exporting domain data layer tests.
+
+This allows running the suite with ``pytest tests/domain`` while keeping the
+canonical test implementations in ``tests/maou/domain``.
+"""
+
+from ..maou.domain.data.test_compressed_schema import *  # noqa: F401,F403
+from ..maou.domain.data.test_compression import *  # noqa: F401,F403
+from ..maou.domain.data.test_compression_io import *  # noqa: F401,F403
+from ..maou.domain.data.test_io import *  # noqa: F401,F403
+from ..maou.domain.data.test_schema import *  # noqa: F401,F403
+
+__all__ = [name for name in globals() if name.startswith("Test")]

--- a/tests/domain/test_model.py
+++ b/tests/domain/test_model.py
@@ -1,0 +1,7 @@
+"""Proxy module re-exporting domain model layer tests."""
+
+from ..maou.domain.model.test_mlp_mixer import *  # noqa: F401,F403
+from ..maou.domain.model.test_resnet import *  # noqa: F401,F403
+from ..maou.domain.model.test_vision_transformer import *  # noqa: F401,F403
+
+__all__ = [name for name in globals() if name.startswith("Test")]


### PR DESCRIPTION
## Summary
- add a tests/domain package that re-exports the existing domain layer tests
- allow running `poetry run pytest tests/domain` in addition to the canonical location

## Testing
- `poetry run pytest tests/domain`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f51e021788327b75c4a189ceb54ee)