### PR TITLE
Fix intermediate schema dtype to use board identifiers

### DIFF
--- a/src/maou/domain/data/schema.py
+++ b/src/maou/domain/data/schema.py
@@ -79,10 +79,15 @@ def get_intermediate_dtype() -> np.dtype:
         [
             ("id", np.uint64),  # Unique identifier
             (
-                "features",
+                "boardIdPositions",
                 np.uint8,
-                (FEATURES_NUM, 9, 9),
-            ),  # Board feature representation
+                (9, 9),
+            ),  # Board position identifiers
+            (
+                "piecesInHand",
+                np.uint8,
+                (14,),
+            ),  # Pieces in hand counts for both players
             (
                 "count",
                 np.int32,
@@ -94,8 +99,8 @@ def get_intermediate_dtype() -> np.dtype:
             ),  # Move label for training
             (
                 "winCount",
-                np.int32,
-            ),  # Win count
+                np.float32,
+            ),  # Sum of result values
         ]
     )
 


### PR DESCRIPTION
## Summary
- update the intermediate preprocessing dtype to expose boardIdPositions and piecesInHand instead of the removed FEATURES_NUM-based features tensor
- store the aggregated winCount as float32 to align with summed result values

## Testing
- poetry run pytest tests/maou/domain/data/test_schema.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fed720974832780120868a1c88fa7)