### PR TITLE
refactor: torch.compile state_dict 改善タスク3件を実施

### DIFF
--- a/docs/torch-compile-state-dict.md
+++ b/docs/torch-compile-state-dict.md
@@ -3,7 +3,7 @@
 ## 概要
 
 `torch.compile()` でモデルをコンパイルすると，`state_dict()` のキーに `_orig_mod.` プレフィックスが付与される．
-本ドキュメントでは，現在の対応状況と残っている改善タスクを整理する．
+本ドキュメントでは，現在の対応状況を整理する．
 
 ## 背景: `_orig_mod.` プレフィックス
 
@@ -18,7 +18,7 @@ compiled.state_dict()  # {"_orig_mod.backbone.layer.weight": ...}
 `torch.compile()` は `OptimizedModule` でラップし，元モジュールを `_orig_mod` 属性として保持する．
 パラメータ自体は同一オブジェクトを共有しており，学習時の勾配更新は元モジュールにも反映される．
 
-## 現在の対応状況 (v0.2.7)
+## 現在の対応状況 (v0.5.5)
 
 ### ユーティリティ
 
@@ -30,8 +30,12 @@ compiled.state_dict()  # {"_orig_mod.backbone.layer.weight": ...}
 |------|---------|---------|
 | `split_state_dict()` | `model_io.py` | プレフィックス除去後に分類・保存 |
 | `load_backbone()` | `model_io.py` | ロード後にプレフィックス除去 |
+| `load_policy_head()` | `model_io.py` | ロード後にプレフィックス除去 |
+| `load_value_head()` | `model_io.py` | ロード後にプレフィックス除去 |
+| `load_reachable_head()` | `model_io.py` | ロード後にプレフィックス除去 |
+| `load_legal_moves_head()` | `model_io.py` | ロード後にプレフィックス除去 |
 | `save_model()` | `model_io.py` | ユーティリティで除去を簡素化 |
-| `_load_component_state_dict()` | `dl.py` | 双方向対応(追加/除去) |
+| `_load_component_state_dict()` | `dl.py` | 双方向対応(追加/除去) + unexpected_keys 検知 |
 | `HeadlessNetwork.load_state_dict()` | `network.py` | フィルタリング前にプレフィックス除去 |
 
 ### Stage 別の状況
@@ -39,69 +43,30 @@ compiled.state_dict()  # {"_orig_mod.backbone.layer.weight": ...}
 | Stage | compile 対象 | 保存方法 | プレフィックス問題 |
 |-------|-------------|---------|------------------|
 | Stage 1/2 | `Stage1/2ModelAdapter` | `self.backbone.state_dict()` | なし(backbone は非コンパイル) |
-| Stage 3 | `Network` 本体 | `trained_model.state_dict()` | `_strip_orig_mod_prefix()` で除去 |
+| Stage 3 | `Stage3ModelAdapter` | `self.model.state_dict()` | なし(Network は非コンパイル) |
 
-## 残タスク
+### Stage 3 アダプターパターン
 
-### 1. Stage 3 アダプターパターン導入 (リファクタリング)
-
-**現状**: Stage 3 では `Network` 本体を直接 `torch.compile()` する．
-そのため `state_dict()` に `_orig_mod.` プレフィックスが付き，保存時に除去が必要になる．
-
-**改善案**: Stage 1/2 と同様にアダプターパターンを導入する．
+Stage 1/2 と同様に，Stage 3 でもアダプターパターンを採用している．
+`Network` 本体ではなく `Stage3ModelAdapter` を `torch.compile()` の対象とすることで，
+`Network.state_dict()` にプレフィックスが付かず，保存時の除去処理が不要になる．
 
 ```python
-# 現在の Stage 3
-compiled_model = torch.compile(network)  # Network 本体をコンパイル
-compiled_model.state_dict()  # _orig_mod. 付き → 除去が必要
-
-# 改善後
-class Stage3ModelAdapter(torch.nn.Module):
-    def __init__(self, network: Network):
-        super().__init__()
-        self.network = network
-
-    def forward(self, inputs):
-        return self.network(inputs)
-
+# Stage 3 アダプターパターン
 adapter = Stage3ModelAdapter(network)
 compiled = torch.compile(adapter)  # アダプターをコンパイル
 network.state_dict()  # プレフィックスなし → 除去不要
 ```
 
-**メリット**:
-- `_strip_orig_mod_prefix()` による保存時の除去が不要になる
-- Stage 1/2/3 で一貫したパターンになる
-- 保存されたチェックポイントが常にクリーンなキーを持つ
+### `_load_component_state_dict()` の安全性
 
-**影響範囲**:
-- `src/maou/app/learning/dl.py` の `Learning` クラス
-- `src/maou/interface/learn.py` の Stage 3 学習フロー
-- `src/maou/app/learning/model_io.py` の `save_model()`
+`_load_component_state_dict()` は `strict=False` で部分読み込みを行う．
+これはコンポーネント単位(backbone のみ / head のみ)のロードに必要な設定である．
 
-**優先度**: 低 (現在の `_strip_orig_mod_prefix()` で実害なし)
+安全性を確保するため以下の対策を実施している:
 
-### 2. head ロード関数のプレフィックス除去
-
-**現状**: `load_policy_head()`，`load_value_head()`，`load_reachable_head()`，`load_legal_moves_head()` は
-プレフィックス除去を行わず `torch.load()` の結果をそのまま返す．
-
-**理由**: 現在の保存フローでは head の `state_dict()` にプレフィックスが付かないため問題は顕在化しない．
-ただし，外部で保存されたコンパイル済みモデルのチェックポイントからヘッドを分離して保存した場合は，
-プレフィックス付きのキーが保存される可能性がある．
-
-**改善案**: `load_backbone()` と同様に `_strip_orig_mod_prefix()` を適用する．
-
-**優先度**: 低 (通常フローでは発生しない)
-
-### 3. `_load_component_state_dict()` の `strict=False` 検討
-
-**現状**: `dl.py` の `_load_component_state_dict()` は常に `strict=False` で部分読み込みを行う．
-これにより，キーの不一致がサイレントに無視される可能性がある．
-
-**検討事項**:
-- backbone 全体をロードする場合は `strict=True` の方が安全
-- 一方，head のみのロードでは backbone キーが missing になるため `strict=False` が必要
-- コンポーネント種別に応じて strict モードを切り替えるのが理想
-
-**優先度**: 中 (パラメータのロード漏れに気づきにくい)
+- **unexpected_keys の検知**: ロードした state_dict にモデルに存在しないキーがある場合，
+  `RuntimeError` を送出する．アーキテクチャ不一致や誤ったチェックポイントを早期に検知できる．
+- **component パラメータ**: ロード対象のコンポーネント名をログに出力し，
+  問題発生時のデバッグを容易にする．
+- **missing_keys のログ**: 部分ロードで期待される missing_keys を INFO レベルで記録する．

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.5.4"
+version = "0.5.5"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/app/learning/model_io.py
+++ b/src/maou/app/learning/model_io.py
@@ -205,9 +205,10 @@ class ModelIO:
         logger.info(
             f"Loading policy head parameters from {file_path}"
         )
-        return torch.load(
+        state_dict: dict[str, torch.Tensor] = torch.load(
             file_path, weights_only=True, map_location=device
         )
+        return ModelIO._strip_orig_mod_prefix(state_dict)
 
     @staticmethod
     def load_value_head(
@@ -225,9 +226,10 @@ class ModelIO:
         logger.info(
             f"Loading value head parameters from {file_path}"
         )
-        return torch.load(
+        state_dict: dict[str, torch.Tensor] = torch.load(
             file_path, weights_only=True, map_location=device
         )
+        return ModelIO._strip_orig_mod_prefix(state_dict)
 
     @staticmethod
     def load_reachable_head(
@@ -247,9 +249,10 @@ class ModelIO:
         logger.info(
             f"Loading reachable squares head parameters from {file_path}"
         )
-        return torch.load(
+        state_dict: dict[str, torch.Tensor] = torch.load(
             file_path, weights_only=True, map_location=device
         )
+        return ModelIO._strip_orig_mod_prefix(state_dict)
 
     @staticmethod
     def load_legal_moves_head(
@@ -269,9 +272,10 @@ class ModelIO:
         logger.info(
             f"Loading legal moves head parameters from {file_path}"
         )
-        return torch.load(
+        state_dict: dict[str, torch.Tensor] = torch.load(
             file_path, weights_only=True, map_location=device
         )
+        return ModelIO._strip_orig_mod_prefix(state_dict)
 
     @staticmethod
     def save_model(


### PR DESCRIPTION
1. Stage 3 アダプターパターン導入
   - Stage3ModelAdapter を追加し，Network 本体ではなくアダプターを torch.compile() の対象にすることで state_dict() のプレフィックス 問題を根本的に解消
   - Stage 1/2/3 で一貫したコンパイル戦略に統一
   - Learning クラスに _train_model 属性を追加し，コンパイル済み モデルと元モデルを分離

2. head ロード関数のプレフィックス除去
   - load_policy_head(), load_value_head(), load_reachable_head(), load_legal_moves_head() に _strip_orig_mod_prefix() を適用
   - load_backbone() と同様の防御的プレフィックス除去を一貫適用

3. _load_component_state_dict() の堅牢性向上
   - component パラメータを追加しログの可読性を改善
   - unexpected_keys を RuntimeError に昇格させ，アーキテクチャ 不一致による無音のパラメータロード漏れを検知可能に

https://claude.ai/code/session_01GPdE2TtYT7Hz5FBZmpbXdt