### PR TITLE
feat: implement early fusion for hand features

### DIFF
--- a/tests/maou/app/learning/test_network.py
+++ b/tests/maou/app/learning/test_network.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 import torch
+from torch import Tensor
 
 from maou.app.learning.network import (
     BACKBONE_ARCHITECTURES,
@@ -48,6 +49,51 @@ def test_network_allows_custom_head_configuration() -> None:
 
     assert policy.shape == (1, MOVE_LABELS_NUM)
     assert value.shape == (1, 1)
+
+
+def test_hand_projection_matches_board_embedding_channels() -> None:
+    network = Network()
+
+    assert network._hand_projection.out_features == network.input_channels
+
+
+def test_forward_features_performs_early_fusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    network = Network()
+    boards = torch.randint(0, DEFAULT_BOARD_VOCAB_SIZE, (2, 9, 9))
+    hands = torch.rand((2, network._hand_projection.in_features))
+
+    captured_inputs: dict[str, Tensor] = {}
+
+    def fake_forward_features(self: HeadlessNetwork, inputs: Tensor) -> Tensor:
+        captured_inputs["inputs"] = inputs
+        return torch.zeros(
+            (inputs.shape[0], network.embedding_dim),
+            dtype=inputs.dtype,
+            device=inputs.device,
+        )
+
+    monkeypatch.setattr(HeadlessNetwork, "forward_features", fake_forward_features)
+
+    features = network.forward_features((boards, hands))
+
+    expected_embedded = network._prepare_inputs(boards)
+    projected = network._hand_projection(
+        hands.to(dtype=expected_embedded.dtype, device=expected_embedded.device)
+    ).view(expected_embedded.shape[0], network.input_channels, 1, 1)
+
+    assert torch.allclose(
+        captured_inputs["inputs"], expected_embedded + projected
+    )
+    assert torch.equal(
+        features,
+        torch.zeros(
+            (boards.shape[0], network.embedding_dim),
+            dtype=expected_embedded.dtype,
+            device=expected_embedded.device,
+        ),
+    )
 
 
 @pytest.mark.parametrize("architecture", BACKBONE_ARCHITECTURES)


### PR DESCRIPTION
## Summary
- align the hand feature projection with the board embedding channels and fuse the signals before the backbone
- update network forward path so hand information is injected ahead of the backbone
- extend tests to verify early fusion behaviour and projection dimensions

## Testing
- poetry run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69103d9496bc8327896112ab90e2ccef)