### PR TITLE
Fix training loop handling of sequence inputs

### DIFF
--- a/src/maou/app/learning/callbacks.py
+++ b/src/maou/app/learning/callbacks.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Protocol, Tuple, Union
 
@@ -16,7 +17,7 @@ from maou.app.learning.resource_monitor import (
 from maou.app.learning.policy_targets import normalize_policy_targets
 
 
-ModelInputs = Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
+ModelInputs = Union[torch.Tensor, Sequence[torch.Tensor]]
 
 
 @dataclass

--- a/tests/maou/app/test_training_loop.py
+++ b/tests/maou/app/test_training_loop.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import torch
+
+from maou.app.learning.callbacks import ModelInputs
+from maou.app.learning.network import Network
+from maou.app.learning.training_loop import TrainingLoop
+
+
+def test_resolve_batch_size_supports_list_inputs() -> None:
+    board = torch.zeros((4, 9, 9), dtype=torch.long)
+    pieces = torch.zeros((4, 14), dtype=torch.float32)
+    inputs: ModelInputs = [board, pieces]
+
+    batch_size = TrainingLoop._resolve_batch_size(inputs)
+
+    assert batch_size == 4
+
+
+def test_network_separate_inputs_accepts_list() -> None:
+    board = torch.zeros((2, 9, 9), dtype=torch.long)
+    pieces = torch.zeros((2, 14), dtype=torch.float32)
+
+    separated_board, separated_pieces = Network._separate_inputs([board, pieces])
+
+    assert separated_board is board
+    assert separated_pieces is pieces


### PR DESCRIPTION
## Summary
- broaden ModelInputs typing to accept tensor sequences across callbacks and the shogi network
- make the training loop move nested sequence inputs to devices and resolve batch sizes safely
- add regression coverage ensuring list-based model inputs are supported

## Testing
- poetry run pytest tests/maou/app/test_training_loop.py
- poetry run mypy src/maou/app/learning/training_loop.py src/maou/app/learning/network.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116a72eadc8327bc2bec24c1631997)