### PR TITLE
fix: validate model_path/engine_path consistency with model_type in evaluate command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.2.5"
+version = "0.2.6"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/app/inference/run.py
+++ b/src/maou/app/inference/run.py
@@ -51,11 +51,6 @@ class InferenceRunner:
         engine_path: Optional[Path] = None
 
     def infer(self, config: InferenceOption) -> Dict[str, str]:
-        # engine_path 指定時は自動的に TENSORRT 扱い
-        effective_model_type = config.model_type
-        if config.engine_path is not None:
-            effective_model_type = ModelType.TENSORRT
-
         # model_path と engine_path のどちらかは必須
         if (
             config.model_path is None
@@ -64,6 +59,26 @@ class InferenceRunner:
             raise ValueError(
                 "Either model_path or engine_path must be provided."
             )
+
+        # model_type と指定パスの整合性チェック
+        if (
+            config.model_type == ModelType.TENSORRT
+            and config.model_path is not None
+        ):
+            raise ValueError(
+                "model_path cannot be used with TENSORRT model type. "
+                "Use engine_path to specify the TensorRT engine file."
+            )
+        if (
+            config.model_type == ModelType.ONNX
+            and config.engine_path is not None
+        ):
+            raise ValueError(
+                "engine_path cannot be used with ONNX model type. "
+                "Use model_type=TENSORRT with engine_path."
+            )
+
+        effective_model_type = config.model_type
 
         # 特徴量の作成
         board: Board

--- a/src/maou/infra/console/evaluate_board.py
+++ b/src/maou/infra/console/evaluate_board.py
@@ -95,6 +95,19 @@ def evaluate_board(
         raise click.UsageError(
             "--model-path or --engine-path is required."
         )
+    if model_type == "TENSORRT" and model_path is not None:
+        raise click.UsageError(
+            "--model-path cannot be used with --model-type TENSORRT. "
+            "Use --engine-path to specify the TensorRT engine file. "
+            "Example: maou evaluate --model-type TENSORRT "
+            "--engine-path <engine-file> --sfen ..."
+        )
+    if model_type == "ONNX" and engine_path is not None:
+        raise click.UsageError(
+            "--engine-path cannot be used with --model-type ONNX. "
+            "Use --model-type TENSORRT with --engine-path, "
+            "or use --model-path with --model-type ONNX."
+        )
     click.echo(
         infer.infer(
             model_type=model_type,

--- a/tests/maou/app/inference/test_run.py
+++ b/tests/maou/app/inference/test_run.py
@@ -313,7 +313,7 @@ class TestInferenceRunner:
             mock_import.side_effect = side_effect_import
 
             config = InferenceRunner.InferenceOption(
-                model_path=mock_model_path,
+                engine_path=mock_model_path,
                 model_type=ModelType.TENSORRT,
                 sfen=sample_sfen,
             )
@@ -367,7 +367,7 @@ class TestInferenceRunner:
             mock_make_usi.side_effect = ["7g7f", "2g2f"]
 
             config = InferenceRunner.InferenceOption(
-                model_path=mock_model_path,
+                engine_path=mock_model_path,
                 model_type=ModelType.TENSORRT,
                 sfen=sample_sfen,
                 num_moves=2,


### PR DESCRIPTION
When --model-type TENSORRT was specified with --model-path (instead of
--engine-path), the code attempted to parse the TensorRT engine file as
ONNX, resulting in a cryptic protobuf DecodeError. Add explicit
validation at both CLI and app layers to reject incompatible
combinations early with clear error messages.

https://claude.ai/code/session_01CAuMzQwULGCMddTUUKyhhg