### PR TITLE
Allow Claude to edit PRs, issues, and manage labels in CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,3 +39,9 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          allowed_tools: |
+            Bash(gh pr edit *)
+            Bash(gh pr ready *)
+            Bash(gh issue edit *)
+            Bash(gh label create *)


### PR DESCRIPTION
## Summary
Expanded Claude's permissions in the GitHub Actions workflow to enable automated management of pull requests, issues, and labels during CI runs.

## Key Changes
- Added `allowed_tools` configuration to the Claude workflow step
- Granted permissions for the following GitHub CLI operations:
  - `gh pr edit` - Allows Claude to modify pull request properties
  - `gh pr ready` - Allows Claude to mark pull requests as ready for review
  - `gh issue edit` - Allows Claude to modify issue properties
  - `gh label create` - Allows Claude to create new labels

## Implementation Details
These tools are now available to Claude during workflow execution, enabling more sophisticated automation capabilities such as updating PR metadata, managing review states, and organizing issues with labels. The permissions follow the principle of least privilege by specifying exact command patterns rather than broad access.

https://claude.ai/code/session_01HkZvqzcyUX1ax9h2RjPswu