### PR TITLE
chore: pre-commit autoupdate 20260301

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,19 @@ repos:
   - id: check-toml
   - id: check-added-large-files
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.12
+  rev: 0.10.7
   hooks:
   - id: uv-lock
 - repo: https://github.com/pycqa/isort
-  rev: 6.0.1
+  rev: 8.0.1
   hooks:
   - id: isort
 - repo: https://github.com/pre-commit/pre-commit
-  rev: v4.3.0
+  rev: v4.5.1
   hooks:
   - id: validate_manifest
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.8.3
+  rev: v4.13.9
   hooks:
   - id: commitizen
 - repo: local
@@ -56,7 +56,7 @@ repos:
     pass_filenames: false
     always_run: true
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.11
+  rev: v0.15.4
   hooks:
   - id: ruff-check
     args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.5.2"
+version = "0.5.3"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -761,10 +761,7 @@ def learn_model(
         _s3_at = "preprocessing"
         _s3_bp = False
         stage3_data_config = StageDataConfig(
-            create_datasource=lambda _p=_s3_paths,
-            _a=_s3_at,
-            _b=_s3_bp,
-            _c=_s3_cache: (
+            create_datasource=lambda _p=_s3_paths, _a=_s3_at, _b=_s3_bp, _c=_s3_cache: (
                 FileDataSource.FileDataSourceSpliter(
                     file_paths=_p,
                     array_type=_a,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and extra != 'extra-4-maou-cpu' and extra != 'extra-4-maou-cuda' and extra == 'extra-4-maou-mpu'",
@@ -1388,7 +1388,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Replaces #296 with a squashed single commit (to fix unverified commit issue)
- pre-commit autoupdate: uv-pre-commit, isort, pre-commit, commitizen, ruff-pre-commit
- Applied ruff format to `learn_model.py`
- Version bump: 0.5.2 → 0.5.3

## Test plan
- [x] Pre-commit hooks pass
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)