### PR TITLE
feat: embed shogi board ids before backbone execution

### DIFF
--- a/src/maou/app/learning/setup.py
+++ b/src/maou/app/learning/setup.py
@@ -24,12 +24,13 @@ except (
 from maou.app.learning.dataset import DataSource, KifDataset
 from maou.app.learning.network import (
     BackboneArchitecture,
+    BOARD_EMBEDDING_DIM,
+    DEFAULT_BOARD_VOCAB_SIZE,
     HeadlessNetwork,
     Network,
 )
 from maou.app.pre_process.label import MOVE_LABELS_NUM
 from maou.app.pre_process.transform import Transform
-from maou.domain.board.shogi import FEATURES_NUM
 from maou.domain.model.resnet import BottleneckBlock
 
 
@@ -224,7 +225,8 @@ class ModelFactory:
         """方策・価値ヘッドを含まないバックボーンを作成."""
 
         backbone = HeadlessNetwork(
-            num_channels=FEATURES_NUM,
+            board_vocab_size=DEFAULT_BOARD_VOCAB_SIZE,
+            embedding_dim=BOARD_EMBEDDING_DIM,
             board_size=(9, 9),
             architecture=architecture,
             block=BottleneckBlock,
@@ -253,7 +255,8 @@ class ModelFactory:
 
         model = Network(
             num_policy_classes=MOVE_LABELS_NUM,
-            num_channels=FEATURES_NUM,
+            board_vocab_size=DEFAULT_BOARD_VOCAB_SIZE,
+            embedding_dim=BOARD_EMBEDDING_DIM,
             board_size=(9, 9),
             architecture=architecture,
             block=BottleneckBlock,

--- a/tests/maou/app/learning/test_vision_transformer.py
+++ b/tests/maou/app/learning/test_vision_transformer.py
@@ -7,8 +7,10 @@ import torch
 
 from torchinfo import summary
 
-from maou.app.learning.network import HeadlessNetwork
-from maou.domain.board.shogi import FEATURES_NUM
+from maou.app.learning.network import (
+    DEFAULT_BOARD_VOCAB_SIZE,
+    HeadlessNetwork,
+)
 from maou.domain.model.resnet import ResNet as DomainResNet
 from maou.domain.model.mlp_mixer import ShogiMLPMixer
 from maou.domain.model.vision_transformer import (
@@ -31,7 +33,7 @@ def test_headless_network_forward_returns_embeddings() -> None:
 
     model = HeadlessNetwork()
     batch_size = 4
-    inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
+    inputs = torch.randint(0, DEFAULT_BOARD_VOCAB_SIZE, (batch_size, 9, 9))
 
     outputs = model(inputs)
 
@@ -43,7 +45,7 @@ def test_headless_network_supports_mlp_mixer_backbone() -> None:
 
     model = HeadlessNetwork(architecture="mlp-mixer")
     batch_size = 2
-    inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
+    inputs = torch.randint(0, DEFAULT_BOARD_VOCAB_SIZE, (batch_size, 9, 9))
 
     outputs = model(inputs)
 
@@ -56,7 +58,7 @@ def test_headless_network_supports_vit_backbone() -> None:
 
     model = HeadlessNetwork(architecture="vit")
     batch_size = 2
-    inputs = torch.randn(batch_size, FEATURES_NUM, 9, 9)
+    inputs = torch.randint(0, DEFAULT_BOARD_VOCAB_SIZE, (batch_size, 9, 9))
 
     outputs = model(inputs)
 
@@ -68,7 +70,8 @@ def test_headless_network_rejects_invalid_shape() -> None:
     """Invalid spatial dimensions should raise a descriptive error."""
 
     model = HeadlessNetwork()
-    bad_inputs = torch.randn(1, FEATURES_NUM, 8, 8)
+    bad_inputs = torch.randint(0, DEFAULT_BOARD_VOCAB_SIZE, (1, 9, 9))
+    bad_inputs = bad_inputs[:, :, :8]
 
     with pytest.raises(ValueError):
         model(bad_inputs)


### PR DESCRIPTION
## Summary
- add configurable board ID embedding to the shared shogi backbones
- initialize ModelFactory networks with the embedding-aware configuration
- update learning tests to exercise integer board IDs across architectures

## Testing
- poetry run pytest tests/maou/app/learning

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691010cc6bb4832794c37ee4f21ef5ee)