### PR TITLE
feat: add input cache mode for learning CLI

### DIFF
--- a/src/maou/app/learning/dl.py
+++ b/src/maou/app/learning/dl.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, MutableMapping, Optional, cast
+from typing import Dict, Literal, MutableMapping, Optional, cast
 
 import torch
 from torch.amp.grad_scaler import GradScaler
@@ -88,6 +88,7 @@ class Learning:
         log_dir: Path
         model_dir: Path
         lr_scheduler_name: Optional[str] = None
+        input_cache_mode: Literal["mmap", "memory"] = "mmap"
 
     def __init__(
         self,

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -95,6 +95,14 @@ S3DataSource: S3DataSourceType | None = getattr(
     required=False,
 )
 @click.option(
+    "--input-cache-mode",
+    type=click.Choice(["mmap", "memory"], case_sensitive=False),
+    help="Cache strategy for local inputs (default: mmap).",
+    default="mmap",
+    show_default=True,
+    required=False,
+)
+@click.option(
     "--input-clustering-key",
     help="BigQuery clustering key.",
     type=str,
@@ -391,6 +399,7 @@ def learn_model(
     input_format: str,
     input_batch_size: int,
     input_max_cached_bytes: int,
+    input_cache_mode: str,
     input_clustering_key: Optional[str],
     input_partitioning_key_date: Optional[str],
     input_local_cache: bool,
@@ -529,6 +538,7 @@ def learn_model(
             file_paths=FileSystem.collect_files(input_dir),
             array_type=array_type,
             bit_pack=input_file_packed,
+            cache_mode=input_cache_mode.lower(),
         )
     elif (
         input_dataset_id is not None
@@ -692,5 +702,6 @@ def learn_model(
             log_dir=log_dir,
             model_dir=model_dir,
             cloud_storage=cloud_storage,
+            input_cache_mode=input_cache_mode.lower(),
         )
     )

--- a/src/maou/interface/learn.py
+++ b/src/maou/interface/learn.py
@@ -2,7 +2,7 @@ import abc
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Literal, Optional
 
 from maou.app.learning.dl import (
     CloudStorage,
@@ -150,6 +150,7 @@ def learn(
     log_dir: Optional[Path] = None,
     model_dir: Optional[Path] = None,
     cloud_storage: Optional[CloudStorage] = None,
+    input_cache_mode: Literal["mmap", "memory"] = "mmap",
 ) -> str:
     """Train neural network model on Shogi data.
 
@@ -180,6 +181,7 @@ def learn(
         log_dir: Directory for training logs
         model_dir: Directory for saving trained model
         cloud_storage: Optional cloud storage for model uploads
+        input_cache_mode: Strategy used by the input datasource cache
 
     Returns:
         JSON string with training results
@@ -352,6 +354,14 @@ def learn(
     if model_dir is not None:
         dir_init(model_dir)
     logger.info(f"Input: {datasource}, Output: {model_dir}")
+
+    normalized_cache_mode = input_cache_mode.lower()
+    if normalized_cache_mode not in {"mmap", "memory"}:
+        raise ValueError(
+            "input_cache_mode must be either 'mmap' or 'memory', "
+            f"got {input_cache_mode}"
+        )
+
     option = Learning.LearningOption(
         datasource=datasource,
         datasource_type=datasource_type,
@@ -378,6 +388,7 @@ def learn(
         model_dir=model_dir,
         model_architecture=model_architecture,
         lr_scheduler_name=lr_scheduler_key,
+        input_cache_mode=normalized_cache_mode,
     )
 
     learning_result = Learning(

--- a/tests/maou/infra/console/test_learn_model_cli.py
+++ b/tests/maou/infra/console/test_learn_model_cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from click.testing import CliRunner
+import pytest
+
+from maou.domain.data.schema import get_hcpe_dtype
+from maou.infra.console import learn_model
+
+
+def _create_sample_file(path: Path) -> None:
+    array = np.zeros(2, dtype=get_hcpe_dtype())
+    array.tofile(path)
+
+
+def test_learn_model_passes_cache_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+
+    captured_kwargs: dict[str, Any] = {}
+
+    def fake_learn(**kwargs: Any) -> str:
+        captured_kwargs.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr(learn_model.learn, "learn", fake_learn)
+
+    with runner.isolated_filesystem():
+        input_path = Path("input.bin")
+        _create_sample_file(input_path)
+
+        result = runner.invoke(
+            learn_model.learn_model,
+            [
+                "--input-dir",
+                str(input_path),
+                "--input-cache-mode",
+                "memory",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured_kwargs["input_cache_mode"] == "memory"
+    assert captured_kwargs["datasource_type"] == "hcpe"


### PR DESCRIPTION
## Summary
- add an `--input-cache-mode` option to the learning CLI and pass the value through to the learning options
- extend the file data source manager with an in-memory cache mode that logs allocation attempts and prioritises cached arrays
- cover the RAM cache path and CLI option propagation with dedicated tests

## Testing
- `poetry run pytest tests/maou/infra/file_system/test_file_data_source.py tests/maou/infra/console/test_learn_model_cli.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117bbbda7c83279be6c688cc72592c)