### PR TITLE
fix: change board input dtype from Int64 to Int32 for TensorRT compatibility

### DIFF
--- a/src/maou/app/inference/run.py
+++ b/src/maou/app/inference/run.py
@@ -77,7 +77,7 @@ class InferenceRunner:
                 "Either sfen or board must be provided."
             )
         board_data = make_board_id_positions(board).astype(
-            np.int64
+            np.int32
         )
         hand_data = make_pieces_in_hand(board).astype(
             np.float32

--- a/src/maou/app/learning/dl.py
+++ b/src/maou/app/learning/dl.py
@@ -279,7 +279,7 @@ class Learning:
                 9,
                 9,
             ),
-            dtypes=[torch.int64],
+            dtypes=[torch.int32],
         )
 
         # Compile after freeze + optimizer setup
@@ -295,7 +295,7 @@ class Learning:
                 config.batch_size,
                 9,
                 9,
-                dtype=torch.int64,
+                dtype=torch.int32,
                 device=self.device,
             )
             warmup_compiled_model(self.model, dummy)

--- a/src/maou/app/learning/model_io.py
+++ b/src/maou/app/learning/model_io.py
@@ -435,7 +435,7 @@ class ModelIO:
                 np.asarray(
                     dummy_data[0]["boardIdPositions"],
                     dtype=np.uint8,
-                ).astype(np.int64)
+                ).astype(np.int32)
             )
             .unsqueeze(0)
             .to(device)

--- a/src/maou/app/learning/network.py
+++ b/src/maou/app/learning/network.py
@@ -382,7 +382,7 @@ class HeadlessNetwork(nn.Module):
         if input_type == "embedded":
             return tensor
 
-        board_tensor = tensor.to(torch.long)
+        board_tensor = tensor.to(torch.int32)
         embedded = self.embedding(board_tensor)
         return embedded.permute(0, 3, 1, 2).contiguous()
 

--- a/src/maou/app/learning/onnx_verifier.py
+++ b/src/maou/app/learning/onnx_verifier.py
@@ -401,7 +401,7 @@ class ONNXExportVerifier:
                 # PyTorch inference (2入力: board + hand)
                 pytorch_board = (
                     torch.from_numpy(
-                        dummy_board.astype(np.int64)
+                        dummy_board.astype(np.int32)
                     )
                     .unsqueeze(0)
                     .to(device)
@@ -419,7 +419,7 @@ class ONNXExportVerifier:
 
                 # ONNX inference (2入力: board + hand)
                 onnx_board = dummy_board.astype(
-                    np.int64
+                    np.int32
                 ).reshape(1, 9, 9)
                 onnx_hand = dummy_hand.astype(
                     np.float32

--- a/src/maou/app/learning/stage_component_factory.py
+++ b/src/maou/app/learning/stage_component_factory.py
@@ -886,7 +886,7 @@ class StageComponentFactory:
                 actual_batch_size,
                 9,
                 9,
-                dtype=torch.int64,
+                dtype=torch.int32,
                 device=device,
             )
             warmup_compiled_model(model, (dummy_board, None))


### PR DESCRIPTION
TensorRT has limited Int64 support, causing engine build failures with
"Could not find any implementation for node {ForeignNode[/Cast...]}" errors.
nn.Embedding supports Int32 indices and board values are 0-255, so Int32 is sufficient.

Also adds automatic ONNX Int64→Int32 conversion in build_engine_from_onnx
for backward compatibility with existing ONNX models exported with Int64.

https://claude.ai/code/session_013MhrEUTHfasNhfaKrnwX7e