### PR TITLE
ci: add and customize Claude Code GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,47 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - "src/**/*.py"
+      - "src/**/*.rs"
+      - "tests/**/*.py"
+      - "pyproject.toml"
+      - "Cargo.toml"
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            このプロジェクト固有のルールも確認してください:
+            - Clean Architecture の依存方向を守る: infra → interface → app → domain
+            - 逆方向の import（例: domain が app を import）は違反
+            - 全ての public API に型ヒントと docstring が必要
+            - 日本語 docstring は句点「，」読点「．」を使う（「、」「。」は NG）
+            - 括弧は半角「()」のみ（全角「（）」は NG）
+            - `pip` の使用禁止（`uv` のみ許可）
+            - `__init__.py` は本当に必要な場合以外作成しない
+            - CLI コマンドを変更した場合は `docs/commands/` の更新も確認

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,18 +19,23 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary

- Claude Code Review ワークフロー (`claude-code-review.yml`) を新規追加
- 既存の Claude Code ワークフロー (`claude.yml`) を最新バージョンに更新
- 両ワークフローをプロジェクト固有のルールに合わせてカスタマイズ

## Problem

PR レビューの自動化と `@claude` メンションによるインタラクションを実現するため，Claude Code の GitHub Actions が必要．
既存の `claude.yml` は旧バージョン (`@beta`) を使用しており，認証方式も古い `anthropic_api_key` のままだった．

## Solution

**新規: `claude-code-review.yml`**
PR 作成・更新時に自動でコードレビューを実行するワークフローを追加．
プロンプトにプロジェクト固有のルールを埋め込み，単なる汎用レビューではなくプロジェクトの規約に沿ったレビューが行われるようにした．

**更新: `claude.yml`**
`@claude` メンションへの応答ワークフローを最新の action バージョンと認証方式に移行した．
コード変更や PR 操作を依頼できるよう，必要な権限も拡張した．

## Changes

**`.github/workflows/claude-code-review.yml`** (新規)
- PR トリガー: `opened / synchronize / ready_for_review / reopened`
- パスフィルター: `src/**/*.py`, `src/**/*.rs`, `tests/**/*.py`, `pyproject.toml`, `Cargo.toml`（ドキュメントのみの変更では不要なレビューを発生させない）
- `pull-requests: write` 権限（レビューコメントの投稿に必須）
- `use_sticky_comment: true`（プッシュのたびに新コメントが増えず，1スレッドに集約）
- カスタムプロンプトでプロジェクト固有ルールをレビューに反映:
  - Clean Architecture の依存方向 (infra → interface → app → domain)
  - 型ヒントと docstring の必須化
  - 日本語句読点規則 (，．)
  - `uv` 使用強制・`pip` 禁止
  - `__init__.py` の不要な作成禁止
  - CLI 変更時の `docs/commands/` 更新確認

**`.github/workflows/claude.yml`** (更新)
- `actions/checkout@v6` → `v4` に更新
- `anthropics/claude-code-action@beta` → `v1` に更新
- `anthropic_api_key` → `claude_code_oauth_token` に認証方式を変更
- 権限を `read` → `write` に拡張（`contents`, `pull-requests`, `issues`）
- `actions: read` 権限を追加（CI 結果の読み取りに必要）
- `additional_permissions: actions: read` を設定

## Impact

**Breaking Changes**: なし

**Dependencies**: なし（既存の `CLAUDE_CODE_OAUTH_TOKEN` シークレットを使用）

**Configuration**: `CLAUDE_CODE_OAUTH_TOKEN` シークレットがリポジトリに設定済みであること（既存）

## Testing

ワークフローファイルの変更のため，自動テスト対象外．
動作確認は本 PR のマージ後，次の PR で Claude Code Review が正常に起動することで確認する．

## Review Notes

- `claude-code-review.yml` のパスフィルターにより，ワークフローファイル自体の変更では自動レビューが発動しない（意図的）
- `claude.yml` の権限拡張は `@claude` に「コードを修正して」「PR を作って」などの依頼をするために必要

## Checklist

- [x] YAML 構文チェック通過 (pre-commit)
- [x] コミットメッセージ規約準拠 (commitizen)
- [x] 1コミットにまとめ済み