### PR TITLE
fix(inference): enable CPU execution for evaluate command

### DIFF
--- a/src/maou/app/inference/onnx_inference.py
+++ b/src/maou/app/inference/onnx_inference.py
@@ -35,8 +35,10 @@ class ONNXInference:
         session = ort.InferenceSession(
             path, sess_options=options, providers=providers
         )
+        # Add batch dimension: (9, 9) -> (1, 9, 9)
+        batched_input = np.expand_dims(input_data, axis=0)
         outputs = session.run(
-            ["policy", "value"], {"input": [input_data]}
+            ["policy", "value"], {"input": batched_input}
         )
         policy_labels: list[int] = list(
             np.argsort(outputs[0][0])[::-1][:num]  # type: ignore

--- a/src/maou/app/inference/run.py
+++ b/src/maou/app/inference/run.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from maou.app.inference.eval import Evaluation
 from maou.app.inference.onnx_inference import ONNXInference
-from maou.app.pre_process.feature import make_feature
+from maou.app.pre_process.feature import make_board_id_positions
 from maou.app.pre_process.label import (
     IllegalMove,
     make_usi_move_from_label,
@@ -58,7 +58,9 @@ class InferenceRunner:
             raise ValueError(
                 "Either sfen or board must be provided."
             )
-        input_data = make_feature(board).astype(np.float32)
+        input_data = make_board_id_positions(board).astype(
+            np.int64
+        )
 
         # 推論
         policy_labels: list[int] = []

--- a/src/maou/app/inference/tensorrt_inference.py
+++ b/src/maou/app/inference/tensorrt_inference.py
@@ -196,9 +196,11 @@ class TensorRTInference:
         # inputの転送 host -> gpu
         # np.copyto(self.host[:data.size], data.flat, casting='safe')
         # cudart.cudaMemcpyAsync(inp.device, inp.host, inp.nbytes, cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, stream)
+        # Add batch dimension before flattening: (9, 9) -> (1, 9, 9) -> flat
+        batched_input = np.expand_dims(input_data, axis=0)
         np.copyto(
             host_input_ctype_array,
-            input_data.astype(trt.nptype(trt.float32)).ravel(),
+            batched_input.astype(np.int64).ravel(),
             casting="safe",
         )
         cudart.cudaMemcpyAsync(


### PR DESCRIPTION
## Summary

Fixes the ONNX Runtime rank mismatch error that prevented `maou evaluate` from running on CPU environments.

**Root Cause**: The inference pipeline was using outdated feature planes `(104, 9, 9)` instead of board ID positions `(9, 9)` that the ONNX model expects.

**Error Fixed**:
```
onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: 
[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Invalid rank for input: input 
Got: 4 Expected: 3
```

## Changes

- **run.py**: Replace `make_feature()` with `make_board_id_positions()` and change dtype from `float32` to `int64`
- **onnx_inference.py**: Add batch dimension using `np.expand_dims()` to convert `(9, 9)` → `(1, 9, 9)`
- **tensorrt_inference.py**: Apply same fix for TensorRT inference consistency

## Impact

- Enables CPU inference for model evaluation
- Aligns inference input format with how ONNX models are exported
- Maintains compatibility with both ONNX and TensorRT backends

## Test Plan

- [x] Type checking passes (`mypy src/maou/app/inference/`)
- [x] Pre-commit hooks pass
- [x] Manual test: Run `maou evaluate` command on CPU with ONNX model
- [x] Verify policy and value outputs are reasonable

## Related Files

- `src/maou/app/inference/run.py` (6 lines changed)
- `src/maou/app/inference/onnx_inference.py` (4 lines changed)
- `src/maou/app/inference/tensorrt_inference.py` (4 lines changed)