### PR TITLE
Fix HCPE loader memory errors for large datasets

### DIFF
--- a/tests/maou/domain/data/test_io.py
+++ b/tests/maou/domain/data/test_io.py
@@ -85,6 +85,27 @@ class TestHCPEIO:
         assert isinstance(loaded_array, np.memmap)
         np.testing.assert_array_equal(loaded_array, array)
 
+    def test_load_hcpe_array_from_numpy_saved_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Test loading .npy files created via numpy.save with mmap."""
+
+        array = create_empty_hcpe_array(7)
+        file_path = tmp_path / "numpy_saved.npy"
+
+        np.save(file_path, array)
+
+        loaded_array = load_hcpe_array(
+            file_path,
+            mmap_mode="r",
+        )
+
+        assert isinstance(loaded_array, np.memmap)
+        np.testing.assert_array_equal(
+            loaded_array,
+            array,
+        )
+
 
 class TestPreprocessingIO:
     """Test preprocessing array I/O operations."""


### PR DESCRIPTION
## Summary
- add numpy.load-backed memmap support inside the array loaders to better handle standard .npy files
- retry array loading with memory mapping when DataIOService encounters memory allocation errors
- add regression tests covering the new loading paths and fallback logic

## Testing
- poetry run pytest tests/maou/domain/data/test_io.py tests/maou/app/common/test_data_io_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911221b74e48327bd1099cc954a5638)