### PR TITLE
Add configurable TensorBoard histogram logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ poetry run maou learn-model --detect-anomaly [...他の引数]
 poetry run maou utility benchmark-training --detect-anomaly [...他の引数]
 ```
 
+## TensorBoardヒストグラムの制御
+
+学習ループではデフォルトで損失や正解率などのスカラー値のみをTensorBoardに
+書き出すため，ログファイルは比較的軽量で扱えます。パラメータ／勾配の分布を
+追跡したい場合は `--tensorboard-histogram-frequency` を設定することで，指定した
+エポック間隔ごとにヒストグラムを追加できます。0を指定するとヒストグラム記録は
+無効化されたままです（従来のスカラー指標は常に出力されます）。
+
+特定モジュールだけを記録したい場合は `--tensorboard-histogram-module` を複数回
+指定してグロブパターン（例: `backbone.*`, `head.value*`）を登録してください。
+
+```bash
+poetry run maou learn-model \
+  --tensorboard-histogram-frequency 5 \
+  --tensorboard-histogram-module "backbone.*" \
+  --tensorboard-histogram-module "head.*" \
+  [...他の引数]
+```
+
+フィルタを指定しない場合は全パラメータ／勾配を記録します。ヒストグラム無効時も
+学習率や検証指標などのスカラー値は引き続き記録されるため，既存のTensorBoard
+ダッシュボードはそのまま利用できます。
+
 ## Preprocessingデータのメモリマップ方式
 
 前処理済みの`.npy`ファイルはデフォルトでコピーオンライト(`mmap_mode="c"`)

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -255,6 +255,24 @@ S3DataSource: S3DataSourceType | None = getattr(
     required=False,
 )
 @click.option(
+    "--tensorboard-histogram-frequency",
+    type=int,
+    help="Log parameter histograms every N epochs (default: disabled).",
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--tensorboard-histogram-module",
+    "tensorboard_histogram_modules",
+    multiple=True,
+    type=str,
+    help=(
+        "Only log histograms for parameter names matching this glob pattern."
+        " Provide multiple times to add more filters."
+    ),
+)
+@click.option(
     "--cache-transforms/--no-cache-transforms",
     default=None,
     help=(
@@ -439,6 +457,8 @@ def learn_model(
     dataloader_workers: Optional[int],
     pin_memory: Optional[bool],
     prefetch_factor: Optional[int],
+    tensorboard_histogram_frequency: int,
+    tensorboard_histogram_modules: tuple[str, ...],
     cache_transforms: Optional[bool],
     gce_parameter: Optional[float],
     policy_loss_ratio: Optional[float],
@@ -706,6 +726,10 @@ def learn_model(
             dataloader_workers=dataloader_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
+            tensorboard_histogram_frequency=tensorboard_histogram_frequency,
+            tensorboard_histogram_modules=(
+                tensorboard_histogram_modules or None
+            ),
             cache_transforms=cache_transforms,
             gce_parameter=gce_parameter,
             policy_loss_ratio=policy_loss_ratio,

--- a/src/maou/interface/learn.py
+++ b/src/maou/interface/learn.py
@@ -153,6 +153,8 @@ def learn(
     model_dir: Optional[Path] = None,
     cloud_storage: Optional[CloudStorage] = None,
     input_cache_mode: Literal["mmap", "memory"] = "mmap",
+    tensorboard_histogram_frequency: int = 0,
+    tensorboard_histogram_modules: Optional[tuple[str, ...]] = None,
 ) -> str:
     """Train neural network model on Shogi data.
 
@@ -185,6 +187,10 @@ def learn(
         model_dir: Directory for saving trained model
         cloud_storage: Optional cloud storage for model uploads
         input_cache_mode: Strategy used by the input datasource cache
+        tensorboard_histogram_frequency: Number of epochs between parameter
+            histogram dumps (0 disables histogram logging)
+        tensorboard_histogram_modules: Optional glob patterns to filter which
+            module names emit histograms
 
     Returns:
         JSON string with training results
@@ -367,6 +373,15 @@ def learn(
             "input_cache_mode must be either 'mmap' or 'memory', "
             f"got {input_cache_mode}"
         )
+    if tensorboard_histogram_frequency < 0:
+        raise ValueError(
+            "tensorboard_histogram_frequency must be non-negative"
+        )
+    normalized_histogram_modules = (
+        tensorboard_histogram_modules
+        if tensorboard_histogram_modules
+        else None
+    )
 
     option = Learning.LearningOption(
         datasource=datasource,
@@ -397,6 +412,8 @@ def learn(
         model_architecture=model_architecture,
         lr_scheduler_name=lr_scheduler_key,
         input_cache_mode=normalized_cache_mode,
+        tensorboard_histogram_frequency=tensorboard_histogram_frequency,
+        tensorboard_histogram_modules=normalized_histogram_modules,
     )
 
     learning_result = Learning(

--- a/tests/maou/app/learning/test_dl.py
+++ b/tests/maou/app/learning/test_dl.py
@@ -7,6 +7,7 @@ from typing import Mapping, cast
 import pytest
 import torch
 
+from maou.app.learning.callbacks import ValidationMetrics
 from maou.app.learning.dl import Learning
 from maou.app.learning.network import HeadlessNetwork, Network
 
@@ -22,6 +23,32 @@ class _DummyCompiledModule(torch.nn.Module):
         self, *args: torch.Tensor, **kwargs: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return self._orig_mod(*args, **kwargs)
+
+
+class _RecordingWriter:
+    """In-memory SummaryWriter replacement used for logging tests."""
+
+    def __init__(self) -> None:
+        self.histograms: list[tuple[str, int]] = []
+        self.scalar_groups: list[tuple[str, dict[str, float], int]] = []
+        self.scalars: list[tuple[str, float, int]] = []
+
+    def add_histogram(
+        self, tag: str, values: torch.Tensor, global_step: int
+    ) -> None:
+        self.histograms.append((tag, global_step))
+
+    def add_scalars(
+        self, main_tag: str, tag_scalar_dict: dict[str, float], global_step: int
+    ) -> None:
+        self.scalar_groups.append(
+            (main_tag, dict(tag_scalar_dict), global_step)
+        )
+
+    def add_scalar(
+        self, tag: str, scalar_value: float, global_step: int
+    ) -> None:
+        self.scalars.append((tag, float(scalar_value), global_step))
 
 
 def _assert_state_dict_equality(
@@ -87,3 +114,57 @@ def test_format_parameter_count_generates_human_readable_labels() -> None:
     assert Learning._format_parameter_count(1_250_000) == "1.2m"
     assert Learning._format_parameter_count(125_000) == "125k"
     assert Learning._format_parameter_count(512) == "512"
+
+
+def test_histogram_logging_can_be_filtered_and_sampled() -> None:
+    """Histogram logging honors frequency and module filters."""
+
+    learning = Learning()
+    learning.model = torch.nn.Sequential(
+        torch.nn.Linear(4, 4, bias=False),
+        torch.nn.Linear(4, 2, bias=False),
+    )
+    learning.tensorboard_histogram_frequency = 2
+    learning.tensorboard_histogram_modules = ("0.weight",)
+
+    writer = _RecordingWriter()
+
+    learning._log_parameter_histograms(writer, epoch_number=0)
+    assert writer.histograms == []
+
+    learning._log_parameter_histograms(writer, epoch_number=1)
+    assert writer.histograms == [("parameters/0.weight", 2)]
+
+
+def test_scalar_metrics_still_logged_when_histograms_disabled() -> None:
+    """Scalar TensorBoard metrics remain available when histograms are off."""
+
+    learning = Learning()
+    learning.model = torch.nn.Linear(2, 2, bias=False)
+    learning.tensorboard_histogram_frequency = 0
+    learning.tensorboard_histogram_modules = None
+
+    writer = _RecordingWriter()
+    metrics = ValidationMetrics(
+        policy_cross_entropy=0.5,
+        value_brier_score=0.25,
+        policy_top5_accuracy=0.75,
+        value_high_confidence_rate=0.6,
+    )
+
+    learning._log_parameter_histograms(writer, epoch_number=0)
+    assert writer.histograms == []
+
+    learning._log_epoch_metrics(
+        writer=writer,
+        metrics=metrics,
+        avg_loss=0.4,
+        avg_vloss=0.3,
+        epoch_number=0,
+        learning_rate=1e-3,
+    )
+
+    assert any(
+        main_tag == "Validation Loss Metrics" for main_tag, _, _ in writer.scalar_groups
+    )
+    assert any(tag == "Learning Rate" for tag, _, _ in writer.scalars)


### PR DESCRIPTION
## Summary
- add CLI and application options to control TensorBoard histogram logging frequency and module filters
- guard the training loop histogram emission and keep scalar metrics logging isolated
- document the new flags and add regression tests that verify scalar metrics continue to work when histograms are disabled

## Testing
- poetry run pytest tests/maou/app/learning/test_dl.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691922f97dbc83279a8fe0ca84b47b6b)