### PR TITLE
feat: enforce semver version bump on every src/ change

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -32,15 +32,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release delete latest --yes --cleanup-tag || true
 
+      - name: Extract version
+        id: version
+        run: |
+          version=$(python3 -c "
+          import re
+          with open('pyproject.toml') as f:
+              m = re.search(r'^version\s*=\s*\"([^\"]+)\"', f.read(), re.MULTILINE)
+              print(m.group(1))
+          ")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           ls dist/*.whl 1>/dev/null 2>&1 || { echo "::error::No wheel files found in dist/"; exit 1; }
           gh release create latest \
-            --title "Development Build" \
+            --title "Development Build (v${{ steps.version.outputs.version }})" \
             --notes "Prebuilt wheels for development use (Colab, etc.).
 
+          - **Version**: ${{ steps.version.outputs.version }}
           - **Commit**: ${{ github.sha }}
           - **Built at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
           - **Platform**: manylinux_2_28 x86_64

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,58 @@
+name: Check Version Bump
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if src/ was modified
+        id: check_src
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD -- 'src/')
+          if [ -z "$changed" ]; then
+            echo "src_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "src_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            echo "$changed"
+          fi
+
+      - name: Check version bump
+        if: steps.check_src.outputs.src_changed == 'true'
+        run: |
+          pr_version=$(python3 -c "
+          import re
+          with open('pyproject.toml') as f:
+              m = re.search(r'^version\s*=\s*\"([^\"]+)\"', f.read(), re.MULTILINE)
+              print(m.group(1))
+          ")
+
+          main_version=$(git show origin/main:pyproject.toml | python3 -c "
+          import sys, re
+          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', sys.stdin.read(), re.MULTILINE)
+          print(m.group(1))
+          ")
+
+          echo "main version: $main_version"
+          echo "PR version:   $pr_version"
+
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "::error::src/ was modified but version in pyproject.toml was not bumped (still $main_version). Please bump the version following semver (fix: → patch, feat: → minor, breaking → major)."
+            exit 1
+          fi
+
+          # Verify the new version is greater than the old one
+          python3 -c "
+          from packaging.version import Version
+          old, new = Version('$main_version'), Version('$pr_version')
+          if new <= old:
+            raise SystemExit(f'::error::New version {new} must be greater than current {old}')
+          print(f'Version bump OK: {old} → {new}')
+          "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ Maou (魔王) is a Shogi (Japanese chess) AI project implemented in Python follo
 - MUST NOT call multiple Serena MCP tools in parallel (to prevent OOM in memory-constrained DevContainer)
 - MUST call Serena tools sequentially, one at a time
 
+### Versioning
+- MUST bump version in `pyproject.toml` when modifying files under `src/`
+- MUST follow semantic versioning: `fix:` → patch, `feat:` → minor, breaking change → major
+- MUST NOT push changes to `src/` without a corresponding version bump
+- Version is the single source of truth in `pyproject.toml` (`version_provider = "pep621"`)
+
 ### Forbidden Actions
 - MUST NOT use pip directly (use `uv` only)
 - MUST NOT create `__init__.py` unless absolutely necessary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.2.0"
+version = "0.2.1"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}


### PR DESCRIPTION
- Add versioning rules to CLAUDE.md (MUST bump on src/ changes)
- Add CI workflow (check-version-bump.yml) to block PRs without version bump
- Add version display to build-wheel.yml release notes
- Bump version 0.2.0 → 0.2.1 to include prior TensorRT fixes

The root cause of stale wheels was that uv cached the old wheel by
URL+version. Since the version never changed (always 0.2.0), reinstalls
served the cached copy. With enforced semver bumps, each release produces
a wheel with a new version in the filename, invalidating the cache.

https://claude.ai/code/session_01FEHosBhyZWw7UtM9j9PykM