### PR TITLE
fix: フォールバックコマンドが未知オプションを受け付けるように修正

### DIFF
--- a/src/maou/infra/console/app.py
+++ b/src/maou/infra/console/app.py
@@ -176,6 +176,10 @@ class LazyGroup(click.Group):
             ),
             help=help_text,
             short_help=short_help,
+            context_settings={
+                "ignore_unknown_options": True,
+                "allow_extra_args": True,
+            },
         )
         self._fallback_commands[cmd_name] = fallback_command
         super().add_command(fallback_command)
@@ -209,6 +213,10 @@ class LazyGroup(click.Group):
             ),
             help=help_message,
             short_help=help_message,
+            context_settings={
+                "ignore_unknown_options": True,
+                "allow_extra_args": True,
+            },
         )
         self._fallback_commands[cmd_name] = fallback_command
         super().add_command(fallback_command)

--- a/tests/maou/infra/console/test_lazy_group.py
+++ b/tests/maou/infra/console/test_lazy_group.py
@@ -239,6 +239,60 @@ class TestCheckPackages:
         assert "Install with one of:" in result.output
 
 
+class TestUnknownOptions:
+    """未知のオプション付き実行時の挙動テスト．"""
+
+    def test_unknown_option_shows_dependency_error(
+        self, runner: CliRunner
+    ) -> None:
+        """未知のオプション付きでもインストール案内が表示される．"""
+        spec = LazyCommandSpec(
+            "fake.module",
+            "fake_cmd",
+            required_packages=(
+                PackageRequirement("gradio", ("visualize",)),
+            ),
+        )
+        cli = _make_group({"visualize": spec})
+
+        with patch(
+            "maou.infra.console.app.find_spec",
+            side_effect=_mock_find_spec({"gradio"}),
+        ):
+            result = runner.invoke(
+                cli, ["visualize", "--share"]
+            )
+
+        assert "No such option" not in result.output
+        assert "gradio (not installed)" in result.output
+        assert "uv sync --extra visualize" in result.output
+
+    def test_unknown_option_with_value_shows_dependency_error(
+        self, runner: CliRunner
+    ) -> None:
+        """値付き未知オプションでもインストール案内が表示される．"""
+        spec = LazyCommandSpec(
+            "fake.module",
+            "fake_cmd",
+            required_packages=(
+                PackageRequirement("gradio", ("visualize",)),
+            ),
+        )
+        cli = _make_group({"visualize": spec})
+
+        with patch(
+            "maou.infra.console.app.find_spec",
+            side_effect=_mock_find_spec({"gradio"}),
+        ):
+            result = runner.invoke(
+                cli,
+                ["visualize", "--port", "8080", "--share"],
+            )
+
+        assert "No such option" not in result.output
+        assert "gradio (not installed)" in result.output
+
+
 class TestHelpDisplay:
     """--help 表示時の挙動テスト．"""
 


### PR DESCRIPTION
依存パッケージ不足時のフォールバックコマンドにcontext_settingsで
ignore_unknown_options/allow_extra_argsを設定し，--shareなどの
オプション付き実行でも「No such option」ではなくインストール案内が
表示されるようにした．

https://claude.ai/code/session_01YKPJamBWTQtYiKwgZh7J1B