### PR TITLE
Fix benchmark dataloader CLI option decorator

### DIFF
--- a/src/maou/infra/console/utility.py
+++ b/src/maou/infra/console/utility.py
@@ -75,6 +75,7 @@ from maou.interface import utility_interface
     required=False,
     show_default=True,
 )
+@click.option(
     "--input-clustering-key",
     help="BigQuery clustering key.",
     type=str,


### PR DESCRIPTION
## Summary
- add missing click.option decorator for benchmark-dataloader CLI clustering key argument to fix indentation error during import

## Testing
- poetry run python -m py_compile src/maou/infra/console/utility.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b22ad5eb083278cd70d0f1d132de7)