### PR TITLE
fix: preserve shape path Int64 in TensorRT ONNX conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.2.3"
+version = "0.2.4"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}


### PR DESCRIPTION
Previously, _convert_int64_to_int32 aggressively converted ALL Int64
values to Int32, including shape computation path values (Shape outputs,
Constant values, initializers, value_int/value_ints attributes). This
caused cascading type errors: converting Shape outputs required Cast
insertion, which then required Cast-back for Expand/Squeeze/Reshape
shape inputs — a never-ending "whack-a-mole" pattern.

The root cause of the TensorRT Mul broadcast error was that Squeeze
axes (from value_ints Constants) were converted to Int32, causing
TensorRT to misinterpret the Squeeze operation and produce wrong
output shapes, breaking the downstream Mul broadcast.

Fix: Only convert data computation path Int64 (model inputs, Cast
targets, model outputs). Leave the entire shape computation path
as Int64, which is correct per ONNX spec and natively supported
by TensorRT for shape operations.

https://claude.ai/code/session_01E7YnKcE8fLweYpRsHPvcS1