### PR TITLE
Downgrade Arrow IPC Stream format warning to info level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.6.2"
+version = "0.6.3"
 description = "shogi ai"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/infra/file_system/streaming_file_source.py
+++ b/src/maou/infra/file_system/streaming_file_source.py
@@ -262,7 +262,7 @@ def scan_row_count(file_path: Path) -> int:
         # Stream形式: DataFrameの高さを取得
         # Note: Stream形式ではメタデータのみの読み出しが不可能なため，
         # 全データを読む必要がある．大規模ファイルではメモリ使用量に注意．
-        logger.warning(
+        logger.info(
             "File %s is Arrow IPC Stream format. "
             "Reading full data for row count "
             "(consider converting to File format).",


### PR DESCRIPTION
## Summary
Changed the log level for Arrow IPC Stream format detection from warning to info level in the file scanning functionality.

## Changes
- **src/maou/infra/file_system/streaming_file_source.py**: Changed `logger.warning()` to `logger.info()` when detecting Arrow IPC Stream format files during row count scanning
- **pyproject.toml**: Bumped version from 0.6.2 to 0.6.3

## Details
The log message informs users that a file is in Arrow IPC Stream format and requires reading full data to determine row count. This is expected behavior rather than a warning condition, so the log level has been appropriately downgraded to info. The message still provides useful context about potential memory considerations for large files.

https://claude.ai/code/session_01HAUDTxYkQkkgv5i33H4hM5