### PR TITLE
feat(analysis): 棋譜 1 局を自動解析する maou analyze-game コマンドを追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,15 +1,14 @@
 name: Claude Code Review
 
+# 手動実行のみ (PR push ごとの自動レビューはトークン浪費のため廃止 —
+# ローカルでの確認を正とする．必要な PR にだけ番号指定で実行する)
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    paths:
-      - "src/**/*.py"
-      - "rust/src/**/*.rs"
-      - "tests/**/*.py"
-      - "pyproject.toml"
-      - "Cargo.toml"
-      - "rust/**/Cargo.toml"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "レビュー対象の PR 番号"
+        required: true
+        type: string
 
 jobs:
   claude-review:
@@ -36,7 +35,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}
 
             このプロジェクト固有のルールも確認してください:
             - Clean Architecture の依存方向を守る: infra → interface → app → domain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.8.1"
+version = "5.8.2"
 dependencies = [
  "arrayvec",
  "rustc-hash",

--- a/docs/commands/analyze_game.md
+++ b/docs/commands/analyze_game.md
@@ -1,0 +1,109 @@
+# `maou analyze-game`
+
+## Overview
+
+- Analyzes a whole game record (CSA / KIF) by running the MCTS engine — the
+  same engine as `maou search` — on the position **before each move**, and
+  produces a machine-readable JSON report plus a human-readable summary
+  (best-move match rate per player, biggest win-rate losses, mates found).
+  Design document: `docs/design/game-analysis/index.md`.
+- The evaluator (ONNX model or the deterministic mock) is loaded **once** via
+  the persistent engine binding (`maou._rust.maou_search.SearchEngine`) and
+  reused across all positions, so per-position model loading is avoided. With
+  TensorRT, the engine cache (`--trt-cache-dir`) additionally makes warmup
+  nearly free from the second process on.
+- Time management lives in this command (a budget allocator decides the
+  per-position budget); the search itself only consumes the budget it is
+  given. Three allocation modes are available: fixed time per position
+  (`--time-ms`), total time divided equally (`--total-time-ms`), and fixed
+  playouts per position (`--playouts`). These are mutually exclusive; when
+  none is given, 1000 ms per position is used (same default as `maou search`).
+- Only single-game files are supported: a CSA file containing multiple games
+  is rejected with an error (split it into one game per file, e.g. the output
+  of `maou fetch-floodgate`). File encoding is auto-detected (strict UTF-8
+  first, then cp932).
+
+## CLI options
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--input-path PATH` | ✅ | Game record file (CSA / KIF). |
+| `--input-format csa\|kif` | | Record format. Auto-detected from the file extension (`.csa` → csa, `.kif` / `.kifu` → kif) when omitted; unknown extensions require this flag. |
+| `--model-path PATH` | | ONNX model file path. When omitted, a deterministic mock evaluator is used (API verification only — analysis quality is meaningless). Requires a wheel built with the `onnx` cargo feature (see `docs/commands/search.md`). |
+| `--time-ms INT` | | Time budget per position in milliseconds. Mutually exclusive with `--total-time-ms` / `--playouts`. Defaults to 1000 when no budget option is given. |
+| `--total-time-ms INT` | | Total time budget for the whole game, divided equally across positions (floor division, min 1 ms per position). |
+| `--playouts INT` | | Playout budget per position. |
+| `--num-candidates INT` | default `5` | Number of candidate moves recorded per position in the JSON (best move first, then by visit count). |
+| `--output PATH` | | Write the JSON report to this file and print the human-readable summary to stdout. When omitted, the JSON itself is printed to stdout (pipe-friendly); progress goes to stderr either way. |
+| `--threads INT` | default `1` | Number of search threads. |
+| `--batch-size INT` | default `8` | Evaluation batch size. |
+| `--root-dfpn/--no-root-dfpn` | **default on** | Run dfpn mate search on each root position in parallel (same as `maou search`). Proven mates appear as `stop=root_proven` / `mate_found=true`. |
+| `--root-dfpn-nodes INT` | default `2000000` | Node budget for the root dfpn mate search. |
+| `--root-dfpn-depth INT` | default `2047` | Search depth limit for the root dfpn mate search (max 2047). |
+| `--leaf-mate/--no-leaf-mate` | **default on** | Enable short mate search at MCTS leaves (async, dedicated threads). |
+| `--leaf-mate-nodes INT` | default `50` | Node budget per leaf-mate df-pn call. |
+| `--leaf-mate-threads INT` | default `1` | Number of dedicated leaf-mate threads. |
+| `--cuda/--no-cuda` | default `--no-cuda` | Enable the CUDA Execution Provider. Requires `--model-path` and a wheel built with `onnx-cuda`. |
+| `--tensorrt/--no-tensorrt` | default `--no-tensorrt` | Enable the TensorRT Execution Provider. Requires `--model-path` and a wheel built with `onnx-tensorrt`. |
+| `--trt-cache-dir PATH` | | TensorRT engine cache directory. |
+
+## Outputs
+
+JSON report (schema details: `docs/design/game-analysis/index.md` §7):
+
+- `input` — file path, format, player names, ratings, result (`win`:
+  0=draw / 1=black / 2=white), endgame marker, number of moves.
+- `engine` — model path (null = mock), threads, batch size, EP flags, mate
+  search options.
+- `budget` — allocation mode, its parameter, and the resolved per-position
+  budget.
+- `positions[]` — one record per move: `ply`, `side_to_move` (`b`/`w`),
+  `sfen` (position before the move), `played_move` / `best_move` (USI) and
+  `match`, `winrate` / `eval_cp` (side-to-move view; Ponanza-style
+  `600 × logit`), `played_move_winrate` / `winrate_loss` (from the same
+  position's root statistics; null when the played move was not visited),
+  `pv`, `candidates[]` (usi / visits / winrate / prior / proven),
+  `mate_found` (`stop == "root_proven"`), `playouts` / `elapsed_ms` / `stop`,
+  and the record's own metadata echo (`record_time_s` / `record_score` /
+  `record_comment`).
+- `summary` — per-player best-move `match_rate` and `mean_winrate_loss`,
+  `worst_moves` (top 5 by `winrate_loss`), `mates_found`,
+  `total_elapsed_ms` / `total_playouts`.
+
+The stdout summary (with `--output`) shows the players, result, match rates,
+mean win-rate losses, the worst moves, mates found, and total elapsed time.
+
+## Example invocation
+
+```bash
+# Quick check with the mock evaluator (development only)
+uv run maou analyze-game \
+  --input-path game.csa --playouts 100 --output report.json
+
+# Real analysis: 1 second per position with an ONNX model
+uv run maou analyze-game \
+  --input-path game.csa --model-path model.onnx \
+  --time-ms 1000 --threads 4 --batch-size 8 \
+  --output report.json
+
+# Whole-game budget: 60 seconds divided equally across positions
+uv run maou analyze-game \
+  --input-path game.kif --model-path model.onnx \
+  --total-time-ms 60000 --output report.json
+
+# Pipe the JSON (no --output): summary is omitted, progress on stderr
+uv run maou analyze-game --input-path game.csa --playouts 800 | jq '.summary'
+```
+
+## Implementation references
+
+- CLI: `src/maou/infra/console/analyze_game.py`
+- Interface (validation / allocator construction / formatting):
+  `src/maou/interface/analyzer.py`
+- Use case (game walk, per-position search, summary):
+  `src/maou/app/analysis/game_analyzer.py`
+- Budget allocation strategies: `BudgetAllocator` and implementations in
+  `src/maou/app/analysis/game_analyzer.py`
+- Persistent engine binding: `SearchEngine` in
+  `rust/maou_rust/src/maou_search.rs`
+- Design document: `docs/design/game-analysis/index.md`

--- a/docs/design/game-analysis/index.md
+++ b/docs/design/game-analysis/index.md
@@ -1,0 +1,187 @@
+# 棋譜解析コマンド (analyze-game) 設計ドキュメント
+
+> **状態: 設計確定・実装中 (living document)**．実装の進行に合わせて本ドキュメントを
+> 更新する．各節に「実装済み」「設計方針 (未実装)」「未決」のいずれかを明記する．
+> 実装済み記述の正は常にコード (`src/maou/app/analysis/` ほか) であり，乖離を
+> 見つけたら本ドキュメント側を直す．
+> 提案・承認の経緯: reviews/2026-07-16-analyze-game-command-design.md
+
+## 1. 目的とスコープ (設計方針)
+
+CSA / KIF ファイルの **1 局の棋譜を丸ごと受け取り，1 手ずつ 1 局面探索を行う
+自動解析コマンド** `maou analyze-game`．各局面のエンジン最善手・勝率・PV と
+実戦の手との比較 (一致率，勝率損失) を機械可読 JSON として出力する．
+
+- **時間管理は本機能の責務**: 1 局面探索エンジン (docs/design/position-search/)
+  は「与えられた予算内で 1 局面を探索する」までが責務であり (binding，user 決定
+  2026-07-07)，持ち時間・全体時間の配分計画はその上位レイヤー = 本機能が担う．
+- 時間配分はまず単純に (1 局面 N ms 固定 / 全体 T ms の等分)．成熟後に
+  難局面・終盤への傾斜配分を戦略追加で導入できる構造にする (user スケッチ
+  2026-07-15)．
+- **スコープ外**: 複数局を含む CSA の一括解析 (当面はエラー，将来拡張)，
+  最終手後の局面の解析，対局機能．
+
+## 2. CLI (設計方針)
+
+```
+maou analyze-game --input-path FILE
+  [--input-format csa|kif]        # 省略時は拡張子から自動判定
+                                  # (.csa → csa / .kif,.kifu → kif / 不明は明示要求エラー)
+  [--model-path PATH]             # 省略時 mock 評価器 (テスト用途)
+  [--time-ms N]                   # 1 局面あたりの時間 (排他, 全省略時 default 1000)
+  [--total-time-ms T]             # 全体 T ms を解析局面数で等分 (排他)
+  [--playouts N]                  # 1 局面あたりの playout 数 (排他)
+  [--num-candidates K]            # JSON に記録する候補手数 (default 5)
+  [--output PATH]                 # JSON 出力先．指定時は stdout にサマリ，
+                                  # 省略時は stdout に JSON のみ (pipe 用途)
+  [探索 passthrough: --threads --batch-size
+   --root-dfpn/--no-root-dfpn --root-dfpn-nodes --root-dfpn-depth
+   --leaf-mate/--no-leaf-mate --leaf-mate-nodes --leaf-mate-threads
+   --cuda/--no-cuda --tensorrt/--no-tensorrt --trt-cache-dir]
+```
+
+- 予算 3 オプション (`--time-ms` / `--total-time-ms` / `--playouts`) は相互排他．
+  2 つ以上の指定はエラー．
+- 探索 passthrough の名前・デフォルトは既存 `maou search` に揃える．
+- **実行プロバイダの選択肢は `maou search` と同一に維持する** (user 指示
+  2026-07-16): デフォルト = CPU，`--cuda` = CUDA EP，`--tensorrt` = TensorRT EP
+  (+ `--trt-cache-dir`)．analyze-game 側で特定 EP を前提・固定しない．
+  TensorRT はエンジンキャッシュ利用時，初回ビルド以降の warmup がほぼ 0 になる．
+
+## 3. レイヤー構成 (設計方針)
+
+fetch-floodgate と同型の Clean Architecture 構成:
+
+| 層 | ファイル | 責務 |
+|---|---|---|
+| infra/console | `src/maou/infra/console/analyze_game.py` | click コマンド + `LAZY_COMMANDS` 登録 |
+| interface | `src/maou/interface/analyzer.py` | 入力検証・オプション組立・JSON/サマリ整形 |
+| app | `src/maou/app/analysis/game_analyzer.py` | `GameAnalyzer` usecase + `BudgetAllocator` |
+| rust (PyO3) | `rust/maou_rust/src/maou_search.rs` | 永続エンジン `SearchEngine` (pyclass) |
+
+- app 層が `maou._rust` を直接呼ぶのは既存 `app/search/run.py` と同じ扱い．
+- 棋譜パースは既存露出の `maou._rust.maou_shogi.parse_csa_str` (複数局対応) /
+  `parse_kif_str` (単一局) を用いる．`GameRecord.moves` (cshogi 互換 32-bit) は
+  domain `Board.push_move` にそのまま渡せ，`move_to_usi` で USI に変換できる．
+
+## 4. 永続エンジン binding `SearchEngine` (設計方針)
+
+現行 `maou._rust.maou_search.search` は呼び出しごとに ONNX モデルをロードする
+(1 局面 1 回)．N 局面の連続解析でこれを排除するため，評価器を保持する pyclass を
+`maou._rust.maou_search` に追加する:
+
+```python
+class SearchEngine:
+    def __init__(self, *, model_path=None, threads=1, batch_size=8,
+                 use_cuda=False, use_tensorrt=False,
+                 trt_engine_cache_dir=None): ...
+    def search(self, sfen, *, moves=None, max_playouts=None, time_ms=None,
+               root_dfpn=True, root_dfpn_nodes=2_000_000,
+               root_dfpn_depth=2047, leaf_mate=True, leaf_mate_nodes=50,
+               leaf_mate_threads=1) -> SearchResult
+```
+
+- `__init__` で評価器 (OnnxEvaluator または mock) を 1 回だけ構築して保持する．
+  `search` は局面ごとに `Searcher::new(&evaluator, options)` を生成する
+  (現行 `run_search` と同じ経路．ツリー / TT は局面ごとに新規)．
+- 探索中は GIL を解放する (`py.allow_threads`)．戻り値は既存 `SearchResult`．
+- 予算は毎回引数で受け取る — **時間配分の判断を一切持たない** (§1 の責務分離)．
+- 実行プロバイダは `__init__` 引数で選択し，既存 `search` 関数と同じ cargo
+  feature gate (`onnx` / `onnx-cuda` / `onnx-tensorrt`) に従う — デフォルト
+  wheel の可搬性を維持 (VETO「wheel 可搬性維持」)．
+- 既存の関数 `search` は互換のため残す．
+- バッチ関数 (1 call で全局面) ではなくハンドル型にした理由: 時間配分・進捗表示
+  (tqdm)・中断を Python 側ループに残せるため．
+
+## 5. 時間配分戦略 `BudgetAllocator` (設計方針)
+
+```python
+@dataclass(frozen=True)
+class PositionBudget:
+    max_playouts: int | None
+    time_ms: int | None
+
+class BudgetAllocator(abc):  # 戦略
+    def allocate(self, n_positions: int) -> list[PositionBudget]
+```
+
+- `FixedTimeAllocator(time_ms)` — 全局面同一時間．
+- `EqualDivisionAllocator(total_time_ms)` — `max(total // n, 1)` ms を全局面に
+  配分 (床関数．端数は捨てる = 全体上限を超えない側に倒す)．
+- `FixedPlayoutsAllocator(playouts)` — ノード予算派．
+- 将来の傾斜配分 (難局面・終盤重視) は Allocator の戦略追加のみで実現し，
+  探索側 API は変えない．
+
+## 6. 解析ループ (設計方針)
+
+1. ファイルを bytes で読み，UTF-8 先行 → 失敗時 cp932 でデコード
+   (cp932 はほぼ任意バイト列で成功するため UTF-8 先行判定が本質)．
+2. `parse_csa_str` / `parse_kif_str` で `GameRecord` を得る．CSA で複数局が
+   返った場合はエラー (1 局のみ対応と明示)．`moves` が空の棋譜もエラー．
+3. 解析対象 = 各指し手の直前局面 P0..P(N-1)．Allocator で N 局面分の予算を確定．
+4. 各 ply i について `engine.search(sfen=初期SFEN, moves=USI prefix m1..mi, ...)`
+   を呼ぶ (prefix を渡すことで千日手履歴が正しく効く)．並行して domain `Board`
+   を `push_move` で進め，記録用の SFEN・手番を得る．
+5. 不正手 (push / パース失敗) は ply を明示して fail-loud．
+
+## 7. 出力スキーマ (設計方針)
+
+JSON (機械可読, per-position 全記録):
+
+```json
+{
+  "input": {"path": "...", "format": "csa", "names": ["...", "..."],
+             "ratings": [3000.0, 2800.0], "win": 1, "endgame": "%TORYO",
+             "n_moves": 118},
+  "engine": {"model_path": "...", "threads": 4},
+  "budget": {"mode": "equal_division", "total_time_ms": 60000,
+              "per_position": {"time_ms": 508}},
+  "positions": [
+    {"ply": 1, "side_to_move": "b", "sfen": "...",
+     "played_move": "7g7f", "best_move": "2g2f", "match": false,
+     "winrate": 0.53, "eval_cp": 42,
+     "played_move_winrate": 0.51, "winrate_loss": 0.02,
+     "pv": ["2g2f", "8c8d"],
+     "candidates": [{"usi": "2g2f", "visits": 420, "winrate": 0.53,
+                      "prior": 0.31, "proven": null}],
+     "mate_found": false,
+     "playouts": 800, "elapsed_ms": 500, "stop": "time_limit",
+     "record_time_s": 12, "record_score": 55, "record_comment": null}
+  ],
+  "summary": {
+    "match_rate": {"black": 0.62, "white": 0.58},
+    "mean_winrate_loss": {"black": 0.031, "white": 0.044},
+    "worst_moves": [{"ply": 88, "side": "w", "played": "5b4b",
+                      "best": "3a4b", "winrate_loss": 0.34}],
+    "mates_found": [{"ply": 115, "side": "b"}]
+  }
+}
+```
+
+- `winrate` / `eval_cp` は手番視点 (eval は既存の Ponanza 係数 600 変換)．
+- `played_move_winrate` は root_children から実戦の手を引いた値．未訪問なら
+  null，その場合 `winrate_loss` (= best − played, 同一局面内比較) も null．
+- `mate_found` は `stop == "root_proven"` (PV が詰み手順)．
+- `record_time_s` / `record_score` / `record_comment` は棋譜側記録の echo
+  (`times` は moves と長さ不一致があり得るため範囲外は null)．
+- stdout サマリ (`--output` 指定時): 対局者・結果，先手/後手の一致率と平均
+  winrate 損失，worst_moves 一覧，詰み発見，総所要時間．
+- 進捗は tqdm (stderr) で局面単位に表示．
+
+## 8. テスト (設計方針)
+
+- allocator 単体 (等分・端数・最小値 1ms 保証)
+- デコード (UTF-8 / cp932 fallback / 不正トレイル)
+- `GameAnalyzer` golden: 数手の小 CSA/KIF fixture + mock 評価器で JSON
+  スキーマと ply 進行を検証
+- CLI: CliRunner + mock 評価器 (`--output` 経由で JSON を読む — tqdm と
+  stdout の連結問題を回避)
+- `SearchEngine` 再利用: mock 評価器で同一エンジンから複数回 search し結果
+  整合を確認 (Python 側テスト)
+- CSA 複数局・空棋譜・不正手の fail-loud
+
+## 9. 未決事項
+
+- 傾斜配分戦略の具体形 (難易度指標・終盤重み) — 単純等分の運用実績を見て設計
+- 複数局 CSA / ディレクトリ一括解析の要否
+- 解析結果の可視化 (勝率グラフ等) との接続

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.42.0"
+version = "0.43.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-07-16-analyze-game-command-design.md
+++ b/reviews/2026-07-16-analyze-game-command-design.md
@@ -1,8 +1,10 @@
 ---
 title: analyze-game コマンド新設 (棋譜 1 局の自動解析) の設計
 date: 2026-07-16
-status: pending
+status: approved
 applied_in:
+# user 承認 2026-07-16．docs/design/game-analysis/index.md は 38482cc で適用済み．
+# docs/commands/analyze_game.md が実装コミットで揃った時点で applied に遷移する．
 target:
   - docs/design/game-analysis/index.md
   - docs/commands/analyze_game.md

--- a/reviews/2026-07-16-analyze-game-command-design.md
+++ b/reviews/2026-07-16-analyze-game-command-design.md
@@ -80,6 +80,11 @@ maou analyze-game --input-path FILE
 予算 3 オプションは相互排他 (2 つ以上指定はエラー)．探索 passthrough の
 名前・デフォルトは既存 `maou search` に揃える．
 
+実行プロバイダの選択肢は `maou search` と同一に維持する (user 指示
+2026-07-16): デフォルト = CPU，`--cuda` = CUDA EP，`--tensorrt` =
+TensorRT EP (+ `--trt-cache-dir`)．analyze-game 側で特定 EP を前提と
+したり固定したりしない．
+
 ### レイヤー構成 (fetch-floodgate と同型)
 
 | 層 | ファイル | 内容 |
@@ -113,6 +118,10 @@ class SearchEngine:
 - 探索中は GIL を解放する (`py.allow_threads`)．戻り値は既存
   `SearchResult` をそのまま使う
 - 予算は毎回引数で受け取る — 時間配分の判断は一切持たない (VETO 整合)
+- 実行プロバイダ (CPU / CUDA EP / TensorRT EP) は `__init__` 引数で
+  選択し，既存 `search` 関数と同じ cargo feature gate
+  (`onnx` / `onnx-cuda` / `onnx-tensorrt`) に従う — デフォルト wheel の
+  可搬性を維持 (VETO「wheel 可搬性維持」整合)
 - 既存の関数 `search` は互換のため残す (内部を `SearchEngine` 経由に
   リファクタするかは実装時判断)
 - 局面ごとの `search` 呼び出しが Python 側ループに残るので，進捗表示

--- a/reviews/2026-07-16-analyze-game-command-design.md
+++ b/reviews/2026-07-16-analyze-game-command-design.md
@@ -1,0 +1,239 @@
+---
+title: analyze-game コマンド新設 (棋譜 1 局の自動解析) の設計
+date: 2026-07-16
+status: pending
+applied_in:
+target:
+  - docs/design/game-analysis/index.md
+  - docs/commands/analyze_game.md
+risk: low
+reversibility: moderate
+---
+
+# 提案: `maou analyze-game` — 棋譜 1 局の自動解析コマンド
+
+## 背景
+
+user スケッチ原文 (2026-07-15):
+
+> CSA や KIF ファイルから 1 局の棋譜を全部渡して，1 手ずつ 1 局面探索を
+> 行う形．自動解析．時間管理は単純なもので良い — 例: 1 手 (1 局面) に
+> 何秒，全局面何秒だったら 1 手は等分．成熟してきたら難しそうな局面に
+> 時間配分を偏らせられると良いかもしれない (後半を重くするとか)
+
+方向確認 (user 回答, 2026-07-16):
+
+- コマンド名: **analyze-game**
+- モデル毎回ロード問題: **最初から Rust 永続 binding を追加** (段階を踏まない)
+- 出力形式: **JSON + stdout サマリ**
+- user 訂正: TensorRT は `--trt-cache-dir` 指定時に初回ビルドした
+  エンジンがキャッシュされ，2 回目以降のプロセスでは warmup 時間は
+  ほぼ 0 になる (「毎回数十秒」は初回のみの話)
+
+binding 制約 (VETO, user 2026-07-07): 持ち時間の消費計画は別レイヤー —
+1 局面探索は与えられた予算内まで．docs/design/position-search/index.md §1
+も時間管理を「上位レイヤーで設計する」と明記しており，本コマンドが
+その上位レイヤーを実装する．
+
+## 調査で確定した前提 (2026-07-16)
+
+- 探索予算はノード数と時間の両対応: Rust `SearchLimits { max_playouts:
+  Option<u64>, time_ms: Option<u64> }` (rust/maou_rust/src/maou_search.rs:330)
+- 現行 `maou._rust.maou_search.search` は呼び出しごとに
+  `OnnxEvaluator::from_file` でモデルをロードする (maou_search.rs:362)．
+  評価器を保持する Python ハンドルは存在しない．maou_search crate は
+  `OnnxEvaluator` / `Searcher` / `SearchOptions` / `SearchLimits` を
+  pub export 済み (rust/maou_search/src/lib.rs:49-55) で永続化の下地はある
+- 棋譜パースは Python 露出済み: `maou._rust.maou_shogi.parse_csa_str`
+  (複数局対応) / `parse_kif_str` (単一局, UTF-8 前提でデコードは呼び出し側
+  責務) → `GameRecord{sfen, moves(cshogi 互換 32-bit), names, ratings,
+  win, endgame, times, scores, comments}` (maou_shogi.rs:520-614)．
+  現状 src/maou の Python コードからは未使用
+- domain `Board` に `set_sfen` / `push_move` / `get_sfen` /
+  `move_to_usi` があり，各手番局面を再構築できる (src/maou/domain/board/shogi.py)
+- コマンド追加は console + interface + app の 3 層 + `LAZY_COMMANDS`
+  1 行という確立パターン (fetch-floodgate と同型, src/maou/infra/console/app.py:240-332)
+- フォーマット自動判定は現状どこにも無い (hcpe-convert は
+  `--input-format` 必須)
+
+## 設計
+
+### CLI
+
+```
+maou analyze-game --input-path FILE
+  [--input-format csa|kif]        # 省略時は拡張子から自動判定
+                                  # (.csa → csa / .kif,.kifu → kif / 不明は明示要求エラー)
+  [--model-path PATH]             # 省略時 mock 評価器 (テスト用途)
+  [--time-ms N]                   # 1 局面あたりの時間 (排他, 全省略時 default 1000)
+  [--total-time-ms T]             # 全体 T ms を解析局面数で等分 (排他)
+  [--playouts N]                  # 1 局面あたりの playout 数 (排他)
+  [--num-candidates K]            # JSON に記録する候補手数 (default 5)
+  [--output PATH]                 # JSON 出力先．指定時は stdout にサマリ，
+                                  # 省略時は stdout に JSON のみ (pipe 用途)
+  [探索 passthrough: --threads --batch-size
+   --root-dfpn/--no-root-dfpn --root-dfpn-nodes --root-dfpn-depth
+   --leaf-mate/--no-leaf-mate --leaf-mate-nodes --leaf-mate-threads
+   --cuda/--no-cuda --tensorrt/--no-tensorrt --trt-cache-dir]
+```
+
+予算 3 オプションは相互排他 (2 つ以上指定はエラー)．探索 passthrough の
+名前・デフォルトは既存 `maou search` に揃える．
+
+### レイヤー構成 (fetch-floodgate と同型)
+
+| 層 | ファイル | 内容 |
+|---|---|---|
+| infra/console | `src/maou/infra/console/analyze_game.py` | click コマンド + `LAZY_COMMANDS` 登録 |
+| interface | `src/maou/interface/analyzer.py` | 入力検証・オプション組立・JSON/サマリ整形 |
+| app | `src/maou/app/analysis/game_analyzer.py` | `GameAnalyzer` usecase + `BudgetAllocator` |
+| rust (PyO3) | `rust/maou_rust/src/maou_search.rs` | 永続エンジン `SearchEngine` (新規 pyclass) |
+
+app 層が `maou._rust` を直接呼ぶのは既存 `app/search/run.py` と同じ扱い．
+
+### Rust 永続エンジン binding (`SearchEngine`)
+
+呼び出しごとのモデルロードを排除するため，評価器を保持する pyclass を
+`maou._rust.maou_search` に追加する:
+
+```python
+class SearchEngine:
+    def __init__(self, *, model_path=None, threads=1, batch_size=8,
+                 use_cuda=False, use_tensorrt=False,
+                 trt_engine_cache_dir=None): ...
+    def search(self, sfen, *, moves=None, max_playouts=None, time_ms=None,
+               root_dfpn=True, root_dfpn_nodes=2_000_000,
+               root_dfpn_depth=2047, leaf_mate=True, leaf_mate_nodes=50,
+               leaf_mate_threads=1) -> SearchResult
+```
+
+- `__init__` で評価器 (OnnxEvaluator または mock) を 1 回だけ構築して保持．
+  `search` は局面ごとに `Searcher::new(&evaluator, options)` を生成する
+  (現行 `run_search` と同じ経路．ツリー/TT は局面ごとに新規)
+- 探索中は GIL を解放する (`py.allow_threads`)．戻り値は既存
+  `SearchResult` をそのまま使う
+- 予算は毎回引数で受け取る — 時間配分の判断は一切持たない (VETO 整合)
+- 既存の関数 `search` は互換のため残す (内部を `SearchEngine` 経由に
+  リファクタするかは実装時判断)
+- 局面ごとの `search` 呼び出しが Python 側ループに残るので，進捗表示
+  (tqdm) と中断が自然に効く
+
+### 時間配分 (BudgetAllocator — 本コマンドが担う「上位レイヤー」)
+
+```python
+@dataclass(frozen=True)
+class PositionBudget:
+    max_playouts: int | None
+    time_ms: int | None
+
+class BudgetAllocator(abc):  # 戦略
+    def allocate(self, n_positions: int) -> list[PositionBudget]
+```
+
+- `FixedTimeAllocator(time_ms)` — 全局面同一時間
+- `EqualDivisionAllocator(total_time_ms)` — `max(total // n, 1)` ms を
+  全局面に配分 (床関数．端数は捨てる = 全体上限を超えない側に倒す)
+- `FixedPlayoutsAllocator(playouts)` — ノード予算派
+
+将来の傾斜配分 (難局面・終盤重視) は Allocator の戦略追加のみで実現でき，
+探索側 API は変わらない．
+
+### 解析ループ (GameAnalyzer)
+
+1. ファイルを bytes で読み，UTF-8 先行 → 失敗時 cp932 でデコード
+   (compass invariant: cp932 はほぼ任意バイト列で成功するため UTF-8 先行が本質)
+2. `parse_csa_str` / `parse_kif_str` で `GameRecord` を得る．
+   CSA で複数局が返った場合はエラー (1 局のみ対応と明示．将来拡張)．
+   `moves` が空の棋譜もエラー
+3. 解析対象 = 各指し手の直前局面 P0..P(N-1) (最終手後の局面は解析しない)．
+   Allocator で N 局面分の予算を確定
+4. 各 ply i について `engine.search(sfen=初期SFEN, moves=USI prefix
+   m1..mi, ...)` を呼ぶ (prefix を渡すことで千日手履歴が正しく効く)．
+   並行して domain `Board` を `push_move` で進め，記録用の SFEN・手番を得る．
+   `GameRecord.moves` の 32-bit 値は `push_move` にそのまま渡せ，
+   `move_to_usi` で USI に変換できる
+5. 不正手 (push/パース失敗) は ply を明示して fail-loud
+
+### 出力
+
+JSON (機械可読, per-position 全記録):
+
+```json
+{
+  "input": {"path": "...", "format": "csa", "names": ["...", "..."],
+             "ratings": [3000.0, 2800.0], "win": 1, "endgame": "%TORYO",
+             "n_moves": 118},
+  "engine": {"model_path": "...", "threads": 4, "...": "..."},
+  "budget": {"mode": "equal_division", "total_time_ms": 60000,
+              "per_position": {"time_ms": 508}},
+  "positions": [
+    {"ply": 1, "side_to_move": "b", "sfen": "...",
+     "played_move": "7g7f", "best_move": "2g2f", "match": false,
+     "winrate": 0.53, "eval_cp": 42,
+     "played_move_winrate": 0.51, "winrate_loss": 0.02,
+     "pv": ["2g2f", "8c8d"],
+     "candidates": [{"usi": "2g2f", "visits": 420, "winrate": 0.53,
+                      "prior": 0.31, "proven": null}],
+     "mate_found": false,
+     "playouts": 800, "elapsed_ms": 500, "stop": "time_limit",
+     "record_time_s": 12, "record_score": 55, "record_comment": null}
+  ],
+  "summary": {
+    "match_rate": {"black": 0.62, "white": 0.58},
+    "mean_winrate_loss": {"black": 0.031, "white": 0.044},
+    "worst_moves": [{"ply": 88, "side": "w", "played": "5b4b",
+                      "best": "3a4b", "winrate_loss": 0.34}],
+    "mates_found": [{"ply": 115, "side": "b"}]
+  }
+}
+```
+
+- `winrate` / `eval_cp` は手番視点 (eval は既存の Ponanza 係数 600 変換)
+- `played_move_winrate` は root_children から実戦の手を引いた値．
+  未訪問なら null，その場合 `winrate_loss` (= best − played, 同一局面内
+  比較) も null
+- `mate_found` は `stop == "root_proven"` (PV が詰み手順)
+- `record_time_s` / `record_score` / `record_comment` は棋譜側の記録の
+  echo (`times` は moves と長さ不一致があり得るため範囲外は null)
+- stdout サマリ (`--output` 指定時): 対局者・結果，先手/後手の一致率と
+  平均 winrate 損失，worst_moves 一覧，詰み発見，総所要時間
+- 進捗は tqdm (stderr) で局面単位に表示
+
+### テスト計画
+
+- allocator 単体 (等分・端数・最小値 1ms 保証)
+- デコード (UTF-8 / cp932 fallback / 不正トレイル)
+- `GameAnalyzer` golden: 数手の小 CSA/KIF fixture + mock 評価器で
+  JSON スキーマと ply 進行を検証
+- CLI: CliRunner + mock 評価器 (`--output` 経由で JSON を読む —
+  tqdm と stdout の連結問題を回避)
+- `SearchEngine` 再利用: mock 評価器で同一エンジンから複数回 search し
+  結果整合を確認 (Python 側テスト)
+- CSA 複数局・空棋譜・不正手の fail-loud
+
+### 版数 (実装時)
+
+- maou 0.42.0 → 0.43.0 (feat: 新コマンド)
+- maou_rust 0.21.1 → 0.22.0 (feat: SearchEngine binding)
+- maou_search crate は既存 export のみで足りる見込み — 変更が生じた
+  場合のみ bump
+
+## 提案する docs 変更 (本 review の approve 対象)
+
+1. **docs/design/game-analysis/index.md (新規)**: 本設計を設計
+   ドキュメントとして常設 (章立て: 目的とスコープ / CLI / レイヤー構成 /
+   SearchEngine binding / 時間配分戦略 / 出力スキーマ / テスト)．
+   position-search 設計との責務境界 (時間管理 = 本機能，1 局面探索 =
+   position-search) を明記
+2. **docs/commands/analyze_game.md (新規)**: CLAUDE.md MUST
+   (新 CLI コマンド追加時のドキュメント作成) に従い，実装 PR 内で
+   既存フォーマット (Overview / CLI options / Example) で作成
+
+## 根拠
+
+- user スケッチ + 方向確認 3 点 (上記) に基づく
+- VETO「持ち時間の消費計画は別レイヤー」と position-search 設計 §1 の
+  スコープ外宣言に整合 — 時間配分は app 層 Allocator，探索は与えられた
+  予算のみ
+- モデル 1 回ロード + N 局面探索は Rust crate の既存 pub export で
+  実装可能 (調査済み)．既存 `search` 関数は不変更で後方互換

--- a/reviews/2026-07-16-analyze-game-command-design.md
+++ b/reviews/2026-07-16-analyze-game-command-design.md
@@ -1,10 +1,10 @@
 ---
 title: analyze-game コマンド新設 (棋譜 1 局の自動解析) の設計
 date: 2026-07-16
-status: approved
-applied_in:
-# user 承認 2026-07-16．docs/design/game-analysis/index.md は 38482cc で適用済み．
-# docs/commands/analyze_game.md が実装コミットで揃った時点で applied に遷移する．
+status: applied
+applied_in: 411fec2
+# user 承認 2026-07-16．docs/design/game-analysis/index.md は 38482cc で適用，
+# docs/commands/analyze_game.md は実装コミット 411fec2 で適用．
 target:
   - docs/design/game-analysis/index.md
   - docs/commands/analyze_game.md

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_search.rs
+++ b/rust/maou_rust/src/maou_search.rs
@@ -179,6 +179,46 @@ fn run_search<E: Evaluator>(
     to_py_result(result)
 }
 
+/// 基準局面 SFEN + USI 指し手列から root 局面と対局履歴 (千日手判定用) を構築する．
+fn build_board_and_history(
+    sfen: &str,
+    moves: Option<&[String]>,
+) -> PyResult<(Board, Vec<HistoryEntry>)> {
+    let mut board = Board::empty();
+    board
+        .set_sfen(sfen)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("不正な SFEN: {e:?}")))?;
+    let mut history: Vec<HistoryEntry> = Vec::new();
+    if let Some(moves) = moves {
+        for usi in moves {
+            let mut probe = board.clone();
+            let mv = generate_legal_moves(&mut probe)
+                .into_iter()
+                .find(|m| m.to_usi() == *usi)
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "非合法または不正な指し手: {usi}"
+                    ))
+                })?;
+            history.push(HistoryEntry::from_board(&board));
+            board.do_move(mv);
+        }
+    }
+    Ok((board, history))
+}
+
+/// dfpn は depth >= 2048 で panic するため ValueError に変換する．
+fn validate_root_dfpn_depth(root_dfpn_depth: Option<u32>) -> PyResult<()> {
+    if let Some(d) = root_dfpn_depth {
+        if !(1..=2047).contains(&d) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "root_dfpn_depth must be in 1..=2047, got {d}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// 1 局面を MCTS で探索して最有力手・勝率・読み筋を返す．
 ///
 /// 返り値: [`PySearchResult`] (`SearchResult`) オブジェクト．
@@ -257,35 +297,9 @@ fn search(
     intra_threads: Option<usize>,
 ) -> PyResult<PySearchResult> {
     // 基準局面 + 対局履歴 (千日手判定用) を構築する
-    let mut board = Board::empty();
-    board
-        .set_sfen(sfen)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("不正な SFEN: {e:?}")))?;
-    let mut history: Vec<HistoryEntry> = Vec::new();
-    if let Some(moves) = &moves {
-        for usi in moves {
-            let mut probe = board.clone();
-            let mv = generate_legal_moves(&mut probe)
-                .into_iter()
-                .find(|m| m.to_usi() == *usi)
-                .ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "非合法または不正な指し手: {usi}"
-                    ))
-                })?;
-            history.push(HistoryEntry::from_board(&board));
-            board.do_move(mv);
-        }
-    }
+    let (board, history) = build_board_and_history(sfen, moves.as_deref())?;
 
-    if let Some(d) = root_dfpn_depth {
-        // dfpn は depth >= 2048 で panic するため ValueError に変換する
-        if !(1..=2047).contains(&d) {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "root_dfpn_depth must be in 1..=2047, got {d}"
-            )));
-        }
-    }
+    validate_root_dfpn_depth(root_dfpn_depth)?;
 
     let mut options = SearchOptions::default();
     if let Some(v) = threads {
@@ -373,6 +387,165 @@ fn search(
              `maturin develop --features onnx` (CUDA: onnx-cuda / TensorRT: onnx-tensorrt) \
              でビルドしてください",
         )),
+    }
+}
+
+/// [`SearchEngine`] が保持する評価器 (mock または ONNX)．
+enum EngineEvaluator {
+    Mock(maou_search::MockEvaluator),
+    #[cfg(feature = "onnx")]
+    Onnx(maou_search::OnnxEvaluator),
+}
+
+/// 評価器を 1 回だけ構築・保持して複数局面を連続探索する永続エンジン．
+///
+/// 関数 [`search`] は呼び出しごとに ONNX モデルをロードするため，棋譜解析の
+/// ように N 局面を連続探索する用途では本クラスを使う (モデルロードは
+/// `__init__` の 1 回のみ．TensorRT はプロセス内でエンジンを使い回せる)．
+///
+/// 予算 (時間/ノード数) は `search` の引数として毎回受け取る — 時間配分の
+/// 計画は上位レイヤーの責務であり本クラスは持たない
+/// (docs/design/game-analysis/index.md §4)．
+///
+/// # コンストラクタ引数
+///
+/// - `model_path` (str, optional): ONNX モデルのパス．未指定なら決定論的な
+///   mock 評価器 (API 検証/開発用 — 指し手の品質は無意味)．指定時は `onnx`
+///   feature 付きの wheel が必要 (無ければ `RuntimeError`)．
+/// - `threads` (int, optional): 探索スレッド数．
+/// - `batch_size` (int, optional): 評価バッチサイズ (TensorRT の padding
+///   サイズもこれに固定される)．
+/// - `use_cuda` (bool, optional): CUDA Execution Provider (`onnx-cuda` feature 必要)．
+/// - `use_tensorrt` (bool, optional): TensorRT Execution Provider
+///   (`onnx-tensorrt` feature 必要)．
+/// - `trt_engine_cache_dir` (str, optional): TensorRT エンジンキャッシュ保存先．
+#[pyclass(frozen)]
+struct SearchEngine {
+    evaluator: EngineEvaluator,
+    threads: usize,
+    batch_size: usize,
+}
+
+#[pymethods]
+impl SearchEngine {
+    #[new]
+    #[pyo3(signature = (*, model_path=None, threads=None, batch_size=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None))]
+    fn new(
+        model_path: Option<String>,
+        threads: Option<usize>,
+        batch_size: Option<usize>,
+        use_cuda: Option<bool>,
+        use_tensorrt: Option<bool>,
+        trt_engine_cache_dir: Option<String>,
+    ) -> PyResult<Self> {
+        let defaults = SearchOptions::default();
+        let threads = threads.unwrap_or(defaults.threads);
+        let batch_size = batch_size.unwrap_or(defaults.batch_size);
+        let evaluator = match model_path {
+            None => {
+                // mock 評価器 (決定論的擬似乱数)．API 検証/開発用
+                let _ = (use_cuda, use_tensorrt, trt_engine_cache_dir);
+                EngineEvaluator::Mock(maou_search::MockEvaluator::new(0))
+            }
+            #[cfg(feature = "onnx")]
+            Some(path) => {
+                let onnx_options = maou_search::onnx::OnnxOptions {
+                    intra_threads: 1,
+                    use_cuda: use_cuda.unwrap_or(false),
+                    use_tensorrt: use_tensorrt.unwrap_or(false),
+                    trt_engine_cache_dir,
+                    // TensorRT は shape ごとにエンジンをビルドするため batch_size に固定する
+                    pad_to: if use_tensorrt.unwrap_or(false) {
+                        Some(batch_size)
+                    } else {
+                        None
+                    },
+                };
+                EngineEvaluator::Onnx(
+                    maou_search::OnnxEvaluator::from_file(&path, &onnx_options).map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "ONNX モデルの読み込みに失敗: {e}"
+                        ))
+                    })?,
+                )
+            }
+            #[cfg(not(feature = "onnx"))]
+            Some(_) => {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "この wheel は onnx feature なしでビルドされているため model_path を使えません．\
+                     `maturin develop --features onnx` (CUDA: onnx-cuda / TensorRT: onnx-tensorrt) \
+                     でビルドしてください",
+                ));
+            }
+        };
+        Ok(SearchEngine {
+            evaluator,
+            threads,
+            batch_size,
+        })
+    }
+
+    /// 保持している評価器で 1 局面を探索する．
+    ///
+    /// 引数・返り値の意味は関数 [`search`] と同じ (評価器系オプションは
+    /// コンストラクタで固定済みのため受け取らない)．探索中は GIL を解放する．
+    #[pyo3(signature = (sfen, *, moves=None, max_playouts=None, time_ms=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn search(
+        &self,
+        py: Python<'_>,
+        sfen: &str,
+        moves: Option<Vec<String>>,
+        max_playouts: Option<u64>,
+        time_ms: Option<u64>,
+        root_dfpn: Option<bool>,
+        root_dfpn_nodes: Option<u64>,
+        root_dfpn_depth: Option<u32>,
+        leaf_mate: Option<bool>,
+        leaf_mate_nodes: Option<u64>,
+        leaf_mate_threads: Option<usize>,
+    ) -> PyResult<PySearchResult> {
+        let (board, history) = build_board_and_history(sfen, moves.as_deref())?;
+        validate_root_dfpn_depth(root_dfpn_depth)?;
+
+        let mut options = SearchOptions {
+            threads: self.threads,
+            batch_size: self.batch_size,
+            ..SearchOptions::default()
+        };
+        if let Some(v) = root_dfpn {
+            options.root_dfpn = v;
+        }
+        if let Some(v) = root_dfpn_nodes {
+            options.root_dfpn_nodes = v;
+        }
+        if let Some(v) = root_dfpn_depth {
+            options.root_dfpn_depth = v;
+        }
+        if let Some(v) = leaf_mate {
+            options.leaf_mate = v;
+        }
+        if let Some(v) = leaf_mate_nodes {
+            options.leaf_mate_nodes = v;
+        }
+        if let Some(v) = leaf_mate_threads {
+            options.leaf_mate_threads = v;
+        }
+        let limits = SearchLimits {
+            max_playouts,
+            time_ms,
+        };
+
+        let result = match &self.evaluator {
+            EngineEvaluator::Mock(ev) => py.detach(move || {
+                Searcher::new(ev, options).search_with_history(&board, &history, &limits)
+            }),
+            #[cfg(feature = "onnx")]
+            EngineEvaluator::Onnx(ev) => py.detach(move || {
+                Searcher::new(ev, options).search_with_history(&board, &history, &limits)
+            }),
+        };
+        Ok(to_py_result(result))
     }
 }
 
@@ -548,6 +721,7 @@ pub fn create_module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
 
     m.add_class::<PySearchResult>()?;
     m.add_class::<SearchRootChild>()?;
+    m.add_class::<SearchEngine>()?;
     m.add_function(wrap_pyfunction!(search, &m)?)?;
     m.add_function(wrap_pyfunction!(preprocess_hcpes, &m)?)?;
     m.add_function(wrap_pyfunction!(encode_hcp_features, &m)?)?;

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.8.1"
+version = "5.8.2"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/search/mod.rs
+++ b/rust/maou_shogi/src/dfpn/search/mod.rs
@@ -138,6 +138,14 @@ fn no_dag() -> bool {
     *C.get_or_init(|| std::env::var("NODAG").is_ok())
 }
 
+/// `DFPN_STATS` env: solve 終了時の統計サマリ (`[dfpn] root ...`) を stderr に出す診断用
+/// (process 内 1 回読み)．default OFF — leaf-mate 統合探索や棋譜解析では solve が
+/// 局面ごと・葉ごとに大量に走るため，常時出力だと stderr が診断行で溢れる．
+fn dfpn_stats_enabled() -> bool {
+    static C: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *C.get_or_init(|| std::env::var("DFPN_STATS").is_ok())
+}
+
 thread_local! {
     /// do_moves per-site breakdown (DMBREAK 報告用; solve 毎に reset)．
     /// [0]=step_best_child(再帰) [1]=eliminate_double_count(DAG) [2]=look-ahead [3]=proof-hand(1手詰).
@@ -620,19 +628,21 @@ impl DfPnSolver {
         // 2 指標を併記: nodes = 探索ノード訪問数 (Emplace 毎に 1),
         // do_moves = do_move 数 (nodes_searched)．混同しないこと．
         let search_do_moves = crate::board::do_move_count();
-        eprintln!(
-            "[dfpn] root pn={} dn={} mate_len={} nodes={} do_moves={} dm/node={:.2} tt_cap={} gc={} dag={} dom={}",
-            last.pn(),
-            last.dn(),
-            last.len().len(),
-            self.nodes,
-            search_do_moves,
-            search_do_moves as f64 / (self.nodes.max(1)) as f64,
-            tt.capacity(),
-            tt.gc_count(),
-            self.dag_fires,
-            self.dom_fires
-        );
+        if dfpn_stats_enabled() {
+            eprintln!(
+                "[dfpn] root pn={} dn={} mate_len={} nodes={} do_moves={} dm/node={:.2} tt_cap={} gc={} dag={} dom={}",
+                last.pn(),
+                last.dn(),
+                last.len().len(),
+                self.nodes,
+                search_do_moves,
+                search_do_moves as f64 / (self.nodes.max(1)) as f64,
+                tt.capacity(),
+                tt.gc_count(),
+                self.dag_fires,
+                self.dom_fires
+            );
+        }
         super::movegen::mate1ply::report_mate_cand_stats();
         super::movegen::mate1ply::report_mate1ply_stats();
         if std::env::var("DMBREAK").is_ok() {

--- a/src/maou/app/analysis/game_analyzer.py
+++ b/src/maou/app/analysis/game_analyzer.py
@@ -1,0 +1,581 @@
+"""棋譜 1 局の自動解析ユースケース．
+
+CSA / KIF の 1 局を受け取り，各指し手の直前局面を 1 局面探索エンジン
+(`maou._rust.maou_search.SearchEngine`) で解析して per-position 記録と
+サマリを返す．対局全体の時間配分 (:class:`BudgetAllocator`) は本モジュール
+の責務であり，探索エンジンは与えられた予算内で 1 局面を探索するのみ
+(docs/design/game-analysis/index.md)．
+"""
+
+import abc
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tqdm.auto import tqdm
+
+from maou._rust.maou_search import SearchEngine
+from maou._rust.maou_shogi import parse_csa_str, parse_kif_str
+from maou.app.inference.eval import Evaluation
+from maou.domain.board.shogi import Board, Turn, move_to_usi
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def decode_kifu_bytes(data: bytes) -> str:
+    """棋譜ファイルの bytes を UTF-8 先行で文字列にデコードする．
+
+    cp932 はほぼ任意のバイト列を受理してしまうため，先に UTF-8 を厳格に
+    試し，失敗した場合のみ cp932 にフォールバックする．
+
+    Args:
+        data: 棋譜ファイルの生バイト列．
+
+    Returns:
+        デコード済み文字列．
+
+    Raises:
+        UnicodeDecodeError: UTF-8 でも cp932 でも解釈できない場合．
+    """
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("cp932")
+
+
+@dataclass(frozen=True)
+class PositionBudget:
+    """1 局面分の探索予算 (playout 数と時間の少なくとも一方)．
+
+    Attributes:
+        max_playouts: playout 数上限 (None で制限なし)．
+        time_ms: 時間上限ミリ秒 (None で制限なし)．
+    """
+
+    max_playouts: int | None
+    time_ms: int | None
+
+
+class BudgetAllocator(metaclass=abc.ABCMeta):
+    """対局全体の予算を局面ごとの探索予算に配分する戦略．
+
+    探索エンジンは配分済みの :class:`PositionBudget` を受け取るのみで，
+    時間配分の判断はこの階層に閉じる．将来の傾斜配分 (難局面・終盤重視)
+    は本クラスの実装追加のみで導入できる．
+    """
+
+    @abc.abstractmethod
+    def allocate(
+        self, n_positions: int
+    ) -> list[PositionBudget]:
+        """n_positions 局面分の予算リストを返す．"""
+
+    @abc.abstractmethod
+    def describe(self) -> dict[str, Any]:
+        """JSON 出力用の予算メタデータ (mode + パラメータ) を返す．"""
+
+
+@dataclass(frozen=True)
+class FixedTimeAllocator(BudgetAllocator):
+    """全局面に同一の時間予算を割り当てる．
+
+    Attributes:
+        time_ms: 1 局面あたりの時間 (ミリ秒)．
+    """
+
+    time_ms: int
+
+    def allocate(
+        self, n_positions: int
+    ) -> list[PositionBudget]:
+        """n_positions 局面分の予算リストを返す．"""
+        budget = PositionBudget(
+            max_playouts=None, time_ms=self.time_ms
+        )
+        return [budget] * n_positions
+
+    def describe(self) -> dict[str, Any]:
+        """JSON 出力用の予算メタデータを返す．"""
+        return {"mode": "fixed_time", "time_ms": self.time_ms}
+
+
+@dataclass(frozen=True)
+class EqualDivisionAllocator(BudgetAllocator):
+    """対局全体の時間を局面数で等分して割り当てる．
+
+    1 局面あたり ``max(total_time_ms // n, 1)`` ミリ秒 (床関数．端数は
+    切り捨て = 全体上限を超えない側に倒す)．
+
+    Attributes:
+        total_time_ms: 対局全体の時間 (ミリ秒)．
+    """
+
+    total_time_ms: int
+
+    def allocate(
+        self, n_positions: int
+    ) -> list[PositionBudget]:
+        """n_positions 局面分の予算リストを返す．"""
+        if n_positions <= 0:
+            return []
+        per_position = max(self.total_time_ms // n_positions, 1)
+        budget = PositionBudget(
+            max_playouts=None, time_ms=per_position
+        )
+        return [budget] * n_positions
+
+    def describe(self) -> dict[str, Any]:
+        """JSON 出力用の予算メタデータを返す．"""
+        return {
+            "mode": "equal_division",
+            "total_time_ms": self.total_time_ms,
+        }
+
+
+@dataclass(frozen=True)
+class FixedPlayoutsAllocator(BudgetAllocator):
+    """全局面に同一の playout 数予算を割り当てる．
+
+    Attributes:
+        playouts: 1 局面あたりの playout 数．
+    """
+
+    playouts: int
+
+    def allocate(
+        self, n_positions: int
+    ) -> list[PositionBudget]:
+        """n_positions 局面分の予算リストを返す．"""
+        budget = PositionBudget(
+            max_playouts=self.playouts, time_ms=None
+        )
+        return [budget] * n_positions
+
+    def describe(self) -> dict[str, Any]:
+        """JSON 出力用の予算メタデータを返す．"""
+        return {
+            "mode": "fixed_playouts",
+            "playouts": self.playouts,
+        }
+
+
+def _turn_char(turn: Turn) -> str:
+    """手番を SFEN の手番文字 ("b"/"w") にする．"""
+    return "b" if turn == Turn.BLACK else "w"
+
+
+class GameAnalyzer:
+    """棋譜 1 局を 1 手ずつ 1 局面探索で解析するユースケース．
+
+    評価器は :class:`SearchEngine` として解析開始時に 1 回だけ構築し，
+    全局面の探索で使い回す (ONNX モデルのロードは 1 回のみ)．
+    """
+
+    @dataclass(kw_only=True, frozen=True)
+    class AnalyzeOption:
+        """解析オプション．
+
+        Attributes:
+            input_path: 棋譜ファイルのパス．
+            input_format: 棋譜形式 ("csa" / "kif")．
+            allocator: 局面ごとの探索予算を決める配分戦略．
+            model_path: ONNX モデルのパス．None なら決定論的な mock 評価器
+                (API 検証/開発用)．
+            threads: 探索スレッド数．
+            batch_size: 評価バッチサイズ．
+            num_candidates: JSON に記録する候補手数．
+            root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
+            root_dfpn_nodes: ルート dfpn のノード予算．
+            root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
+            leaf_mate: MCTS の葉の短手詰み探索 (専用スレッド) を行うか．
+            leaf_mate_nodes: leaf-mate 1 回あたりのノード予算．
+            leaf_mate_threads: leaf-mate 専用スレッド数．
+            cuda: CUDA Execution Provider を使うか．
+            tensorrt: TensorRT Execution Provider を使うか．
+            trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+        """
+
+        input_path: Path
+        input_format: str
+        allocator: BudgetAllocator
+        model_path: Path | None = None
+        threads: int = 1
+        batch_size: int = 8
+        num_candidates: int = 5
+        root_dfpn: bool = True
+        root_dfpn_nodes: int = 2_000_000
+        root_dfpn_depth: int = 2047
+        leaf_mate: bool = True
+        leaf_mate_nodes: int = 50
+        leaf_mate_threads: int = 1
+        cuda: bool = False
+        tensorrt: bool = False
+        trt_engine_cache_dir: Path | None = None
+
+    def analyze(self, option: AnalyzeOption) -> dict[str, Any]:
+        """棋譜 1 局を解析して JSON 化可能な結果 dict を返す．
+
+        Args:
+            option: 解析オプション．
+
+        Returns:
+            ``input`` / ``engine`` / ``budget`` / ``positions`` / ``summary``
+            をキーとする dict (スキーマは docs/design/game-analysis/index.md §7)．
+
+        Raises:
+            ValueError: 棋譜のパース失敗，複数局の CSA，指し手ゼロの棋譜，
+                または棋譜中の不正手．
+        """
+        content = decode_kifu_bytes(
+            option.input_path.read_bytes()
+        )
+        record = self._parse_record(
+            content, option.input_format
+        )
+        moves: list[int] = list(record.moves)
+        if not moves:
+            raise ValueError(
+                f"棋譜に指し手がありません: {option.input_path}"
+            )
+        usi_moves = [move_to_usi(m) for m in moves]
+        budgets = option.allocator.allocate(len(moves))
+
+        engine = SearchEngine(
+            model_path=(
+                str(option.model_path)
+                if option.model_path is not None
+                else None
+            ),
+            threads=option.threads,
+            batch_size=option.batch_size,
+            use_cuda=option.cuda,
+            use_tensorrt=option.tensorrt,
+            trt_engine_cache_dir=(
+                str(option.trt_engine_cache_dir)
+                if option.trt_engine_cache_dir is not None
+                else None
+            ),
+        )
+
+        record_times: list[int] = list(record.times)
+        record_scores: list[int] = list(record.scores)
+        record_comments: list[str] = list(record.comments)
+
+        board = Board()
+        board.set_sfen(record.sfen)
+        positions: list[dict[str, Any]] = []
+        for i, (move, played_usi, budget) in enumerate(
+            tqdm(
+                zip(moves, usi_moves, budgets),
+                total=len(moves),
+                desc="analyze",
+                unit="pos",
+            )
+        ):
+            ply = i + 1
+            side = _turn_char(board.get_turn())
+            sfen = board.get_sfen()
+            try:
+                result = engine.search(
+                    record.sfen,
+                    moves=usi_moves[:i] if i > 0 else None,
+                    max_playouts=budget.max_playouts,
+                    time_ms=budget.time_ms,
+                    root_dfpn=option.root_dfpn,
+                    root_dfpn_nodes=option.root_dfpn_nodes,
+                    root_dfpn_depth=option.root_dfpn_depth,
+                    leaf_mate=option.leaf_mate,
+                    leaf_mate_nodes=option.leaf_mate_nodes,
+                    leaf_mate_threads=option.leaf_mate_threads,
+                )
+            except ValueError as e:
+                raise ValueError(
+                    f"{option.input_path} の {ply} 手目 (直前局面 {sfen}) "
+                    f"の探索に失敗: {e}"
+                ) from e
+            positions.append(
+                self._position_record(
+                    ply=ply,
+                    side=side,
+                    sfen=sfen,
+                    played_usi=played_usi,
+                    result=result,
+                    num_candidates=option.num_candidates,
+                    record_time_s=(
+                        record_times[i]
+                        if i < len(record_times)
+                        else None
+                    ),
+                    record_score=(
+                        record_scores[i]
+                        if i < len(record_scores)
+                        else None
+                    ),
+                    record_comment=(
+                        record_comments[i] or None
+                        if i < len(record_comments)
+                        else None
+                    ),
+                )
+            )
+            try:
+                board.push_move(move)
+            except ValueError as e:
+                raise ValueError(
+                    f"{option.input_path} の {ply} 手目 {played_usi} を "
+                    f"適用できません: {e}"
+                ) from e
+
+        return {
+            "input": {
+                "path": str(option.input_path),
+                "format": option.input_format,
+                "names": list(record.names),
+                "ratings": list(record.ratings),
+                "win": record.win,
+                "endgame": record.endgame,
+                "n_moves": len(moves),
+            },
+            "engine": {
+                "model_path": (
+                    str(option.model_path)
+                    if option.model_path is not None
+                    else None
+                ),
+                "threads": option.threads,
+                "batch_size": option.batch_size,
+                "cuda": option.cuda,
+                "tensorrt": option.tensorrt,
+                "root_dfpn": option.root_dfpn,
+                "root_dfpn_nodes": option.root_dfpn_nodes,
+                "root_dfpn_depth": option.root_dfpn_depth,
+                "leaf_mate": option.leaf_mate,
+                "leaf_mate_nodes": option.leaf_mate_nodes,
+                "leaf_mate_threads": option.leaf_mate_threads,
+            },
+            "budget": self._budget_meta(
+                option.allocator, budgets
+            ),
+            "positions": positions,
+            "summary": self._summary(positions),
+        }
+
+    def _parse_record(
+        self, content: str, input_format: str
+    ) -> Any:
+        """棋譜文字列をパースして GameRecord を返す．
+
+        CSA はファイル内に複数局を含み得るが，本コマンドは 1 局のみ対応
+        (複数局は ValueError)．
+        """
+        if input_format == "csa":
+            records = parse_csa_str(content)
+            if len(records) != 1:
+                raise ValueError(
+                    f"CSA ファイルに {len(records)} 局が含まれています．"
+                    "analyze-game は 1 局のみ対応です "
+                    "(複数局は 1 局ずつのファイルに分割してください)"
+                )
+            return records[0]
+        if input_format == "kif":
+            return parse_kif_str(content)
+        raise ValueError(
+            f"未対応の棋譜形式です: {input_format} (csa / kif のみ)"
+        )
+
+    def _budget_meta(
+        self,
+        allocator: BudgetAllocator,
+        budgets: list[PositionBudget],
+    ) -> dict[str, Any]:
+        """JSON 出力用の予算セクション (mode + 代表 per-position 値) を作る．
+
+        現状の配分戦略は全局面同一のため，先頭要素を代表値として載せる．
+        """
+        meta = allocator.describe()
+        if budgets:
+            meta["per_position"] = {
+                "max_playouts": budgets[0].max_playouts,
+                "time_ms": budgets[0].time_ms,
+            }
+        return meta
+
+    def _position_record(
+        self,
+        *,
+        ply: int,
+        side: str,
+        sfen: str,
+        played_usi: str,
+        result: Any,
+        num_candidates: int,
+        record_time_s: int | None,
+        record_score: int | None,
+        record_comment: str | None,
+    ) -> dict[str, Any]:
+        """1 局面分の解析記録 (JSON 化可能な dict) を作る．
+
+        ``played_move_winrate`` / ``winrate_loss`` は同一局面の
+        root_children 統計から取る (未訪問の手は winrate が「データなし」
+        のため null)．``winrate_loss`` は best との差を 0 で下限クランプ
+        する (訪問数基準の最終手選択では played の Q が best を僅かに
+        上回り得るが，その場合も「損失なし」と扱う)．
+        """
+        best_move = result.best_move
+        children = list(result.root_children)
+        played_child = next(
+            (c for c in children if c.usi == played_usi), None
+        )
+        played_winrate = (
+            float(played_child.winrate)
+            if played_child is not None
+            and int(played_child.visits) > 0
+            else None
+        )
+        winrate = float(result.winrate)
+        best_child = (
+            next(
+                (c for c in children if c.usi == best_move),
+                None,
+            )
+            if best_move is not None
+            else None
+        )
+        best_winrate = (
+            float(best_child.winrate)
+            if best_child is not None
+            and int(best_child.visits) > 0
+            else winrate
+        )
+        match = (
+            best_move is not None and played_usi == best_move
+        )
+        winrate_loss: float | None
+        if match:
+            winrate_loss = 0.0
+        elif played_winrate is not None:
+            winrate_loss = max(
+                best_winrate - played_winrate, 0.0
+            )
+        else:
+            winrate_loss = None
+
+        # 候補手: best を先頭に，残りは訪問回数の降順 (SearchRunner と同じ整列)
+        children_sorted = sorted(
+            children, key=lambda c: int(c.visits), reverse=True
+        )
+        best_first = [
+            c for c in children_sorted if c.usi == best_move
+        ]
+        rest = [
+            c for c in children_sorted if c.usi != best_move
+        ]
+        candidates: list[dict[str, Any]] = []
+        for child in (best_first + rest)[:num_candidates]:
+            candidates.append(
+                {
+                    "usi": child.usi,
+                    "visits": int(child.visits),
+                    "winrate": (
+                        float(child.winrate)
+                        if int(child.visits) > 0
+                        else None
+                    ),
+                    "prior": float(child.prior),
+                    "proven": (
+                        float(child.proven)
+                        if child.proven is not None
+                        else None
+                    ),
+                }
+            )
+
+        return {
+            "ply": ply,
+            "side_to_move": side,
+            "sfen": sfen,
+            "played_move": played_usi,
+            "best_move": best_move,
+            "match": match,
+            "winrate": winrate,
+            "eval_cp": float(
+                Evaluation.get_eval_from_winrate(winrate)
+            ),
+            "played_move_winrate": played_winrate,
+            "winrate_loss": winrate_loss,
+            "pv": list(result.pv),
+            "candidates": candidates,
+            "mate_found": result.stop == "root_proven",
+            "playouts": int(result.playouts),
+            "elapsed_ms": int(result.elapsed_ms),
+            "stop": result.stop,
+            "record_time_s": record_time_s,
+            "record_score": record_score,
+            "record_comment": record_comment,
+        }
+
+    def _summary(
+        self, positions: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """per-position 記録から対局サマリを作る．
+
+        worst_moves は winrate_loss の大きい順に上位 5 手 (null は除外)．
+        """
+        sides = {"b": "black", "w": "white"}
+        match_rate: dict[str, float | None] = {}
+        mean_winrate_loss: dict[str, float | None] = {}
+        for side, label in sides.items():
+            side_positions = [
+                p
+                for p in positions
+                if p["side_to_move"] == side
+            ]
+            match_rate[label] = (
+                sum(1 for p in side_positions if p["match"])
+                / len(side_positions)
+                if side_positions
+                else None
+            )
+            losses = [
+                p["winrate_loss"]
+                for p in side_positions
+                if p["winrate_loss"] is not None
+            ]
+            mean_winrate_loss[label] = (
+                sum(losses) / len(losses) if losses else None
+            )
+        worst = sorted(
+            (
+                p
+                for p in positions
+                if p["winrate_loss"] is not None
+            ),
+            key=lambda p: p["winrate_loss"],
+            reverse=True,
+        )[:5]
+        return {
+            "match_rate": match_rate,
+            "mean_winrate_loss": mean_winrate_loss,
+            "worst_moves": [
+                {
+                    "ply": p["ply"],
+                    "side": p["side_to_move"],
+                    "played": p["played_move"],
+                    "best": p["best_move"],
+                    "winrate_loss": p["winrate_loss"],
+                }
+                for p in worst
+            ],
+            "mates_found": [
+                {"ply": p["ply"], "side": p["side_to_move"]}
+                for p in positions
+                if p["mate_found"]
+            ],
+            "total_elapsed_ms": sum(
+                p["elapsed_ms"] for p in positions
+            ),
+            "total_playouts": sum(
+                p["playouts"] for p in positions
+            ),
+        }

--- a/src/maou/infra/console/analyze_game.py
+++ b/src/maou/infra/console/analyze_game.py
@@ -1,0 +1,256 @@
+from pathlib import Path
+
+import click
+
+from maou.infra.console.common import handle_exception
+from maou.interface import analyzer as analyzer_interface
+
+
+@click.command("analyze-game")
+@click.option(
+    "--input-path",
+    help="Path to the game record file (CSA / KIF).",
+    type=click.Path(
+        exists=True, dir_okay=False, path_type=Path
+    ),
+    required=True,
+)
+@click.option(
+    "--input-format",
+    help=(
+        "Game record format. Auto-detected from the file extension "
+        "(.csa / .kif / .kifu) when omitted."
+    ),
+    type=click.Choice(["csa", "kif"]),
+    default=None,
+    required=False,
+)
+@click.option(
+    "--model-path",
+    help=(
+        "Path to the ONNX model file. Uses a deterministic mock evaluator "
+        "when omitted (for development only)."
+    ),
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    required=False,
+)
+@click.option(
+    "--time-ms",
+    help=(
+        "Time budget per position in milliseconds. Defaults to 1000 when "
+        "no budget option is given. Mutually exclusive with "
+        "--total-time-ms / --playouts."
+    ),
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--total-time-ms",
+    help=(
+        "Total time budget for the whole game in milliseconds, divided "
+        "equally across positions. Mutually exclusive with "
+        "--time-ms / --playouts."
+    ),
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--playouts",
+    help=(
+        "Playout budget per position. Mutually exclusive with "
+        "--time-ms / --total-time-ms."
+    ),
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--num-candidates",
+    help="Number of candidate moves recorded per position in the JSON.",
+    type=int,
+    default=5,
+    required=False,
+)
+@click.option(
+    "--output",
+    help=(
+        "Write the JSON report to this file and print a human-readable "
+        "summary to stdout. When omitted, the JSON is printed to stdout."
+    ),
+    type=click.Path(path_type=Path),
+    default=None,
+    required=False,
+)
+@click.option(
+    "--threads",
+    help="Number of search threads.",
+    type=int,
+    default=1,
+    required=False,
+)
+@click.option(
+    "--batch-size",
+    help="Evaluation batch size.",
+    type=int,
+    default=8,
+    required=False,
+)
+@click.option(
+    "--root-dfpn/--no-root-dfpn",
+    help="Run dfpn mate search on each root position in parallel.",
+    default=True,
+    required=False,
+)
+@click.option(
+    "--root-dfpn-nodes",
+    help="Node budget for the root dfpn mate search.",
+    type=int,
+    default=2_000_000,
+    required=False,
+)
+@click.option(
+    "--root-dfpn-depth",
+    help="Search depth limit for the root dfpn mate search (max 2047).",
+    type=int,
+    default=2047,
+    required=False,
+)
+@click.option(
+    "--leaf-mate/--no-leaf-mate",
+    help="Enable short mate search at MCTS leaves (async).",
+    default=True,
+    required=False,
+)
+@click.option(
+    "--leaf-mate-nodes",
+    help="Node budget per leaf-mate df-pn call.",
+    type=int,
+    default=50,
+    required=False,
+)
+@click.option(
+    "--leaf-mate-threads",
+    help="Number of dedicated leaf-mate threads.",
+    type=int,
+    default=1,
+    required=False,
+)
+@click.option(
+    "--cuda/--no-cuda",
+    help="Enable CUDA Execution Provider.",
+    default=False,
+    required=False,
+)
+@click.option(
+    "--tensorrt/--no-tensorrt",
+    help="Enable TensorRT Execution Provider.",
+    default=False,
+    required=False,
+)
+@click.option(
+    "--trt-cache-dir",
+    help="TensorRT engine cache directory.",
+    type=click.Path(path_type=Path),
+    default=None,
+    required=False,
+)
+@handle_exception
+def analyze_game(
+    input_path: Path,
+    input_format: str | None,
+    model_path: Path | None,
+    time_ms: int | None,
+    total_time_ms: int | None,
+    playouts: int | None,
+    num_candidates: int,
+    output: Path | None,
+    threads: int,
+    batch_size: int,
+    root_dfpn: bool,
+    root_dfpn_nodes: int,
+    root_dfpn_depth: int,
+    leaf_mate: bool,
+    leaf_mate_nodes: int,
+    leaf_mate_threads: int,
+    cuda: bool,
+    tensorrt: bool,
+    trt_cache_dir: Path | None,
+) -> None:
+    """Analyze a whole game record with per-position MCTS search.
+
+    This command parses a single game from a CSA/KIF file and runs the
+    MCTS engine (the same engine as `maou search`) on the position before
+    each move. The evaluator is loaded once and reused across all
+    positions. The per-position budget is decided by a budget allocator
+    (fixed time per position, total time divided equally, or fixed
+    playouts) — the search itself only consumes the budget it is given.
+    The result is a machine-readable JSON report (per-position best move,
+    win rate, PV, comparison with the played move) plus a human-readable
+    summary (best-move match rate, biggest win-rate losses, mates found).
+
+    Args:
+        input_path: Path to the game record file (CSA / KIF).
+        input_format: Game record format; auto-detected when omitted.
+        model_path: Path to the ONNX model file.
+        time_ms: Time budget per position in milliseconds.
+        total_time_ms: Total time budget divided equally across positions.
+        playouts: Playout budget per position.
+        num_candidates: Candidate moves recorded per position.
+        output: JSON report destination; JSON goes to stdout when omitted.
+        threads: Number of search threads.
+        batch_size: Evaluation batch size.
+        root_dfpn: Run dfpn mate search on each root position in parallel.
+        root_dfpn_nodes: Node budget for the root dfpn mate search.
+        root_dfpn_depth: Search depth limit for the root dfpn mate search.
+        leaf_mate: Enable short mate search at MCTS leaves (async).
+        leaf_mate_nodes: Node budget per leaf-mate df-pn call.
+        leaf_mate_threads: Number of dedicated leaf-mate threads.
+        cuda: Enable CUDA Execution Provider.
+        tensorrt: Enable TensorRT Execution Provider.
+        trt_cache_dir: TensorRT engine cache directory.
+    """
+    if (cuda or tensorrt) and model_path is None:
+        raise click.UsageError(
+            "--cuda / --tensorrt require --model-path."
+        )
+    if (
+        sum(
+            v is not None
+            for v in (time_ms, total_time_ms, playouts)
+        )
+        > 1
+    ):
+        raise click.UsageError(
+            "Specify at most one of --time-ms / --total-time-ms / "
+            "--playouts."
+        )
+    json_str, summary = analyzer_interface.analyze_game(
+        input_path=input_path,
+        input_format=input_format,
+        model_path=model_path,
+        time_ms=time_ms,
+        total_time_ms=total_time_ms,
+        playouts=playouts,
+        num_candidates=num_candidates,
+        threads=threads,
+        batch_size=batch_size,
+        root_dfpn=root_dfpn,
+        root_dfpn_nodes=root_dfpn_nodes,
+        root_dfpn_depth=root_dfpn_depth,
+        leaf_mate=leaf_mate,
+        leaf_mate_nodes=leaf_mate_nodes,
+        leaf_mate_threads=leaf_mate_threads,
+        cuda=cuda,
+        tensorrt=tensorrt,
+        trt_engine_cache_dir=trt_cache_dir,
+    )
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json_str + "\n", encoding="utf-8")
+        click.echo(summary)
+        click.echo(f"JSON report: {output}")
+    else:
+        click.echo(json_str)

--- a/src/maou/infra/console/app.py
+++ b/src/maou/infra/console/app.py
@@ -298,6 +298,11 @@ LAZY_COMMANDS: dict[str, LazyCommandSpec] = {
         "maou.infra.console.search_board",
         "search_board",
     ),
+    # 棋譜 1 局の自動解析 (1 手ずつ 1 局面探索; 追加依存なし)
+    "analyze-game": LazyCommandSpec(
+        "maou.infra.console.analyze_game",
+        "analyze_game",
+    ),
     "evaluate": LazyCommandSpec(
         "maou.infra.console.evaluate_board",
         "evaluate_board",

--- a/src/maou/interface/analyzer.py
+++ b/src/maou/interface/analyzer.py
@@ -1,0 +1,229 @@
+"""棋譜解析 (analyze-game) の interface アダプタ．
+
+CLI 入力の検証・予算配分戦略の構築・結果の整形 (JSON / 人間向けサマリ)
+を担う．解析本体は :class:`maou.app.analysis.game_analyzer.GameAnalyzer`．
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from maou.app.analysis.game_analyzer import (
+    BudgetAllocator,
+    EqualDivisionAllocator,
+    FixedPlayoutsAllocator,
+    FixedTimeAllocator,
+    GameAnalyzer,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SUFFIX_TO_FORMAT: dict[str, str] = {
+    ".csa": "csa",
+    ".kif": "kif",
+    ".kifu": "kif",
+}
+
+
+def resolve_input_format(
+    input_path: Path, input_format: str | None
+) -> str:
+    """棋譜形式を確定する (明示指定を優先し，無ければ拡張子から判定)．
+
+    Args:
+        input_path: 棋譜ファイルのパス．
+        input_format: 明示指定された形式 ("csa" / "kif")．None なら自動判定．
+
+    Returns:
+        "csa" または "kif"．
+
+    Raises:
+        ValueError: 不正な明示指定，または拡張子から判定できない場合．
+    """
+    if input_format is not None:
+        if input_format not in ("csa", "kif"):
+            raise ValueError(
+                f"未対応の棋譜形式です: {input_format} (csa / kif のみ)"
+            )
+        return input_format
+    fmt = _SUFFIX_TO_FORMAT.get(input_path.suffix.lower())
+    if fmt is None:
+        raise ValueError(
+            f"拡張子 '{input_path.suffix}' から棋譜形式を判定できません．"
+            "--input-format csa|kif を明示してください"
+        )
+    return fmt
+
+
+def build_allocator(
+    *,
+    time_ms: int | None,
+    total_time_ms: int | None,
+    playouts: int | None,
+) -> BudgetAllocator:
+    """予算オプション (相互排他) から配分戦略を構築する．
+
+    全て未指定の場合は 1 局面 1000ms (``maou search`` の既定と同じ)．
+
+    Args:
+        time_ms: 1 局面あたりの時間 (ミリ秒)．
+        total_time_ms: 対局全体の時間 (ミリ秒，局面数で等分)．
+        playouts: 1 局面あたりの playout 数．
+
+    Returns:
+        構築した配分戦略．
+
+    Raises:
+        ValueError: 2 つ以上の同時指定，または正でない値．
+    """
+    specified = [
+        v
+        for v in (time_ms, total_time_ms, playouts)
+        if v is not None
+    ]
+    if len(specified) > 1:
+        raise ValueError(
+            "--time-ms / --total-time-ms / --playouts は同時に 1 つまで"
+            "しか指定できません"
+        )
+    if specified and specified[0] <= 0:
+        raise ValueError(
+            f"探索予算は正の値が必要です: {specified[0]}"
+        )
+    if time_ms is not None:
+        return FixedTimeAllocator(time_ms=time_ms)
+    if total_time_ms is not None:
+        return EqualDivisionAllocator(
+            total_time_ms=total_time_ms
+        )
+    if playouts is not None:
+        return FixedPlayoutsAllocator(playouts=playouts)
+    return FixedTimeAllocator(time_ms=1000)
+
+
+def analyze_game(
+    *,
+    input_path: Path,
+    input_format: str | None = None,
+    model_path: Path | None = None,
+    time_ms: int | None = None,
+    total_time_ms: int | None = None,
+    playouts: int | None = None,
+    num_candidates: int = 5,
+    threads: int = 1,
+    batch_size: int = 8,
+    root_dfpn: bool = True,
+    root_dfpn_nodes: int = 2_000_000,
+    root_dfpn_depth: int = 2047,
+    leaf_mate: bool = True,
+    leaf_mate_nodes: int = 50,
+    leaf_mate_threads: int = 1,
+    cuda: bool = False,
+    tensorrt: bool = False,
+    trt_engine_cache_dir: Path | None = None,
+) -> tuple[str, str]:
+    """棋譜 1 局を解析して (JSON 文字列, サマリ文字列) を返す．
+
+    Args:
+        input_path: 棋譜ファイル (CSA / KIF) のパス．
+        input_format: 棋譜形式．None なら拡張子から自動判定．
+        model_path: ONNX モデルのパス．None なら mock 評価器 (開発用)．
+        time_ms: 1 局面あたりの時間予算 (ミリ秒，排他)．
+        total_time_ms: 対局全体の時間予算 (ミリ秒，等分，排他)．
+        playouts: 1 局面あたりの playout 予算 (排他)．
+        num_candidates: JSON に記録する候補手数．
+        threads: 探索スレッド数．
+        batch_size: 評価バッチサイズ．
+        root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
+        root_dfpn_nodes: ルート dfpn のノード予算．
+        root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
+        leaf_mate: MCTS の葉の短手詰み探索 (専用スレッド) を行うか．
+        leaf_mate_nodes: leaf-mate 1 回あたりのノード予算．
+        leaf_mate_threads: leaf-mate 専用スレッド数．
+        cuda: CUDA Execution Provider を使うか．
+        tensorrt: TensorRT Execution Provider を使うか．
+        trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+
+    Returns:
+        ``(JSON 文字列, 人間向けサマリ文字列)`` のタプル．JSON スキーマは
+        docs/design/game-analysis/index.md §7．
+    """
+    fmt = resolve_input_format(input_path, input_format)
+    allocator = build_allocator(
+        time_ms=time_ms,
+        total_time_ms=total_time_ms,
+        playouts=playouts,
+    )
+    option = GameAnalyzer.AnalyzeOption(
+        input_path=input_path,
+        input_format=fmt,
+        allocator=allocator,
+        model_path=model_path,
+        threads=threads,
+        batch_size=batch_size,
+        num_candidates=num_candidates,
+        root_dfpn=root_dfpn,
+        root_dfpn_nodes=root_dfpn_nodes,
+        root_dfpn_depth=root_dfpn_depth,
+        leaf_mate=leaf_mate,
+        leaf_mate_nodes=leaf_mate_nodes,
+        leaf_mate_threads=leaf_mate_threads,
+        cuda=cuda,
+        tensorrt=tensorrt,
+        trt_engine_cache_dir=trt_engine_cache_dir,
+    )
+    result = GameAnalyzer().analyze(option)
+    json_str = json.dumps(result, ensure_ascii=False, indent=2)
+    return json_str, _format_summary(result)
+
+
+def _format_summary(result: dict[str, Any]) -> str:
+    """解析結果 dict から人間向けサマリ文字列を作る．"""
+    inp = result["input"]
+    summ = result["summary"]
+    names = inp["names"]
+    black = (names[0] if len(names) > 0 else None) or "?"
+    white = (names[1] if len(names) > 1 else None) or "?"
+    win_label = {0: "draw", 1: "black win", 2: "white win"}.get(
+        inp["win"], "unknown"
+    )
+    endgame = f" ({inp['endgame']})" if inp["endgame"] else ""
+    model = result["engine"]["model_path"] or "mock"
+
+    def pct(v: float | None) -> str:
+        return f"{v * 100:.1f}%" if v is not None else "n/a"
+
+    def num(v: float | None) -> str:
+        return f"{v:.4f}" if v is not None else "n/a"
+
+    mr = summ["match_rate"]
+    mwl = summ["mean_winrate_loss"]
+    lines = [
+        f"Game: {black} (black) vs {white} (white)",
+        f"Result: {win_label}{endgame}",
+        f"Moves: {inp['n_moves']} | model: {model}",
+        f"Match rate: black {pct(mr['black'])}, white {pct(mr['white'])}",
+        (
+            f"Mean winrate loss: black {num(mwl['black'])}, "
+            f"white {num(mwl['white'])}"
+        ),
+    ]
+    if summ["worst_moves"]:
+        lines.append("Worst moves:")
+        for w in summ["worst_moves"]:
+            lines.append(
+                f"  ply {w['ply']} ({w['side']}): played {w['played']}, "
+                f"best {w['best']}, winrate_loss {w['winrate_loss']:.4f}"
+            )
+    if summ["mates_found"]:
+        mates = ", ".join(
+            f"ply {m['ply']} ({m['side']})"
+            for m in summ["mates_found"]
+        )
+        lines.append(f"Mates found: {mates}")
+    lines.append(
+        f"Total: elapsed {summ['total_elapsed_ms'] / 1000:.1f}s, "
+        f"playouts {summ['total_playouts']}"
+    )
+    return "\n".join(lines)

--- a/tests/maou/app/analysis/resources/mini.csa
+++ b/tests/maou/app/analysis/resources/mini.csa
@@ -1,0 +1,22 @@
+V2
+N+black_engine
+N-white_engine
+P1-KY-KE-GI-KI-OU-KI-GI-KE-KY
+P2 * -HI *  *  *  *  * -KA *
+P3-FU-FU-FU-FU-FU-FU-FU-FU-FU
+P4 *  *  *  *  *  *  *  *  *
+P5 *  *  *  *  *  *  *  *  *
+P6 *  *  *  *  *  *  *  *  *
+P7+FU+FU+FU+FU+FU+FU+FU+FU+FU
+P8 * +KA *  *  *  *  * +HI *
+P9+KY+KE+GI+KI+OU+KI+GI+KE+KY
++
++7776FU
+T1
+-3334FU
+T2
++2726FU
+T3
+-8384FU
+T4
+%TORYO

--- a/tests/maou/app/analysis/test_game_analyzer.py
+++ b/tests/maou/app/analysis/test_game_analyzer.py
@@ -1,0 +1,203 @@
+"""GameAnalyzer / BudgetAllocator / 棋譜デコードのテスト．"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maou._rust.maou_shogi import parse_kif_str
+from maou.app.analysis.game_analyzer import (
+    EqualDivisionAllocator,
+    FixedPlayoutsAllocator,
+    FixedTimeAllocator,
+    GameAnalyzer,
+    PositionBudget,
+    decode_kifu_bytes,
+)
+
+RESOURCES = Path(__file__).parent / "resources"
+CONVERTER_INPUT = (
+    Path(__file__).parents[1]
+    / "converter"
+    / "resources"
+    / "test_dir"
+    / "input"
+)
+
+
+class TestBudgetAllocators:
+    def test_fixed_time(self) -> None:
+        allocator = FixedTimeAllocator(time_ms=500)
+        budgets = allocator.allocate(3)
+        assert (
+            budgets
+            == [PositionBudget(max_playouts=None, time_ms=500)]
+            * 3
+        )
+        assert allocator.describe() == {
+            "mode": "fixed_time",
+            "time_ms": 500,
+        }
+
+    def test_equal_division(self) -> None:
+        allocator = EqualDivisionAllocator(total_time_ms=1000)
+        budgets = allocator.allocate(3)
+        # 床関数: 端数は切り捨てて全体上限を超えない側に倒す
+        assert (
+            budgets
+            == [PositionBudget(max_playouts=None, time_ms=333)]
+            * 3
+        )
+        assert allocator.describe() == {
+            "mode": "equal_division",
+            "total_time_ms": 1000,
+        }
+
+    def test_equal_division_clamps_to_1ms(self) -> None:
+        allocator = EqualDivisionAllocator(total_time_ms=2)
+        budgets = allocator.allocate(4)
+        assert all(b.time_ms == 1 for b in budgets)
+
+    def test_equal_division_empty(self) -> None:
+        allocator = EqualDivisionAllocator(total_time_ms=1000)
+        assert allocator.allocate(0) == []
+
+    def test_fixed_playouts(self) -> None:
+        allocator = FixedPlayoutsAllocator(playouts=100)
+        budgets = allocator.allocate(2)
+        assert (
+            budgets
+            == [PositionBudget(max_playouts=100, time_ms=None)]
+            * 2
+        )
+        assert allocator.describe() == {
+            "mode": "fixed_playouts",
+            "playouts": 100,
+        }
+
+
+class TestDecodeKifuBytes:
+    def test_utf8(self) -> None:
+        assert (
+            decode_kifu_bytes("将棋".encode("utf-8")) == "将棋"
+        )
+
+    def test_cp932_fallback(self) -> None:
+        text = "先手：将棋太郎"
+        assert decode_kifu_bytes(text.encode("cp932")) == text
+
+    def test_invalid_both_raises(self) -> None:
+        # 0x81 0x20 は UTF-8 でも cp932 でも不正 (不正トレイル)
+        with pytest.raises(UnicodeDecodeError):
+            decode_kifu_bytes(b"\x81\x20")
+
+    def test_sjis_kif_fixture_parses(self) -> None:
+        data = (
+            CONVERTER_INPUT / "test_data_sjis.kif"
+        ).read_bytes()
+        record = parse_kif_str(decode_kifu_bytes(data))
+        assert len(record.moves) == 163
+
+
+class TestGameAnalyzer:
+    def _analyze(
+        self, input_path: Path, input_format: str
+    ) -> dict[str, Any]:
+        option = GameAnalyzer.AnalyzeOption(
+            input_path=input_path,
+            input_format=input_format,
+            allocator=FixedPlayoutsAllocator(playouts=8),
+            root_dfpn=False,
+            leaf_mate=False,
+        )
+        return GameAnalyzer().analyze(option)
+
+    def test_analyze_mini_csa(self) -> None:
+        result = self._analyze(RESOURCES / "mini.csa", "csa")
+
+        assert set(result) == {
+            "input",
+            "engine",
+            "budget",
+            "positions",
+            "summary",
+        }
+        assert result["input"]["names"] == [
+            "black_engine",
+            "white_engine",
+        ]
+        assert result["input"]["win"] == 2
+        assert result["input"]["endgame"] == "%TORYO"
+        assert result["input"]["n_moves"] == 4
+        assert result["budget"] == {
+            "mode": "fixed_playouts",
+            "playouts": 8,
+            "per_position": {
+                "max_playouts": 8,
+                "time_ms": None,
+            },
+        }
+        assert result["engine"]["model_path"] is None
+
+        positions = result["positions"]
+        assert [p["ply"] for p in positions] == [1, 2, 3, 4]
+        assert [p["side_to_move"] for p in positions] == [
+            "b",
+            "w",
+            "b",
+            "w",
+        ]
+        assert [p["played_move"] for p in positions] == [
+            "7g7f",
+            "3c3d",
+            "2g2f",
+            "8c8d",
+        ]
+        assert positions[0]["sfen"].startswith(
+            "lnsgkgsnl/1r5b1/ppppppppp"
+        )
+        assert [p["record_time_s"] for p in positions] == [
+            1,
+            2,
+            3,
+            4,
+        ]
+        assert all(
+            p["stop"] == "playout_limit" for p in positions
+        )
+        assert all(
+            p["best_move"] is not None for p in positions
+        )
+        assert all(len(p["candidates"]) <= 5 for p in positions)
+        # 候補手の先頭は best_move (SearchRunner と同じ整列)
+        assert all(
+            p["candidates"][0]["usi"] == p["best_move"]
+            for p in positions
+        )
+
+        summary = result["summary"]
+        assert set(summary["match_rate"]) == {"black", "white"}
+        assert summary["total_playouts"] >= 4 * 8
+        assert isinstance(summary["worst_moves"], list)
+        assert summary["mates_found"] == []
+
+    def test_multi_game_csa_rejected(self) -> None:
+        with pytest.raises(ValueError, match="2 局"):
+            self._analyze(
+                CONVERTER_INPUT / "csa_multi_game.csa", "csa"
+            )
+
+    def test_no_moves_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="指し手がありません"
+        ):
+            self._analyze(
+                CONVERTER_INPUT / "test_data_no_moves.csa",
+                "csa",
+            )
+
+    def test_unknown_format_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="未対応の棋譜形式"
+        ):
+            self._analyze(RESOURCES / "mini.csa", "sgf")

--- a/tests/maou/app/search/test_search_engine.py
+++ b/tests/maou/app/search/test_search_engine.py
@@ -1,0 +1,61 @@
+"""maou._rust.maou_search.SearchEngine (永続エンジン binding) のテスト．"""
+
+import pytest
+
+from maou._rust.maou_search import SearchEngine, search
+
+SFEN_INITIAL = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+MATE_IN_1 = "4k4/9/4P4/9/9/9/9/9/9 b G 1"
+
+
+class TestSearchEngine:
+    def test_engine_reuse_is_deterministic(self) -> None:
+        engine = SearchEngine()
+        r1 = engine.search(SFEN_INITIAL, max_playouts=200)
+        r2 = engine.search(SFEN_INITIAL, max_playouts=200)
+        # mock 評価器は決定論的なので同一エンジンの再利用で結果が一致する
+        assert r1.best_move == r2.best_move
+        assert r1.winrate == r2.winrate
+        assert r1.stop == "playout_limit"
+
+    def test_engine_matches_one_shot_search(self) -> None:
+        # 同一条件なら関数 search (毎回評価器を構築) と結果が一致する
+        engine_result = SearchEngine().search(
+            SFEN_INITIAL, max_playouts=200
+        )
+        function_result = search(SFEN_INITIAL, max_playouts=200)
+        assert (
+            engine_result.best_move == function_result.best_move
+        )
+        assert engine_result.winrate == function_result.winrate
+        assert (
+            engine_result.playouts == function_result.playouts
+        )
+
+    def test_moves_history_is_applied(self) -> None:
+        engine = SearchEngine()
+        result = engine.search(
+            SFEN_INITIAL,
+            moves=["7g7f", "3c3d"],
+            max_playouts=100,
+        )
+        assert result.best_move is not None
+
+    def test_mate_in_1_is_proven_by_root_dfpn(self) -> None:
+        engine = SearchEngine()
+        result = engine.search(MATE_IN_1, max_playouts=2000)
+        assert result.stop == "root_proven"
+        assert result.best_move == "G*5b"
+        assert result.winrate == 1.0
+
+    def test_illegal_move_raises(self) -> None:
+        engine = SearchEngine()
+        with pytest.raises(ValueError):
+            engine.search(
+                SFEN_INITIAL, moves=["9a9b"], max_playouts=10
+            )
+
+    def test_invalid_sfen_raises(self) -> None:
+        engine = SearchEngine()
+        with pytest.raises(ValueError):
+            engine.search("not-a-sfen", max_playouts=10)

--- a/tests/maou/infra/console/test_analyze_game_cli.py
+++ b/tests/maou/infra/console/test_analyze_game_cli.py
@@ -1,0 +1,107 @@
+"""`maou analyze-game` CLI のテスト．"""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from maou.infra.console.analyze_game import analyze_game
+
+MINI_CSA = (
+    Path(__file__).parents[2]
+    / "app"
+    / "analysis"
+    / "resources"
+    / "mini.csa"
+)
+
+
+class TestAnalyzeGameCli:
+    def test_expected_options_exist(self) -> None:
+        param_names = [p.name for p in analyze_game.params]
+        for expected in [
+            "input_path",
+            "input_format",
+            "model_path",
+            "time_ms",
+            "total_time_ms",
+            "playouts",
+            "num_candidates",
+            "output",
+            "threads",
+            "batch_size",
+            "root_dfpn",
+            "leaf_mate",
+            "cuda",
+            "tensorrt",
+            "trt_cache_dir",
+        ]:
+            assert expected in param_names
+        input_path_param = next(
+            p
+            for p in analyze_game.params
+            if p.name == "input_path"
+        )
+        assert input_path_param.required is True
+
+    def test_writes_json_and_prints_summary(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "report.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_game,
+            [
+                "--input-path",
+                str(MINI_CSA),
+                "--playouts",
+                "4",
+                "--output",
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Match rate:" in result.output
+        assert "black_engine (black)" in result.output
+        data = json.loads(output.read_text(encoding="utf-8"))
+        assert data["input"]["n_moves"] == 4
+        assert len(data["positions"]) == 4
+        assert data["input"]["format"] == "csa"
+
+    def test_json_to_stdout_without_output(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_game,
+            ["--input-path", str(MINI_CSA), "--playouts", "4"],
+        )
+        assert result.exit_code == 0, result.output
+        # tqdm の progress 行 (stderr 由来) が混ざり得るため，JSON の開始
+        # 位置から末尾までをパースする
+        json_start = result.output.index("{")
+        data = json.loads(result.output[json_start:])
+        assert len(data["positions"]) == 4
+
+    def test_budget_options_are_exclusive(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_game,
+            [
+                "--input-path",
+                str(MINI_CSA),
+                "--playouts",
+                "4",
+                "--time-ms",
+                "100",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "at most one" in result.output
+
+    def test_cuda_without_model_path_is_rejected(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_game,
+            ["--input-path", str(MINI_CSA), "--cuda"],
+        )
+        assert result.exit_code != 0
+        assert "require --model-path" in result.output

--- a/tests/maou/interface/test_analyzer.py
+++ b/tests/maou/interface/test_analyzer.py
@@ -1,0 +1,91 @@
+"""interface.analyzer のバリデーションのテスト．"""
+
+from pathlib import Path
+
+import pytest
+
+from maou.app.analysis.game_analyzer import (
+    EqualDivisionAllocator,
+    FixedPlayoutsAllocator,
+    FixedTimeAllocator,
+)
+from maou.interface import analyzer
+
+
+class TestResolveInputFormat:
+    def test_csa_extension(self) -> None:
+        assert (
+            analyzer.resolve_input_format(Path("a/b.csa"), None)
+            == "csa"
+        )
+
+    def test_kif_extensions(self) -> None:
+        assert (
+            analyzer.resolve_input_format(Path("a.kif"), None)
+            == "kif"
+        )
+        assert (
+            analyzer.resolve_input_format(Path("a.kifu"), None)
+            == "kif"
+        )
+        # 大文字拡張子も判定できる
+        assert (
+            analyzer.resolve_input_format(Path("a.CSA"), None)
+            == "csa"
+        )
+
+    def test_unknown_extension_raises(self) -> None:
+        with pytest.raises(ValueError, match="判定できません"):
+            analyzer.resolve_input_format(Path("a.txt"), None)
+
+    def test_explicit_overrides_extension(self) -> None:
+        assert (
+            analyzer.resolve_input_format(Path("a.csa"), "kif")
+            == "kif"
+        )
+
+    def test_invalid_explicit_raises(self) -> None:
+        with pytest.raises(
+            ValueError, match="未対応の棋譜形式"
+        ):
+            analyzer.resolve_input_format(Path("a.csa"), "sgf")
+
+
+class TestBuildAllocator:
+    def test_default_is_1000ms_per_position(self) -> None:
+        allocator = analyzer.build_allocator(
+            time_ms=None, total_time_ms=None, playouts=None
+        )
+        assert allocator == FixedTimeAllocator(time_ms=1000)
+
+    def test_time_ms(self) -> None:
+        allocator = analyzer.build_allocator(
+            time_ms=250, total_time_ms=None, playouts=None
+        )
+        assert allocator == FixedTimeAllocator(time_ms=250)
+
+    def test_total_time_ms(self) -> None:
+        allocator = analyzer.build_allocator(
+            time_ms=None, total_time_ms=60_000, playouts=None
+        )
+        assert allocator == EqualDivisionAllocator(
+            total_time_ms=60_000
+        )
+
+    def test_playouts(self) -> None:
+        allocator = analyzer.build_allocator(
+            time_ms=None, total_time_ms=None, playouts=800
+        )
+        assert allocator == FixedPlayoutsAllocator(playouts=800)
+
+    def test_multiple_budgets_rejected(self) -> None:
+        with pytest.raises(ValueError, match="1 つまで"):
+            analyzer.build_allocator(
+                time_ms=100, total_time_ms=None, playouts=800
+            )
+
+    def test_non_positive_budget_rejected(self) -> None:
+        with pytest.raises(ValueError, match="正の値"):
+            analyzer.build_allocator(
+                time_ms=0, total_time_ms=None, playouts=None
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1507,7 +1507,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.42.0"
+version = "0.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- CSA/KIF の 1 局を受け取り，各指し手の直前局面を 1 局面探索して JSON レポート + サマリ (最善一致率/勝率損失/詰み発見) を出力する新コマンド `maou analyze-game` を追加
- Rust に永続エンジン binding `SearchEngine` (pyclass) を新設し，評価器の構築 (ONNX ロード) を 1 局 1 回に削減
- 時間配分を `BudgetAllocator` 戦略 (1 局面固定 / 全体等分 / playout 固定) として app 層に分離
- 副修正: dfpn の solve 終了統計行を `DFPN_STATS` env gate 配下へ (棋譜解析での stderr 洪水対策)

## Problem

学習済みモデルの実戦的な評価・棋譜の振り返りには「1 局を丸ごと自動解析する」機能が必要だが，既存の `maou search` は 1 局面ずつ手動で叩く形しかなかった．また既存の Rust binding は呼び出しごとに ONNX モデルをロードするため，N 局面の連続解析ではロードが N 回発生し実用にならない．

## Solution

設計は user 承認済みの reviews/2026-07-16-analyze-game-command-design.md (status: applied) に基づく．常設設計ドキュメント: docs/design/game-analysis/index.md．

1. **永続エンジン binding** (`rust/maou_rust/src/maou_search.rs`): `SearchEngine` pyclass が評価器 (OnnxEvaluator / mock) を `__init__` で 1 回構築して保持し，`search()` は局面ごとに `Searcher` を生成する．予算は毎回引数で受け取り，時間配分の判断を一切持たない (「持ち時間の消費計画は別レイヤー」の設計制約と整合)．実行プロバイダ (CPU / CUDA / TensorRT) の選択肢と cargo feature gate は既存 `search` 関数と同一で，デフォルト wheel の可搬性を維持
2. **app 層** (`src/maou/app/analysis/game_analyzer.py`): `GameAnalyzer` が棋譜デコード (UTF-8 先行 → cp932 fallback) → パース (既存露出の `parse_csa_str`/`parse_kif_str` を初使用) → Board walk → per-position 探索 → サマリ集計を行う．`BudgetAllocator` は fixed_time / equal_division / fixed_playouts の 3 戦略で，将来の傾斜配分は戦略追加のみで導入可能
3. **CLI** (`src/maou/infra/console/analyze_game.py`): 予算 3 オプションは相互排他，`--input-format` は拡張子自動判定つき，`--output` 指定時は JSON ファイル + stdout サマリ / 省略時は stdout に JSON (pipe 用)

## Changes

- `rust/maou_rust/src/maou_search.rs`: `SearchEngine` pyclass 追加 + 局面構築/検証ヘルパー抽出 (maou_rust 0.21.1 → 0.22.0)
- `rust/maou_shogi/src/dfpn/search/mod.rs`: `[dfpn] root ...` 統計行を `DFPN_STATS` env gate 配下へ (maou_shogi 5.8.1 → 5.8.2)．他の診断 (SHORTEN/SPROF/PROF 等) と同じ opt-in 慣行に統一
- `src/maou/app/analysis/game_analyzer.py` / `src/maou/interface/analyzer.py` / `src/maou/infra/console/analyze_game.py`: 新設 (fetch-floodgate と同型のレイヤー構成，maou 0.42.0 → 0.43.0)
- `src/maou/infra/console/app.py`: `LAZY_COMMANDS` に analyze-game を登録
- `docs/design/game-analysis/index.md` / `docs/commands/analyze_game.md`: 設計・コマンドドキュメント新設
- tests: 新規 35 件

## Impact

**Breaking Changes**: なし (新コマンド + 追加 binding のみ．既存 `search` 関数は不変更)

**挙動変更 (opt-in 化)**: dfpn solve 終了時の `[dfpn] root pn=...` stderr 行はデフォルト非表示になり，`DFPN_STATS=1` で従来どおり出力される．探索意味論は不変更で，canonical テスト (29te/39te) は node 数を自前 assert しているため影響なし

**Performance**: 棋譜解析での評価器構築が 1 局 1 回に (従来 API のままなら局面数分)．TensorRT はエンジンキャッシュ併用で 2 プロセス目以降の warmup がほぼゼロ

**Dependencies**: 追加依存なし

## Testing

- 新規テスト 35 件: allocator (等分/端数/最小 1ms) / デコード (UTF-8/cp932/不正トレイル) / `GameAnalyzer` golden (4 手 CSA fixture + mock 評価器で JSON スキーマ・ply 進行・棋譜メタ echo を検証) / fail-loud (複数局 CSA・指し手なし・未対応形式) / CLI (CliRunner: JSON+サマリ出力・排他チェック) / `SearchEngine` (再利用の決定論性・関数 `search` との結果一致・mate-in-1 の root_proven)
- 全体: pytest 1531 passed / 46 skipped，mypy / ruff / isort green，cargo clippy / fmt green，maou_shogi 通常テスト 201 件 green
- 実地 e2e: floodgate 実棋譜 (44 手) を mock 評価器で解析し，JSON スキーマ・サマリ・進捗表示 (stderr)・stderr 静音化を確認

## Review Notes

- **勝率損失の定義**: `winrate_loss` は同一局面の root_children 統計から best と実戦の手の Q 差を取り 0 で下限クランプ (訪問数基準の最終手選択では played の Q が best を僅かに上回り得るため)．実戦の手が未訪問なら null (未訪問の winrate 0 は「データなし」)
- **複数局 CSA は明示エラー** (1 局のみ対応，将来拡張)．fetch-floodgate の出力 (1 局 1 ファイル) とは直結する
- follow-up 候補: 実 ONNX モデルでの実地解析，傾斜配分戦略，design doc の「実装済み」マーカー更新

## Checklist

- [x] Code formatted and linted (ruff, isort)
- [x] Type checking passes (mypy)
- [x] All tests pass (pytest)
- [x] New tests added for new features
- [x] Architecture compliance verified (infra → interface → app → domain)
- [x] Docstrings added (all public APIs)
- [x] docs/commands/ updated (analyze_game.md 新設)
- [x] Version bumps: maou 0.43.0 / maou_rust 0.22.0 / maou_shogi 5.8.2