### PR TITLE
fix: ONNX verifier テストの board input dtype を Int32 に修正

### DIFF
--- a/tests/maou/app/learning/test_onnx_verifier.py
+++ b/tests/maou/app/learning/test_onnx_verifier.py
@@ -149,7 +149,7 @@ def test_verify_onnx_functional_equivalence_fp32(
             np.asarray(
                 dummy_data[0]["boardIdPositions"],
                 dtype=np.uint8,
-            ).astype(np.int64)
+            ).astype(np.int32)
         )
         .unsqueeze(0)
         .to(device)
@@ -226,7 +226,7 @@ def test_verify_onnx_functional_equivalence_fp16(
             np.asarray(
                 dummy_data[0]["boardIdPositions"],
                 dtype=np.uint8,
-            ).astype(np.int64)
+            ).astype(np.int32)
         )
         .unsqueeze(0)
         .to(device)
@@ -308,7 +308,7 @@ def test_verify_onnx_graph_structure(
             np.asarray(
                 dummy_data[0]["boardIdPositions"],
                 dtype=np.uint8,
-            ).astype(np.int64)
+            ).astype(np.int32)
         )
         .unsqueeze(0)
         .to(device)


### PR DESCRIPTION
## Summary

- commit `0ef8ebf` で board input の dtype を Int64→Int32 に変更した際，`test_onnx_verifier.py` の2箇所が更新漏れとなっていた
- テストの dummy_board 生成で `np.int64` → `np.int32` に修正
- `huggingface-hub` の明示的依存を `visualize` extra から削除 (maou コードベースで直接利用しておらず，gradio の推移的依存に委ねる)

### numpy 2.0 対応について

numpy 2.0.2 へのアップグレードを検討したが，`cshogi 0.9.7` が Python 3.12 に対して `numpy>=1.26.0,<1.27.0` をハードピンしており，かつ NumPy 1.23 の C ABI でコンパイルされているため，現時点では移行不可．maou コード自体は numpy 2.0 互換 (ruff NPY201 チェック全パス)．cshogi の対応リリースを待つ．

## Test plan

- [x] `tests/maou/app/learning/test_onnx_verifier.py` — 6 tests passed (修正前は2テスト失敗)
- [x] `uv lock` — 232 packages resolved
- [x] pre-push hooks (mypy, ruff, isort) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)