### PR TITLE
fix: convert Int64 Constant nodes to Int32 for TensorRT compatibility

### DIFF
--- a/src/maou/app/inference/tensorrt_inference.py
+++ b/src/maou/app/inference/tensorrt_inference.py
@@ -57,6 +57,23 @@ class TensorRTInference:
                         attr.i = TensorProto.INT32
                         converted = True
 
+        # Constantノードの値テンソル型変換
+        for node in model.graph.node:
+            if node.op_type == "Constant":
+                for attr in node.attribute:
+                    if (
+                        attr.name == "value"
+                        and attr.t.data_type
+                        == TensorProto.INT64
+                    ):
+                        data = numpy_helper.to_array(attr.t)
+                        new_tensor = numpy_helper.from_array(
+                            data.astype(np.int32),
+                            attr.t.name,
+                        )
+                        attr.t.CopyFrom(new_tensor)
+                        converted = True
+
         # 初期化テンソルの型変換
         for initializer in model.graph.initializer:
             if initializer.data_type == TensorProto.INT64:


### PR DESCRIPTION
_convert_int64_to_int32 was only converting initializer tensors,
Cast nodes, and type annotations, but missed Constant nodes
(op_type="Constant"). This caused TensorRT Range operator parse
failures when start/delta inputs were Constant nodes with Int64
values while limit was an initializer already converted to Int32.

https://claude.ai/code/session_012LY9H5pD3gWo9tDqGydag2