### PR TITLE
feat: analyze-gui に対話解析機能 (分岐・盤面クリック・GUI 内解析) を追加 (maou 0.45.0)

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -36,7 +36,21 @@ jobs:
       - name: Delete existing release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release delete latest --yes --cleanup-tag || true
+        # 削除は API の伝播遅延・一時失敗で「成功したように見えて残る」ことが
+        # ある (run 29539610667: delete が "release not found" を返した直後に
+        # create が "already exists" で失敗し release は残存)．削除を試みた後に
+        # 消えたことを検証し，残っていてもここでは fail せず後続ステップの
+        # in-place 更新にフォールバックする．
+        run: |
+          gh release delete latest --yes --cleanup-tag || true
+          for _ in $(seq 1 12); do
+            if ! gh release view latest >/dev/null 2>&1; then
+              echo "Release 'latest' deleted."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::warning::Release 'latest' still exists after delete; falling back to in-place update."
 
       - name: Extract version
         id: version
@@ -54,19 +68,38 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ls dist/*.whl 1>/dev/null 2>&1 || { echo "::error::No wheel files found in dist/"; exit 1; }
-          gh release create latest \
-            --title "Development Build (v${{ steps.version.outputs.version }})" \
-            --notes "Prebuilt unified wheels for development use (Colab, etc.).
+          built_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          cat > "$RUNNER_TEMP/release-notes.md" <<EOF
+          Prebuilt unified wheels for development use (Colab, etc.).
 
           - **Version**: ${{ steps.version.outputs.version }}
           - **Commit**: ${{ github.sha }}
-          - **Built at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          - **Built at**: ${built_at}
           - **Platform**: manylinux_2_28 x86_64
           - **Python**: CPython 3.11, 3.12
           - **Cargo features**: onnx-cuda, onnx-tensorrt (単一配布 wheel．
             CPU-only 環境でもそのまま動作し，ONNX CPU 推論可)
           - GPU 実行時要件: \`pip install 'maou[tensorrt-infer] @ <wheel>'\` が
             onnxruntime-gpu 1.22 (provider .so) + tensorrt-cu12 10 系を版一致で
-            揃える (CUDA 12 環境)．手順: docs/design/position-search/benchmarking.md" \
-            --latest \
-            dist/*.whl
+            揃える (CUDA 12 環境)．手順: docs/design/position-search/benchmarking.md
+          EOF
+          if gh release view latest >/dev/null 2>&1; then
+            # delete が反映されなかった場合の in-place 更新フォールバック．
+            # 旧版数の asset が残ると取得手順 (cp タグ名でのマッチ) が誤った
+            # wheel を掴み得るため，全 asset を削除してから upload する．
+            # tag も現行コミットへ force 更新して notes の Commit と一致させる
+            gh release view latest --json assets --jq '.assets[].name' \
+              | xargs -r -n1 -I{} gh release delete-asset latest '{}' --yes
+            git push --force origin "HEAD:refs/tags/latest"
+            gh release upload latest dist/*.whl
+            gh release edit latest \
+              --title "Development Build (v${{ steps.version.outputs.version }})" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --latest
+          else
+            gh release create latest \
+              --title "Development Build (v${{ steps.version.outputs.version }})" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --latest \
+              dist/*.whl
+          fi

--- a/docs/commands/analyze_gui.md
+++ b/docs/commands/analyze_gui.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-- Launches a **Gradio browser UI for reviewing a game record** (CSA / KIF)
-  together with an `maou analyze-game` JSON report. Design document:
-  `docs/design/game-analysis/gui.md`.
-- Features (viewer milestone):
+- Launches a **Gradio browser UI for reviewing and interactively analyzing a
+  game record** (CSA / KIF) together with an `maou analyze-game` JSON report.
+  Design document: `docs/design/game-analysis/gui.md`.
+- Viewer features:
   - Board view (SVG) with last-move highlight and **candidate-move arrows**
     (best move in red with rank labels, others in blue with opacity scaled by
     visit count; optional PV chain arrows for the best move).
@@ -16,16 +16,34 @@
     win-rate loss, mate ★) — clicking a row jumps to the position after that
     move.
   - Per-position candidate table (rank / move / visits / win rate
-    (side-to-move) / prior / proven value).
+    (side-to-move) / prior / proven value) — clicking a row plays that move
+    as a variation.
   - Position info: SFEN and USI `position` string for hand-off to other
     tools, per-move notes (engine best vs played, recorded time / comments).
   - Files can be loaded at startup (CLI flags) or uploaded from the UI.
-- Interactive analysis (board move input, variation branching, on-demand
-  engine search from the GUI) is designed but **not implemented yet** — see
-  `docs/design/game-analysis/gui.md` §13 milestones.
-- Requires the `visualize` extra (`uv sync --extra visualize`); analysis
-  reports are produced separately by `maou analyze-game` (any environment,
-  e.g. Colab GPU), so the GUI itself needs no model or GPU.
+- Interactive analysis features:
+  - **Board click input**: click a piece (or a piece in hand) then a
+    destination square to play a move; legal destinations are highlighted
+    and a promote / no-promote confirmation is shown when both are legal.
+    A legal-move dropdown is provided as a fallback input.
+  - **Variation branching (継ぎ盤)**: playing a move that differs from the
+    mainline automatically creates a branch. A breadcrumb shows the branch
+    point and moves; "本譜へ戻る" returns to the mainline. Branches persist
+    for the session.
+  - **Single-position analysis**: analyze the current position (mainline or
+    branch) with the resident engine. Results are cached per position;
+    "再解析" overwrites the cache. "PV を分岐で再生" replays the analyzed PV
+    as a branch.
+  - **Whole-game analysis**: analyze every mainline position with progress
+    display and cooperative cancellation; the result updates the graph /
+    move list and is downloadable as an analyze-game compatible JSON report.
+  - The engine is loaded once per server process and search events are
+    serialized (`concurrency_limit=1`). Without `--model-path` a
+    deterministic **mock evaluator** is used (development verification only —
+    clearly labeled in the UI).
+- Requires the `visualize` extra (`uv sync --extra visualize`). Viewing a
+  pre-computed report needs no model or GPU; in-GUI analysis quality requires
+  a real ONNX model (`--model-path`).
 
 ## CLI options
 
@@ -33,7 +51,21 @@
 | --- | --- | --- |
 | `--input-path PATH` | | Game record file (CSA / KIF) loaded at startup. Files can also be uploaded from the UI. |
 | `--report PATH` | | analyze-game JSON report (the `--output` file) matching the game record. Requires `--input-path`. The report is validated against the record (move count, played moves, per-position SFEN). |
-| `--num-candidates INT` | default `5` | Maximum number of candidate moves shown in the UI (table rows and arrows). |
+| `--model-path PATH` | | ONNX model file for in-GUI analysis. Uses a deterministic mock evaluator when omitted (development only; labeled in the UI). |
+| `--time-ms INT` | | Default time budget per in-GUI analysis in milliseconds (default `1000`). Mutually exclusive with `--playouts`. |
+| `--playouts INT` | | Default playout budget per in-GUI analysis. Mutually exclusive with `--time-ms`. |
+| `--num-candidates INT` | default `5` | Maximum number of candidate moves shown in the UI (table rows and arrows) and recorded per position. |
+| `--threads INT` | default `1` | Number of search threads. |
+| `--batch-size INT` | default `8` | Evaluation batch size. |
+| `--root-dfpn/--no-root-dfpn` | default on | Run dfpn mate search on each root position in parallel. |
+| `--root-dfpn-nodes INT` | default `2000000` | Node budget for the root dfpn mate search. |
+| `--root-dfpn-depth INT` | default `2047` | Search depth limit for the root dfpn mate search (max 2047). |
+| `--leaf-mate/--no-leaf-mate` | default on | Enable short mate search at MCTS leaves (async). |
+| `--leaf-mate-nodes INT` | default `50` | Node budget per leaf-mate df-pn call. |
+| `--leaf-mate-threads INT` | default `1` | Number of dedicated leaf-mate threads. |
+| `--cuda/--no-cuda` | default off | Enable CUDA Execution Provider (requires `--model-path`). |
+| `--tensorrt/--no-tensorrt` | default off | Enable TensorRT Execution Provider (requires `--model-path`). |
+| `--trt-cache-dir PATH` | | TensorRT engine cache directory. |
 | `--port INT` | | Gradio server port. Auto-selected by Gradio when omitted. |
 | `--share` | flag | Create a public Gradio link (auto-enabled on Google Colab). |
 | `--server-name HOST` | default `127.0.0.1` | Server bind address. |
@@ -49,7 +81,10 @@ uv run maou analyze-game \
 # 2. Review it in the browser (no model needed)
 uv run maou analyze-gui --input-path game.csa --report report.json
 
-# Board replay only (no report)
+# Interactive analysis with a real model (per-position 1000ms)
+uv run maou analyze-gui --input-path game.csa --model-path model.onnx
+
+# Board replay / branching only (no report, mock engine labeled in UI)
 uv run maou analyze-gui --input-path game.csa
 
 # Start empty and upload files from the UI
@@ -59,11 +94,13 @@ uv run maou analyze-gui
 ## Implementation references
 
 - CLI: `src/maou/infra/console/analyze_gui.py`
-- Gradio server (Blocks wiring): `src/maou/infra/visualization/analysis_gui_server.py`
-- Interface adapter (board SVG / graph / tables / perspective conversion):
-  `src/maou/interface/analysis_gui.py`
-- Use case (kifu → per-ply snapshots, report validation):
-  `src/maou/app/analysis/analysis_session.py`
-- Multi-arrow board rendering: `ArrowSpec` in
-  `src/maou/domain/visualization/board_renderer.py`
+- Gradio server (Blocks wiring, click bridge, engine events):
+  `src/maou/infra/visualization/analysis_gui_server.py`
+- Interface adapter (board SVG / graph / tables / perspective conversion /
+  click state machine / breadcrumb): `src/maou/interface/analysis_gui.py`
+- Use cases (kifu → per-ply snapshots, report validation, variation tree):
+  `src/maou/app/analysis/analysis_session.py`; resident engine:
+  `src/maou/app/analysis/interactive_analyzer.py`
+- Multi-arrow board rendering and click targets: `ArrowSpec` /
+  `interactive` in `src/maou/domain/visualization/board_renderer.py`
 - Design document: `docs/design/game-analysis/gui.md`

--- a/docs/design/game-analysis/gui.md
+++ b/docs/design/game-analysis/gui.md
@@ -1,7 +1,8 @@
 # 棋譜解析 GUI (analyze-gui) 設計ドキュメント
 
-> **状態: 設計確定・実装中 (living document)**．実装の進行に合わせて本ドキュメントを
-> 更新する．各節に「実装済み」「設計方針 (未実装)」「未決」のいずれかを明記する．
+> **状態: 実装済み (マイルストーン 1・2 とも，living document)**．実装の進行に
+> 合わせて本ドキュメントを更新する．各節に「実装済み」「設計方針 (未実装)」
+> 「未決」のいずれかを明記する．
 > 実装済み記述の正は常にコードであり，乖離を見つけたら本ドキュメント側を直す．
 > 提案・承認の経緯: reviews/2026-07-16-analyze-gui-design.md
 > 前提となる解析コマンドの設計: [index.md](index.md)
@@ -32,7 +33,7 @@
 | ぴよ将棋 | グラフ上の悪手マーカー (色で深刻度) |
 | KENTO | 局面+手順の文字列エクスポート |
 
-## 3. CLI (設計方針)
+## 3. CLI (実装済み)
 
 ```
 maou analyze-gui
@@ -53,29 +54,31 @@ maou analyze-gui
 - gradio は visualize と同じ遅延 import (`uv sync --extra visualize` を案内)．
 - 利用モード 3 態:
   1. **棋譜 + モデル**: GUI 内で一括解析も 1 局面解析も可能 (フル機能)
-  2. **棋譜 + `--report`**: 解析済み JSON の閲覧 (モデル不要)．
-     1 局面解析ボタンは無効化
-  3. **棋譜のみ**: 盤面再生と分岐 (継盤) のみ．解析系は無効化
-- 閲覧機能のみの段階では，エンジン系オプション (--model-path 以下の
-  探索 passthrough) は未実装とし，docs/commands/analyze_gui.md には
-  実装済みオプションのみを記載する．
+  2. **棋譜 + `--report`**: 解析済み JSON の閲覧 (モデル不要)
+  3. **棋譜のみ**: 盤面再生と分岐 (継盤)
+- モデル未指定 (モード 2/3) でも解析ボタンは使えるが，決定論的な
+  **mock 評価器**で動作し UI に「開発検証専用」と明示する
+  (`analyze-game` の `--model-path` 省略時と同じ扱い)．当初案の
+  「モデル未指定時は解析ボタン無効化」は本節の mock 記述と矛盾して
+  いたため，実装時に mock + 明示へ一本化した (2026-07-17)．
 
-## 4. レイヤー構成 (設計方針)
+## 4. レイヤー構成 (実装済み)
 
 | 層 | ファイル | 責務 |
 |---|---|---|
 | infra/console | `src/maou/infra/console/analyze_gui.py` | click コマンド + `LAZY_COMMANDS` 登録 |
 | infra/visualization | `src/maou/infra/visualization/analysis_gui_server.py` | gr.Blocks 構築・イベント配線・サーバー起動 |
-| interface | `src/maou/interface/analysis_gui.py` | 表示整形 (SVG/テーブル/グラフ/日本語表記)．`usi_to_japanese` 等を再利用 |
-| app | `src/maou/app/analysis/analysis_session.py` | 棋譜ロード・分岐木・解析キャッシュ・エンジン呼び出し |
-| domain | `src/maou/domain/visualization/board_renderer.py` | 複数矢印拡張 |
+| interface | `src/maou/interface/analysis_gui.py` | 表示整形 (SVG/テーブル/グラフ/日本語表記/クリック状態機械/パンくず)．`usi_to_japanese` 等を再利用 |
+| app | `src/maou/app/analysis/analysis_session.py` | 棋譜ロード・分岐木 (`VariationTree`)・合法手列挙 |
+| app | `src/maou/app/analysis/interactive_analyzer.py` | 常駐エンジン (`InteractiveAnalyzer`)・1 局面/全局面解析・レポート組み立て |
+| domain | `src/maou/domain/visualization/board_renderer.py` | 複数矢印拡張・クリック標的 rect・選択/行き先の塗り |
 
 - `GradioVisualizationServer` (データセット可視化) には統合しない．
   `game_graph_shared.py` の共有部品は再利用する．
 - app 層が `maou._rust` (SearchEngine / parse_csa_str / parse_kif_str) を
   直接呼ぶのは `app/analysis/game_analyzer.py` と同じ扱い．
 
-## 5. 画面構成 (設計方針)
+## 5. 画面構成 (実装済み)
 
 ```
 ┌────────────────────────┬──────────────────────────────┐
@@ -125,71 +128,123 @@ maou analyze-gui
 - 候補手ごとの PV は Rust 拡張が必要なため採らない (user 承認 2026-07-16)．
   候補手クリック → その手で分岐して解析，で代替する．
 
-## 8. 継盤 (分岐) モデル (設計方針)
+## 8. 継盤 (分岐) モデル (実装済み)
 
-app 層 `AnalysisSession` が分岐木を保持する:
+app 層 `analysis_session.py` が分岐木を保持する．ノードは親子を
+**ID で参照する配列格納** (arena) とし，`gr.State` の deepcopy に耐える
+plain data にする (実装が正):
 
 ```python
 @dataclass
 class VariationNode:
+    node_id: int                    # VariationTree.nodes の索引
+    parent_id: int | None           # root は None
     move_usi: str | None            # None = 初期局面 (root)
-    parent: "VariationNode | None"
-    children: list["VariationNode"]
-    is_mainline: bool               # 本譜の手か
-    analysis: dict | None           # この手の直前局面の解析結果キャッシュ
+    snapshot: PositionSnapshot      # この手を指した後の局面
+    children: list[int]
+    is_mainline: bool               # 本譜のノードか
+    analysis: dict | None           # このノードの局面の解析結果キャッシュ
+
+@dataclass
+class VariationTree:
+    nodes: list[VariationNode]
+    mainline_ids: list[int]         # 索引 = ply
+    current_id: int
 ```
 
-- ロード時に `GameRecord.moves` から本譜チェーンを構築．analyze-game JSON
-  (`positions[i]`) は対応する本譜ノードのキャッシュに取り込む．
-- **盤面で手を指す / 候補手行をクリック / PV 再生** はすべて「現在ノードの
-  子に手を追加して移動」に統一 (同じ手の子が既にあれば再利用)．本譜から
-  外れた時点で自動的に分岐が生まれる．
+- 解析キャッシュは「**そのノードの局面を探索した結果**」を持つ
+  (analyze-game の `positions[i]` は「i+1 手目を指す直前の局面 =
+  本譜ノード i」に対応)．当初案の「この手の直前局面」表現と同じ対応を
+  ノード自身に付け替えたもの．
+- ロード時に本譜チェーンを構築．analyze-game JSON (`positions[i]`) は
+  対応する本譜ノードのキャッシュに取り込む (`apply_report_to_tree`)．
+- **盤面で手を指す / 候補手行をクリック / PV 再生** はすべて
+  `advance_move` (「現在ノードの子に手を追加して移動」，同じ手の子が
+  既にあれば再利用) に統一．本譜から外れた時点で自動的に分岐が生まれる．
 - パンくず表示: `本譜 42手目 ▶ △8四飛 ▶ ▲2四歩 …`．「本譜へ戻る」で
   分岐点の本譜側へ復帰．分岐は複数保持でき，セッション中は消えない．
 - 現局面の `position` 文字列 (`position sfen ... moves ...`) と SFEN を
   常時エクスポート表示する．
 
-## 9. 任意局面での 1 局面解析 (設計方針)
+## 9. 任意局面での 1 局面解析 (実装済み)
 
 - 「この局面を解析」ボタン: 現在ノードの局面を `SearchEngine.search(
   sfen=初期SFEN, moves=root からの USI 経路, ...)` で解析．経路を渡すのは
   千日手履歴を正しく効かせるため (GameAnalyzer と同じ規約)．
-- 予算は UI の time-ms / playouts (デフォルトは CLI 指定値)．
+- 予算は UI の time-ms / playouts (デフォルトは CLI 指定値，未指定は
+  1000ms)．
 - 結果はノードにキャッシュし，候補手テーブル・矢印・局面情報を更新．
-  再訪時は再解析しない (明示的な「再解析」ボタンで上書き)．
-- 「全局面解析」ボタン: 本譜全体を GameAnalyzer 相当のループで解析
-  (進捗バー + キャンセル)．結果は analyze-game の出力スキーマと同一の
-  JSON としてダウンロード可能 (CLI と GUI でレポートの相互運用を保つ)．
+  再訪時は再解析しない (明示的な「再解析 (上書き)」ボタンで上書き)．
+  本譜ノードは実戦手比較 (`played_move` / `match` / `winrate_loss`)
+  付き，分岐ノードは実戦手なし (`played_move: null`) の記録になる．
+- 「PV を分岐で再生」ボタン: 現在ノードの解析 PV を分岐として一括適用する
+  (§8 の `advance_move` 経路)．
+- 「全局面解析」ボタン: 本譜全体を `InteractiveAnalyzer.analyze_mainline`
+  (ジェネレータ) で解析し，進捗をテキスト表示する．キャンセルは協調
+  フラグ (実行中の 1 局面は完了を待って停止．解析済み局面はキャッシュに
+  残る)．完走時は analyze-game の出力スキーマと同一の JSON として
+  ダウンロード可能 (CLI と GUI でレポートの相互運用を保つ)．グラフ・
+  棋譜リスト・サマリも生成レポートで更新される．
 
-## 10. 盤面クリック入力 (設計方針)
+## 10. 盤面クリック入力 (実装済み)
 
-- SVG の各マス + 持ち駒に透明 rect (`data-square` 属性) を重ね，クリックで
-  hidden `gr.Textbox` に値を書いて Python コールバックを発火させる
-  (JS は `gr.Blocks(js=...)` で注入)．
-- 2 クリック方式: 1 回目 = 自駒/持ち駒選択 → 合法手の行き先を
-  `highlight_squares` で表示．2 回目 = 行き先確定．成/不成が両方合法なら
-  確認ボタンを表示．非合法クリックは選択解除．
-- 合法手判定は `Board.get_legal_moves()` の列挙をフィルタするだけ．
-- フォールバックとして合法手 Dropdown (日本語表記) も併設 (clickable SVG が
-  Gradio のサニタイズで不成立でも機能を失わない．テストもこちら経由)．
+- SVG の各マス + 持ち駒 (枚数 > 0 の表示行) に透明 rect
+  (`data-click="sq:{square}"` / `data-click="hand:{b|w}:{piece_type}"`,
+  square は column-major) を重ねる (`SVGBoardRenderer.render` の
+  `interactive=True`)．
+- JS → Python は hidden Textbox では**なく** `gr.HTML` の
+  `server_functions` + `js_on_load` ブリッジを使う (Gradio 6 では JS で
+  Textbox の値を変えても `.change()` が発火しない — game_graph_server.py
+  と同じパターン)．クリック委譲リスナーは `demo.launch(head=...)` で
+  注入し，永続する `#board-display` コンテナに 1 回だけ付ける．
+- **ブリッジ .change の制約 (実測 2026-07-17)**: server_functions の
+  `trigger("change")` 経由イベントは value 更新のみ反映され，
+  `gr.update` の prop 更新 (visible / choices) が適用されない．prop
+  更新を含む再描画は `.then()` で通常イベントを連鎖させて反映する
+  (成/不成ボタンの表示と合法手 Dropdown の choices 更新がこれに依存)．
+- 2 クリック方式 (interface 層 `handle_board_click` 純関数): 1 回目 =
+  自駒/持ち駒選択 → 合法手の行き先を専用色で塗る (選択 = アンバー，
+  行き先 = グリーン)．2 回目 = 行き先確定．成/不成が両方合法なら
+  「成る/成らず」確認ボタンを表示．非合法クリックは選択解除，選択中の
+  別自駒クリックは選択切替．
+- 合法手判定は `Board.get_legal_moves()` の列挙 (`legal_move_infos`) を
+  フィルタするだけ．
+- フォールバックとして合法手 Dropdown (日本語表記) + 「指す」ボタンも
+  併設 (clickable SVG が不成立でも機能を失わない．ユニットテストも
+  こちら経由)．
 
-## 11. 状態管理と並行性 (設計方針)
+## 11. 状態管理と並行性 (実装済み)
 
-- `SearchEngine` はサーバープロセスで 1 個 (モデル 1 回ロード)．
-  探索系イベントは Gradio queue の `concurrency_limit=1` で直列化する
-  (メモリ/EP 資源の競合を避ける．8GB DevContainer 制約)．
-- セッション状態 (棋譜・分岐木・現在ノード・解析キャッシュ) は `gr.State`
-  (ブラウザセッション独立，エンジンのみ共有)．`gr.State` の初期値は
-  セッションごとに deepcopy されるため，状態には PyO3 オブジェクト
-  (Board 等) を持たせず plain data のみとする．
-- 一括解析は長時間になり得るためキャンセルフラグを最初から実装する．
+- `SearchEngine` はサーバープロセスで 1 個 (`InteractiveAnalyzer` が遅延
+  構築しモデルは 1 回ロード)．探索系イベント (1 局面解析/再解析/全局面
+  解析) は `concurrency_id="engine"` + `concurrency_limit=1` で直列化する
+  (メモリ/EP 資源の競合を避ける．8GB DevContainer 制約)．キャンセル
+  ボタンは別レーンで即時実行される．
+- セッション状態 (棋譜 `SessionView`・分岐木 `VariationTree`・クリック
+  状態 `ClickState`) は `gr.State` (ブラウザセッション独立，エンジンのみ
+  共有)．`gr.State` の初期値はセッションごとに deepcopy されるため，
+  状態には PyO3 オブジェクト (Board 等) を持たせず plain data のみとする．
+- 一括解析は長時間になり得るためキャンセルフラグ (threading.Event) を
+  実装済み．
+- 制約: 盤面クリックブリッジの受け渡しバッファ (`pending_click`) は
+  クロージャとして全ブラウザセッションに共有される (game_graph_server の
+  `_pending` と同じ)．ローカル解析ツールとして単一利用者を前提とする．
+- 局面スライダーは `.release` イベントで配線する (ナビゲーションボタン等
+  がスライダー値をプログラム更新しても再描画が二重に走らない．`.change`
+  はプログラム更新でも発火するため使わない)．
 
-## 12. テスト (設計方針)
+## 12. テスト (実装済み)
 
 - 視点変換 (手番視点 → 先手視点) の純関数単体
-- `VariationNode` 木: 追加/同一手の子再利用/本譜復帰/root からの USI 経路生成
-- `SVGBoardRenderer` 複数矢印: N 本・色/透明度・駒打ち矢印・後方互換
-- `AnalysisSession`: mock 評価器で 1 局面解析 → キャッシュヒット → 再解析上書き
+- `VariationTree`: 追加/同一手の子再利用/本譜復帰/root からの USI 経路
+  生成/レポート取込/deepcopy 可能性
+- 盤面クリック状態機械: 選択/解除/切替/行き先確定/成・不成保留/駒打ち/
+  相手持ち駒の無視
+- `SVGBoardRenderer` 複数矢印: N 本・色/透明度・駒打ち矢印 (手番側始点)・
+  後方互換．クリック標的 rect・選択/行き先の塗り
+- `InteractiveAnalyzer`: mock 評価器で 1 局面解析 (本譜/分岐)・全局面
+  解析 + キャンセル・レポート組み立て．サーバー側でキャッシュヒット →
+  再解析上書き
 - interface 整形: analyze-game JSON fixture → グラフ用データ/棋譜テーブルの golden
 - CLI: CliRunner でオプション検証 (サーバー起動はモック)．gr.Blocks の
   demo 構築が例外なく通るスモーク
@@ -199,7 +254,8 @@ class VariationNode:
 
 ## 13. マイルストーンと決定事項
 
-実装は 2 段階に分割する (user 承認 2026-07-16):
+実装は 2 段階に分割する (user 承認 2026-07-16)．**両マイルストーンとも
+実装済み** (1: maou 0.44.0 / 2: maou 0.45.0):
 
 1. **閲覧機能** — 棋譜ロード + 盤面再生 + `--report` JSON 読込 + 評価値
    グラフ/棋譜リスト + 候補手テーブル/複数矢印 (renderer 拡張含む)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.44.0"
+version = "0.45.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/app/analysis/analysis_session.py
+++ b/src/maou/app/analysis/analysis_session.py
@@ -1,14 +1,15 @@
 """棋譜解析 GUI のセッション基盤ユースケース．
 
 棋譜 (CSA / KIF) を per-ply の盤面スナップショット列 (plain data) に展開し，
-`maou analyze-game` の JSON レポートとの整合検証を提供する．
+`maou analyze-game` の JSON レポートとの整合検証，および継盤 (分岐) 検討の
+ための分岐木 (:class:`VariationTree`) を提供する．
 
-スナップショットは PyO3 オブジェクト (Board 等) を保持しない plain data と
-する — Gradio の ``gr.State`` はセッションごとに初期値を deepcopy するため
-(docs/design/game-analysis/gui.md §11)．
+スナップショット・分岐木は PyO3 オブジェクト (Board 等) を保持しない
+plain data とする — Gradio の ``gr.State`` はセッションごとに初期値を
+deepcopy するため (docs/design/game-analysis/gui.md §11)．
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from maou.app.analysis.game_analyzer import (
@@ -256,3 +257,270 @@ def validate_report(
                 f"{i + 1} 手目の直前局面 SFEN が一致しません "
                 f"(棋譜と別の対局のレポートの可能性があります)"
             )
+
+
+@dataclass(frozen=True)
+class LegalMoveInfo:
+    """合法手 1 つ分の情報 (plain data, 盤面クリック入力用)．
+
+    Attributes:
+        usi: USI 表記 (例: "7g7f", "7g7f+", "P*5e")．
+        from_square: 移動元マス (0-80, column-major)．駒打ちは None．
+        to_square: 移動先マス (0-80, column-major)．
+        is_drop: 駒打ちかどうか．
+        drop_piece_type: 駒打ちの駒種 (0=歩, 1=香, ...)．通常手は None．
+        piece_id: 動かした駒の domain PieceId (移動前の駒種)．
+        is_promotion: 成る手かどうか．
+    """
+
+    usi: str
+    from_square: int | None
+    to_square: int
+    is_drop: bool
+    drop_piece_type: int | None
+    piece_id: int
+    is_promotion: bool
+
+
+def legal_move_infos(
+    snapshot: PositionSnapshot,
+) -> list[LegalMoveInfo]:
+    """スナップショット局面の合法手を列挙する．
+
+    Args:
+        snapshot: 対象局面のスナップショット．
+
+    Returns:
+        合法手の LegalMoveInfo リスト (Rust 側の列挙順)．
+    """
+    board = Board()
+    board.set_sfen(snapshot.sfen)
+    infos: list[LegalMoveInfo] = []
+    for move in board.get_legal_moves():
+        base = _move_info(board, move)
+        infos.append(
+            LegalMoveInfo(
+                usi=base.usi,
+                from_square=base.from_square,
+                to_square=base.to_square,
+                is_drop=base.is_drop,
+                drop_piece_type=base.drop_piece_type,
+                piece_id=base.piece_id,
+                is_promotion=base.usi.endswith("+"),
+            )
+        )
+    return infos
+
+
+@dataclass
+class VariationNode:
+    """分岐木の 1 ノード = 1 局面 (plain data)．
+
+    本譜も分岐もすべて同じ木構造で表す (docs/design/game-analysis/gui.md
+    §8)．解析キャッシュ ``analysis`` は「このノードの局面を探索した結果」
+    (analyze-game の ``positions[i]`` と同スキーマ) を保持する — レポートの
+    ``positions[i]`` は「i+1 手目を指す直前の局面 = 本譜ノード i」に対応する．
+
+    Attributes:
+        node_id: ノード ID (:attr:`VariationTree.nodes` の索引)．
+        parent_id: 親ノード ID (root は None)．
+        move_usi: このノードに至った指し手 (root は None)．
+        snapshot: このノードの局面スナップショット．
+        children: 子ノード ID のリスト (追加順)．
+        is_mainline: 本譜のノードかどうか．
+        analysis: この局面の解析結果キャッシュ (未解析は None)．
+    """
+
+    node_id: int
+    parent_id: int | None
+    move_usi: str | None
+    snapshot: PositionSnapshot
+    children: list[int] = field(default_factory=list)
+    is_mainline: bool = False
+    analysis: dict[str, Any] | None = None
+
+
+@dataclass
+class VariationTree:
+    """継盤 (分岐) 検討の分岐木 (plain data)．
+
+    Attributes:
+        nodes: 全ノード (索引 = node_id)．
+        mainline_ids: 本譜ノード ID 列 (索引 = ply)．
+        current_id: 現在表示中のノード ID．
+    """
+
+    nodes: list[VariationNode]
+    mainline_ids: list[int]
+    current_id: int
+
+
+def build_variation_tree(
+    document: GameDocument,
+    report: dict[str, Any] | None = None,
+) -> VariationTree:
+    """棋譜の本譜チェーンから分岐木を構築する．
+
+    Args:
+        document: 棋譜の GameDocument．
+        report: analyze-game の JSON レポート (検証済みのもの)．
+            指定時は ``positions[i]`` を本譜ノード i のキャッシュに
+            取り込む．
+
+    Returns:
+        本譜のみからなる VariationTree (current は root)．
+    """
+    nodes: list[VariationNode] = [
+        VariationNode(
+            node_id=0,
+            parent_id=None,
+            move_usi=None,
+            is_mainline=True,
+            snapshot=document.snapshots[0],
+        )
+    ]
+    mainline_ids = [0]
+    for i, usi in enumerate(document.moves_usi):
+        node = VariationNode(
+            node_id=i + 1,
+            parent_id=i,
+            move_usi=usi,
+            is_mainline=True,
+            snapshot=document.snapshots[i + 1],
+        )
+        nodes[i].children.append(node.node_id)
+        nodes.append(node)
+        mainline_ids.append(node.node_id)
+    tree = VariationTree(
+        nodes=nodes, mainline_ids=mainline_ids, current_id=0
+    )
+    if report is not None:
+        apply_report_to_tree(tree, report)
+    return tree
+
+
+def apply_report_to_tree(
+    tree: VariationTree, report: dict[str, Any]
+) -> None:
+    """レポートの ``positions`` を本譜ノードの解析キャッシュに取り込む．
+
+    ``positions[i]`` は「i+1 手目を指す直前の局面」= 本譜ノード i の解析．
+
+    Args:
+        tree: 対象の分岐木．
+        report: analyze-game の JSON レポート (検証済みのもの)．
+    """
+    positions = report.get("positions") or []
+    for i, pos in enumerate(positions):
+        if i < len(tree.mainline_ids):
+            tree.nodes[tree.mainline_ids[i]].analysis = pos
+
+
+def current_node(tree: VariationTree) -> VariationNode:
+    """現在表示中のノードを返す．"""
+    return tree.nodes[tree.current_id]
+
+
+def goto_node(
+    tree: VariationTree, node_id: int
+) -> VariationNode:
+    """指定ノードへ移動する．
+
+    Raises:
+        ValueError: node_id が範囲外の場合．
+    """
+    if not 0 <= node_id < len(tree.nodes):
+        raise ValueError(f"不正なノード ID です: {node_id}")
+    tree.current_id = node_id
+    return tree.nodes[node_id]
+
+
+def advance_move(
+    tree: VariationTree, usi: str
+) -> VariationNode:
+    """現在ノードから指し手 usi で 1 手進める．
+
+    同じ手の子ノードが既にあれば再利用して移動し，なければ合法手検証の
+    うえ子ノードを追加する (本譜から外れた時点で自動的に分岐になる —
+    docs/design/game-analysis/gui.md §8)．
+
+    Args:
+        tree: 対象の分岐木．
+        usi: 指し手 (USI 表記)．
+
+    Returns:
+        移動先のノード．
+
+    Raises:
+        ValueError: usi が現局面の合法手でない場合．
+    """
+    node = tree.nodes[tree.current_id]
+    for child_id in node.children:
+        child = tree.nodes[child_id]
+        if child.move_usi == usi:
+            tree.current_id = child_id
+            return child
+
+    board = Board()
+    board.set_sfen(node.snapshot.sfen)
+    try:
+        move = board.move_from_usi(usi)
+    except ValueError as e:
+        raise ValueError(
+            f"指し手を解釈できません: {usi} ({e})"
+        ) from e
+    if move not in set(board.get_legal_moves()):
+        raise ValueError(
+            f"合法手ではありません: {usi} "
+            f"(局面 {node.snapshot.sfen})"
+        )
+    info = _move_info(board, move)
+    board.push_move(move)
+    child = VariationNode(
+        node_id=len(tree.nodes),
+        parent_id=node.node_id,
+        move_usi=info.usi,
+        is_mainline=False,
+        snapshot=_snapshot(board, node.snapshot.ply + 1, info),
+    )
+    tree.nodes.append(child)
+    node.children.append(child.node_id)
+    tree.current_id = child.node_id
+    return child
+
+
+def path_moves_usi(
+    tree: VariationTree, node_id: int | None = None
+) -> list[str]:
+    """root から指定ノード (省略時は現在ノード) までの USI 経路を返す．
+
+    エンジンには「初期局面 SFEN + この経路」を渡す (千日手履歴を正しく
+    効かせるため — docs/design/game-analysis/gui.md §9)．
+    """
+    node = tree.nodes[
+        tree.current_id if node_id is None else node_id
+    ]
+    moves: list[str] = []
+    while node.parent_id is not None:
+        assert node.move_usi is not None
+        moves.append(node.move_usi)
+        node = tree.nodes[node.parent_id]
+    moves.reverse()
+    return moves
+
+
+def mainline_ancestor(
+    tree: VariationTree, node_id: int | None = None
+) -> VariationNode:
+    """指定ノード (省略時は現在ノード) から最も近い本譜ノードを返す．
+
+    本譜ノード自身を渡した場合はそのノードを返す．「本譜へ戻る」と
+    評価値グラフの現在位置線に使う．
+    """
+    node = tree.nodes[
+        tree.current_id if node_id is None else node_id
+    ]
+    while not node.is_mainline:
+        assert node.parent_id is not None
+        node = tree.nodes[node.parent_id]
+    return node

--- a/src/maou/app/analysis/game_analyzer.py
+++ b/src/maou/app/analysis/game_analyzer.py
@@ -199,6 +199,240 @@ def _turn_char(turn: Turn) -> str:
     return "b" if turn == Turn.BLACK else "w"
 
 
+def build_search_engine(
+    *,
+    model_path: Path | None = None,
+    threads: int = 1,
+    batch_size: int = 8,
+    cuda: bool = False,
+    tensorrt: bool = False,
+    trt_engine_cache_dir: Path | None = None,
+) -> SearchEngine:
+    """評価器を 1 回ロードして再利用する SearchEngine を構築する．
+
+    Args:
+        model_path: ONNX モデルのパス．None なら決定論的な mock 評価器
+            (API 検証/開発用)．
+        threads: 探索スレッド数．
+        batch_size: 評価バッチサイズ．
+        cuda: CUDA Execution Provider を使うか．
+        tensorrt: TensorRT Execution Provider を使うか．
+        trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+
+    Returns:
+        構築済みの SearchEngine．
+    """
+    return SearchEngine(
+        model_path=(
+            str(model_path) if model_path is not None else None
+        ),
+        threads=threads,
+        batch_size=batch_size,
+        use_cuda=cuda,
+        use_tensorrt=tensorrt,
+        trt_engine_cache_dir=(
+            str(trt_engine_cache_dir)
+            if trt_engine_cache_dir is not None
+            else None
+        ),
+    )
+
+
+def position_record(
+    *,
+    ply: int,
+    side: str,
+    sfen: str,
+    result: Any,
+    num_candidates: int,
+    played_usi: str | None = None,
+    record_time_s: int | None = None,
+    record_score: int | None = None,
+    record_comment: str | None = None,
+) -> dict[str, Any]:
+    """1 局面分の解析記録 (JSON 化可能な dict) を作る．
+
+    ``played_move_winrate`` / ``winrate_loss`` は同一局面の
+    root_children 統計から取る (未訪問の手は winrate が「データなし」
+    のため null)．``winrate_loss`` は best との差を 0 で下限クランプ
+    する (訪問数基準の最終手選択では played の Q が best を僅かに
+    上回り得るが，その場合も「損失なし」と扱う)．
+
+    Args:
+        ply: 手数 (この局面から指す手の番号)．
+        side: 手番 ("b" / "w")．
+        sfen: 局面の SFEN．
+        result: SearchEngine.search の結果オブジェクト．
+        num_candidates: 記録する候補手数．
+        played_usi: 実戦で指された手 (USI)．GUI の任意局面解析など
+            実戦手が存在しない場合は None (match=False /
+            winrate_loss=None になる)．
+        record_time_s: 棋譜記載の消費時間 (秒)．
+        record_score: 棋譜記載の評価値．
+        record_comment: 棋譜記載のコメント．
+
+    Returns:
+        analyze-game の ``positions[i]`` スキーマの dict．
+    """
+    best_move = result.best_move
+    children = list(result.root_children)
+    played_child = (
+        next((c for c in children if c.usi == played_usi), None)
+        if played_usi is not None
+        else None
+    )
+    played_winrate = (
+        float(played_child.winrate)
+        if played_child is not None
+        and int(played_child.visits) > 0
+        else None
+    )
+    winrate = float(result.winrate)
+    best_child = (
+        next(
+            (c for c in children if c.usi == best_move),
+            None,
+        )
+        if best_move is not None
+        else None
+    )
+    best_winrate = (
+        float(best_child.winrate)
+        if best_child is not None and int(best_child.visits) > 0
+        else winrate
+    )
+    match = (
+        best_move is not None
+        and played_usi is not None
+        and played_usi == best_move
+    )
+    winrate_loss: float | None
+    if played_usi is None:
+        winrate_loss = None
+    elif match:
+        winrate_loss = 0.0
+    elif played_winrate is not None:
+        winrate_loss = max(best_winrate - played_winrate, 0.0)
+    else:
+        winrate_loss = None
+
+    # 候補手: best を先頭に，残りは訪問回数の降順 (SearchRunner と同じ整列)
+    children_sorted = sorted(
+        children, key=lambda c: int(c.visits), reverse=True
+    )
+    best_first = [
+        c for c in children_sorted if c.usi == best_move
+    ]
+    rest = [c for c in children_sorted if c.usi != best_move]
+    candidates: list[dict[str, Any]] = []
+    for child in (best_first + rest)[:num_candidates]:
+        candidates.append(
+            {
+                "usi": child.usi,
+                "visits": int(child.visits),
+                "winrate": (
+                    float(child.winrate)
+                    if int(child.visits) > 0
+                    else None
+                ),
+                "prior": float(child.prior),
+                "proven": (
+                    float(child.proven)
+                    if child.proven is not None
+                    else None
+                ),
+            }
+        )
+
+    return {
+        "ply": ply,
+        "side_to_move": side,
+        "sfen": sfen,
+        "played_move": played_usi,
+        "best_move": best_move,
+        "match": match,
+        "winrate": winrate,
+        "eval_cp": float(
+            Evaluation.get_eval_from_winrate(winrate)
+        ),
+        "played_move_winrate": played_winrate,
+        "winrate_loss": winrate_loss,
+        "pv": list(result.pv),
+        "candidates": candidates,
+        "mate_found": result.stop == "root_proven",
+        "playouts": int(result.playouts),
+        "elapsed_ms": int(result.elapsed_ms),
+        "stop": result.stop,
+        "record_time_s": record_time_s,
+        "record_score": record_score,
+        "record_comment": record_comment,
+    }
+
+
+def summarize_positions(
+    positions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """per-position 記録から対局サマリを作る．
+
+    worst_moves は winrate_loss の大きい順に上位 5 手 (null は除外)．
+
+    Args:
+        positions: :func:`position_record` の dict のリスト．
+
+    Returns:
+        analyze-game の ``summary`` スキーマの dict．
+    """
+    sides = {"b": "black", "w": "white"}
+    match_rate: dict[str, float | None] = {}
+    mean_winrate_loss: dict[str, float | None] = {}
+    for side, label in sides.items():
+        side_positions = [
+            p for p in positions if p["side_to_move"] == side
+        ]
+        match_rate[label] = (
+            sum(1 for p in side_positions if p["match"])
+            / len(side_positions)
+            if side_positions
+            else None
+        )
+        losses = [
+            p["winrate_loss"]
+            for p in side_positions
+            if p["winrate_loss"] is not None
+        ]
+        mean_winrate_loss[label] = (
+            sum(losses) / len(losses) if losses else None
+        )
+    worst = sorted(
+        (p for p in positions if p["winrate_loss"] is not None),
+        key=lambda p: p["winrate_loss"],
+        reverse=True,
+    )[:5]
+    return {
+        "match_rate": match_rate,
+        "mean_winrate_loss": mean_winrate_loss,
+        "worst_moves": [
+            {
+                "ply": p["ply"],
+                "side": p["side_to_move"],
+                "played": p["played_move"],
+                "best": p["best_move"],
+                "winrate_loss": p["winrate_loss"],
+            }
+            for p in worst
+        ],
+        "mates_found": [
+            {"ply": p["ply"], "side": p["side_to_move"]}
+            for p in positions
+            if p["mate_found"]
+        ],
+        "total_elapsed_ms": sum(
+            p["elapsed_ms"] for p in positions
+        ),
+        "total_playouts": sum(p["playouts"] for p in positions),
+    }
+
+
 class GameAnalyzer:
     """棋譜 1 局を 1 手ずつ 1 局面探索で解析するユースケース．
 
@@ -275,21 +509,13 @@ class GameAnalyzer:
         usi_moves = [move_to_usi(m) for m in moves]
         budgets = option.allocator.allocate(len(moves))
 
-        engine = SearchEngine(
-            model_path=(
-                str(option.model_path)
-                if option.model_path is not None
-                else None
-            ),
+        engine = build_search_engine(
+            model_path=option.model_path,
             threads=option.threads,
             batch_size=option.batch_size,
-            use_cuda=option.cuda,
-            use_tensorrt=option.tensorrt,
-            trt_engine_cache_dir=(
-                str(option.trt_engine_cache_dir)
-                if option.trt_engine_cache_dir is not None
-                else None
-            ),
+            cuda=option.cuda,
+            tensorrt=option.tensorrt,
+            trt_engine_cache_dir=option.trt_engine_cache_dir,
         )
 
         record_times: list[int] = list(record.times)
@@ -329,7 +555,7 @@ class GameAnalyzer:
                     f"の探索に失敗: {e}"
                 ) from e
             positions.append(
-                self._position_record(
+                position_record(
                     ply=ply,
                     side=side,
                     sfen=sfen,
@@ -392,7 +618,7 @@ class GameAnalyzer:
                 option.allocator, budgets
             ),
             "positions": positions,
-            "summary": self._summary(positions),
+            "summary": summarize_positions(positions),
         }
 
     def _parse_record(
@@ -421,182 +647,3 @@ class GameAnalyzer:
                 "time_ms": budgets[0].time_ms,
             }
         return meta
-
-    def _position_record(
-        self,
-        *,
-        ply: int,
-        side: str,
-        sfen: str,
-        played_usi: str,
-        result: Any,
-        num_candidates: int,
-        record_time_s: int | None,
-        record_score: int | None,
-        record_comment: str | None,
-    ) -> dict[str, Any]:
-        """1 局面分の解析記録 (JSON 化可能な dict) を作る．
-
-        ``played_move_winrate`` / ``winrate_loss`` は同一局面の
-        root_children 統計から取る (未訪問の手は winrate が「データなし」
-        のため null)．``winrate_loss`` は best との差を 0 で下限クランプ
-        する (訪問数基準の最終手選択では played の Q が best を僅かに
-        上回り得るが，その場合も「損失なし」と扱う)．
-        """
-        best_move = result.best_move
-        children = list(result.root_children)
-        played_child = next(
-            (c for c in children if c.usi == played_usi), None
-        )
-        played_winrate = (
-            float(played_child.winrate)
-            if played_child is not None
-            and int(played_child.visits) > 0
-            else None
-        )
-        winrate = float(result.winrate)
-        best_child = (
-            next(
-                (c for c in children if c.usi == best_move),
-                None,
-            )
-            if best_move is not None
-            else None
-        )
-        best_winrate = (
-            float(best_child.winrate)
-            if best_child is not None
-            and int(best_child.visits) > 0
-            else winrate
-        )
-        match = (
-            best_move is not None and played_usi == best_move
-        )
-        winrate_loss: float | None
-        if match:
-            winrate_loss = 0.0
-        elif played_winrate is not None:
-            winrate_loss = max(
-                best_winrate - played_winrate, 0.0
-            )
-        else:
-            winrate_loss = None
-
-        # 候補手: best を先頭に，残りは訪問回数の降順 (SearchRunner と同じ整列)
-        children_sorted = sorted(
-            children, key=lambda c: int(c.visits), reverse=True
-        )
-        best_first = [
-            c for c in children_sorted if c.usi == best_move
-        ]
-        rest = [
-            c for c in children_sorted if c.usi != best_move
-        ]
-        candidates: list[dict[str, Any]] = []
-        for child in (best_first + rest)[:num_candidates]:
-            candidates.append(
-                {
-                    "usi": child.usi,
-                    "visits": int(child.visits),
-                    "winrate": (
-                        float(child.winrate)
-                        if int(child.visits) > 0
-                        else None
-                    ),
-                    "prior": float(child.prior),
-                    "proven": (
-                        float(child.proven)
-                        if child.proven is not None
-                        else None
-                    ),
-                }
-            )
-
-        return {
-            "ply": ply,
-            "side_to_move": side,
-            "sfen": sfen,
-            "played_move": played_usi,
-            "best_move": best_move,
-            "match": match,
-            "winrate": winrate,
-            "eval_cp": float(
-                Evaluation.get_eval_from_winrate(winrate)
-            ),
-            "played_move_winrate": played_winrate,
-            "winrate_loss": winrate_loss,
-            "pv": list(result.pv),
-            "candidates": candidates,
-            "mate_found": result.stop == "root_proven",
-            "playouts": int(result.playouts),
-            "elapsed_ms": int(result.elapsed_ms),
-            "stop": result.stop,
-            "record_time_s": record_time_s,
-            "record_score": record_score,
-            "record_comment": record_comment,
-        }
-
-    def _summary(
-        self, positions: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """per-position 記録から対局サマリを作る．
-
-        worst_moves は winrate_loss の大きい順に上位 5 手 (null は除外)．
-        """
-        sides = {"b": "black", "w": "white"}
-        match_rate: dict[str, float | None] = {}
-        mean_winrate_loss: dict[str, float | None] = {}
-        for side, label in sides.items():
-            side_positions = [
-                p
-                for p in positions
-                if p["side_to_move"] == side
-            ]
-            match_rate[label] = (
-                sum(1 for p in side_positions if p["match"])
-                / len(side_positions)
-                if side_positions
-                else None
-            )
-            losses = [
-                p["winrate_loss"]
-                for p in side_positions
-                if p["winrate_loss"] is not None
-            ]
-            mean_winrate_loss[label] = (
-                sum(losses) / len(losses) if losses else None
-            )
-        worst = sorted(
-            (
-                p
-                for p in positions
-                if p["winrate_loss"] is not None
-            ),
-            key=lambda p: p["winrate_loss"],
-            reverse=True,
-        )[:5]
-        return {
-            "match_rate": match_rate,
-            "mean_winrate_loss": mean_winrate_loss,
-            "worst_moves": [
-                {
-                    "ply": p["ply"],
-                    "side": p["side_to_move"],
-                    "played": p["played_move"],
-                    "best": p["best_move"],
-                    "winrate_loss": p["winrate_loss"],
-                }
-                for p in worst
-            ],
-            "mates_found": [
-                {"ply": p["ply"], "side": p["side_to_move"]}
-                for p in positions
-                if p["mate_found"]
-            ],
-            "total_elapsed_ms": sum(
-                p["elapsed_ms"] for p in positions
-            ),
-            "total_playouts": sum(
-                p["playouts"] for p in positions
-            ),
-        }

--- a/src/maou/app/analysis/interactive_analyzer.py
+++ b/src/maou/app/analysis/interactive_analyzer.py
@@ -1,0 +1,369 @@
+"""GUI 常駐の対話解析ユースケース (app 層)．
+
+`maou analyze-gui` の「この局面を解析」「全局面解析」を担う．評価器
+(:class:`maou._rust.maou_search.SearchEngine`) はサーバープロセスで
+1 個だけ遅延構築して使い回す (docs/design/game-analysis/gui.md §11)．
+解析結果は analyze-game の ``positions[i]`` と同一スキーマの dict
+(:func:`maou.app.analysis.game_analyzer.position_record`) で返し，
+CLI と GUI でレポートの相互運用を保つ (同 §9)．
+"""
+
+import logging
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from maou.app.analysis.analysis_session import (
+    GameDocument,
+    VariationTree,
+    path_moves_usi,
+)
+from maou.app.analysis.game_analyzer import (
+    FixedPlayoutsAllocator,
+    FixedTimeAllocator,
+    build_search_engine,
+    position_record,
+    summarize_positions,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# 予算未指定時のデフォルト (1 局面あたり，docs/design/game-analysis/gui.md §3)
+DEFAULT_TIME_MS = 1000
+
+
+@dataclass(frozen=True)
+class EngineSettings:
+    """GUI 常駐エンジンの構築・探索設定．
+
+    :class:`maou.app.analysis.game_analyzer.GameAnalyzer.AnalyzeOption`
+    のエンジン系オプションと同じ意味・デフォルトを持つ．
+
+    Attributes:
+        model_path: ONNX モデルのパス．None なら決定論的な mock 評価器
+            (開発検証専用．GUI に明示される)．
+        threads: 探索スレッド数．
+        batch_size: 評価バッチサイズ．
+        num_candidates: 記録する候補手数．
+        root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
+        root_dfpn_nodes: ルート dfpn のノード予算．
+        root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
+        leaf_mate: MCTS の葉の短手詰み探索 (専用スレッド) を行うか．
+        leaf_mate_nodes: leaf-mate 1 回あたりのノード予算．
+        leaf_mate_threads: leaf-mate 専用スレッド数．
+        cuda: CUDA Execution Provider を使うか．
+        tensorrt: TensorRT Execution Provider を使うか．
+        trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+    """
+
+    model_path: Path | None = None
+    threads: int = 1
+    batch_size: int = 8
+    num_candidates: int = 5
+    root_dfpn: bool = True
+    root_dfpn_nodes: int = 2_000_000
+    root_dfpn_depth: int = 2047
+    leaf_mate: bool = True
+    leaf_mate_nodes: int = 50
+    leaf_mate_threads: int = 1
+    cuda: bool = False
+    tensorrt: bool = False
+    trt_engine_cache_dir: Path | None = None
+
+    def describe(self) -> dict[str, Any]:
+        """レポートの ``engine`` セクション (analyze-game 互換) を返す．"""
+        return {
+            "model_path": (
+                str(self.model_path)
+                if self.model_path is not None
+                else None
+            ),
+            "threads": self.threads,
+            "batch_size": self.batch_size,
+            "cuda": self.cuda,
+            "tensorrt": self.tensorrt,
+            "root_dfpn": self.root_dfpn,
+            "root_dfpn_nodes": self.root_dfpn_nodes,
+            "root_dfpn_depth": self.root_dfpn_depth,
+            "leaf_mate": self.leaf_mate,
+            "leaf_mate_nodes": self.leaf_mate_nodes,
+            "leaf_mate_threads": self.leaf_mate_threads,
+        }
+
+
+def _normalize_budget(
+    time_ms: int | None, max_playouts: int | None
+) -> tuple[int | None, int | None]:
+    """予算を正規化する (両方 None ならデフォルト時間予算)．"""
+    if time_ms is None and max_playouts is None:
+        return DEFAULT_TIME_MS, None
+    return time_ms, max_playouts
+
+
+class InteractiveAnalyzer:
+    """GUI 常駐の対話解析エンジン．
+
+    評価器は初回の解析要求時に 1 回だけ構築する (モデルロードを起動時
+    から解析時まで遅延)．呼び出し側 (Gradio イベント) は
+    ``concurrency_limit=1`` で直列化する前提であり，本クラス自体は
+    スレッドセーフではない．
+    """
+
+    def __init__(self, settings: EngineSettings) -> None:
+        """設定を保持する (エンジンはまだ構築しない)．
+
+        Args:
+            settings: エンジンの構築・探索設定．
+        """
+        self._settings = settings
+        self._engine: Any | None = None
+
+    @property
+    def settings(self) -> EngineSettings:
+        """エンジン設定．"""
+        return self._settings
+
+    @property
+    def is_mock(self) -> bool:
+        """mock 評価器 (モデル未指定，開発検証専用) かどうか．"""
+        return self._settings.model_path is None
+
+    def _ensure_engine(self) -> Any:
+        """SearchEngine を遅延構築して返す．"""
+        if self._engine is None:
+            logger.info(
+                "Building SearchEngine (model=%s)",
+                self._settings.model_path,
+            )
+            self._engine = build_search_engine(
+                model_path=self._settings.model_path,
+                threads=self._settings.threads,
+                batch_size=self._settings.batch_size,
+                cuda=self._settings.cuda,
+                tensorrt=self._settings.tensorrt,
+                trt_engine_cache_dir=(
+                    self._settings.trt_engine_cache_dir
+                ),
+            )
+        return self._engine
+
+    def _search(
+        self,
+        root_sfen: str,
+        moves: list[str],
+        time_ms: int | None,
+        max_playouts: int | None,
+    ) -> Any:
+        """初期局面 + USI 経路で 1 局面探索を実行する．"""
+        engine = self._ensure_engine()
+        s = self._settings
+        return engine.search(
+            root_sfen,
+            moves=moves or None,
+            max_playouts=max_playouts,
+            time_ms=time_ms,
+            root_dfpn=s.root_dfpn,
+            root_dfpn_nodes=s.root_dfpn_nodes,
+            root_dfpn_depth=s.root_dfpn_depth,
+            leaf_mate=s.leaf_mate,
+            leaf_mate_nodes=s.leaf_mate_nodes,
+            leaf_mate_threads=s.leaf_mate_threads,
+        )
+
+    def analyze_position(
+        self,
+        document: GameDocument,
+        tree: VariationTree,
+        node_id: int | None = None,
+        *,
+        time_ms: int | None = None,
+        max_playouts: int | None = None,
+    ) -> dict[str, Any]:
+        """分岐木の 1 ノードの局面を解析する．
+
+        エンジンには「初期局面 SFEN + root からの USI 経路」を渡す
+        (千日手履歴を正しく効かせるため — GameAnalyzer と同じ規約)．
+
+        Args:
+            document: 棋譜の GameDocument．
+            tree: 分岐木．
+            node_id: 対象ノード (省略時は現在ノード)．
+            time_ms: 時間予算 (ミリ秒)．
+            max_playouts: playout 数予算．両方 None なら
+                :data:`DEFAULT_TIME_MS`．
+
+        Returns:
+            analyze-game の ``positions[i]`` スキーマの解析記録．
+            本譜ノードで次の手が既知なら実戦手比較
+            (``played_move`` / ``match`` / ``winrate_loss``) を含む．
+
+        Raises:
+            ValueError: 探索の失敗 (不正局面等)．
+        """
+        node = tree.nodes[
+            tree.current_id if node_id is None else node_id
+        ]
+        time_ms, max_playouts = _normalize_budget(
+            time_ms, max_playouts
+        )
+        moves = path_moves_usi(tree, node.node_id)
+        result = self._search(
+            document.snapshots[0].sfen,
+            moves,
+            time_ms,
+            max_playouts,
+        )
+        ply = node.snapshot.ply
+        played: str | None = None
+        record_time_s: int | None = None
+        record_score: int | None = None
+        record_comment: str | None = None
+        if node.is_mainline and ply < document.n_moves:
+            played = document.moves_usi[ply]
+            if ply < len(document.times):
+                record_time_s = document.times[ply]
+            if ply < len(document.scores):
+                record_score = document.scores[ply]
+            if ply < len(document.comments):
+                record_comment = document.comments[ply] or None
+        return position_record(
+            ply=ply + 1,
+            side=node.snapshot.turn,
+            sfen=node.snapshot.sfen,
+            played_usi=played,
+            result=result,
+            num_candidates=self._settings.num_candidates,
+            record_time_s=record_time_s,
+            record_score=record_score,
+            record_comment=record_comment,
+        )
+
+    def analyze_mainline(
+        self,
+        document: GameDocument,
+        *,
+        time_ms: int | None = None,
+        max_playouts: int | None = None,
+        cancel: threading.Event | None = None,
+    ) -> Iterator[tuple[int, int, dict[str, Any]]]:
+        """本譜の全局面を順に解析するジェネレータ．
+
+        1 局面解析するごとに ``(i, n_moves, 解析記録)`` を yield する
+        (i は 0 始まりの局面番号)．``cancel`` がセットされた時点で
+        以降の局面を解析せずに終了する (実行中の 1 局面は完了を待つ)．
+
+        Args:
+            document: 棋譜の GameDocument．
+            time_ms: 1 局面あたりの時間予算 (ミリ秒)．
+            max_playouts: 1 局面あたりの playout 数予算．
+            cancel: 協調キャンセル用のイベント．
+
+        Yields:
+            ``(局面番号, 総局面数, 解析記録)``．
+        """
+        time_ms, max_playouts = _normalize_budget(
+            time_ms, max_playouts
+        )
+        root_sfen = document.snapshots[0].sfen
+        n = document.n_moves
+        for i in range(n):
+            if cancel is not None and cancel.is_set():
+                logger.info(
+                    "Mainline analysis cancelled at %d/%d", i, n
+                )
+                return
+            snapshot = document.snapshots[i]
+            result = self._search(
+                root_sfen,
+                document.moves_usi[:i],
+                time_ms,
+                max_playouts,
+            )
+            record = position_record(
+                ply=i + 1,
+                side=snapshot.turn,
+                sfen=snapshot.sfen,
+                played_usi=document.moves_usi[i],
+                result=result,
+                num_candidates=self._settings.num_candidates,
+                record_time_s=(
+                    document.times[i]
+                    if i < len(document.times)
+                    else None
+                ),
+                record_score=(
+                    document.scores[i]
+                    if i < len(document.scores)
+                    else None
+                ),
+                record_comment=(
+                    document.comments[i] or None
+                    if i < len(document.comments)
+                    else None
+                ),
+            )
+            yield i, n, record
+
+    def build_report(
+        self,
+        document: GameDocument,
+        positions: list[dict[str, Any]],
+        *,
+        source_name: str,
+        time_ms: int | None = None,
+        max_playouts: int | None = None,
+    ) -> dict[str, Any]:
+        """全局面解析の結果から analyze-game 互換のレポートを組み立てる．
+
+        Args:
+            document: 棋譜の GameDocument．
+            positions: :meth:`analyze_mainline` が返した全解析記録
+                (本譜の手数と同数であること)．
+            source_name: レポートの ``input.path`` に記録する棋譜名
+                (GUI アップロードではファイル名)．
+            time_ms: 使用した時間予算 (ミリ秒)．
+            max_playouts: 使用した playout 数予算．
+
+        Returns:
+            analyze-game の JSON 出力と同一スキーマの dict．
+
+        Raises:
+            ValueError: positions の件数が本譜の手数と一致しない場合．
+        """
+        if len(positions) != document.n_moves:
+            raise ValueError(
+                f"解析記録の件数 {len(positions)} が本譜の手数 "
+                f"{document.n_moves} と一致しません"
+            )
+        time_ms, max_playouts = _normalize_budget(
+            time_ms, max_playouts
+        )
+        allocator = (
+            FixedPlayoutsAllocator(playouts=max_playouts)
+            if max_playouts is not None
+            else FixedTimeAllocator(
+                time_ms=time_ms or DEFAULT_TIME_MS
+            )
+        )
+        budget = allocator.describe()
+        budget["per_position"] = {
+            "max_playouts": max_playouts,
+            "time_ms": time_ms,
+        }
+        return {
+            "input": {
+                "path": source_name,
+                "format": document.input_format,
+                "names": list(document.names),
+                "ratings": list(document.ratings),
+                "win": document.win,
+                "endgame": document.endgame,
+                "n_moves": document.n_moves,
+            },
+            "engine": self._settings.describe(),
+            "budget": budget,
+            "positions": positions,
+            "summary": summarize_positions(positions),
+        }

--- a/src/maou/domain/visualization/board_renderer.py
+++ b/src/maou/domain/visualization/board_renderer.py
@@ -133,6 +133,10 @@ class SVGBoardRenderer:
     COLOR_HIGHLIGHT = (
         "rgba(0,112,243,0.12)"  # ハイライト（モダンブルー）
     )
+    COLOR_SELECTED = "rgba(255,152,0,0.35)"  # クリック選択中のマス（アンバー）
+    COLOR_DESTINATION = (
+        "rgba(76,175,80,0.28)"  # 選択駒の行き先候補（グリーン）
+    )
 
     # 矢印の色設定 (module-level のデフォルトを共有)
     COLOR_ARROW = DEFAULT_ARROW_COLOR
@@ -146,23 +150,34 @@ class SVGBoardRenderer:
         record_id: str | None = None,
         move_arrow: MoveArrow | None = None,
         move_arrows: list[ArrowSpec] | None = None,
+        selected_squares: list[int] | None = None,
+        destination_squares: list[int] | None = None,
+        interactive: bool = False,
     ) -> str:
         """将棋盤をSVGとして描画する．
 
         Args:
             position: 描画する盤面状態
-            highlight_squares: ハイライトするマス（0-80のインデックス）
+            highlight_squares: ハイライトするマス（0-80のインデックス．
+                highlight/selected/destination は row * 9 + col の
+                行優先索引 — 矢印の column-major とは異なる既存仕様）
             turn: 手番（Turn.BLACK または Turn.WHITE）
             record_id: レコードID
             move_arrow: 描画する指し手矢印（Noneの場合は矢印なし）．
                 デフォルトスタイルの ArrowSpec 1 本と等価な後方互換引数
             move_arrows: スタイル付き矢印のリスト（候補手の複数表示等）．
                 move_arrow と併用した場合は move_arrow が先に描画される
+            selected_squares: クリック選択中として塗るマス
+            destination_squares: 選択駒の行き先候補として塗るマス
+            interactive: True でクリック標的の透明 rect
+                (``data-click`` 属性付き) を盤上マスと持ち駒に重ねる
 
         Returns:
             完全なSVG文字列（HTML埋め込み可能）
         """
         highlight_set = set(highlight_squares or [])
+        selected_set = set(selected_squares or [])
+        destination_set = set(destination_squares or [])
         arrows: list[ArrowSpec] = []
         if move_arrow is not None:
             arrows.append(ArrowSpec(move=move_arrow))
@@ -174,13 +189,24 @@ class SVGBoardRenderer:
             self._draw_header(turn, record_id),
             self._draw_grid(),
             self._draw_pieces(
-                position.board_id_positions, highlight_set
+                position.board_id_positions,
+                highlight_set,
+                selected_set,
+                destination_set,
             ),
             self._draw_pieces_in_hand(position.pieces_in_hand),
-            self._draw_arrows(arrows, position.pieces_in_hand),
+            self._draw_arrows(
+                arrows, position.pieces_in_hand, turn
+            ),
             self._draw_coordinates(),
-            self._svg_footer(),
         ]
+        if interactive:
+            svg_parts.append(
+                self._draw_click_targets(
+                    position.pieces_in_hand
+                )
+            )
+        svg_parts.append(self._svg_footer())
 
         return "\n".join(svg_parts)
 
@@ -435,6 +461,8 @@ class SVGBoardRenderer:
         self,
         board_id_positions: list[list[int]],
         highlight_set: set,
+        selected_set: set | None = None,
+        destination_set: set | None = None,
     ) -> str:
         """盤上の駒を描画．
 
@@ -444,8 +472,12 @@ class SVGBoardRenderer:
                 - col: 0=右端(筋9), 8=左端(筋1) ← 将棋の筋は右から左
                 - row: 0=上端(段a), 8=下端(段i) ← 段は上から下
             highlight_set: ハイライトするマスのセット
+            selected_set: クリック選択中として塗るマスのセット
+            destination_set: 行き先候補として塗るマスのセット
         """
         piece_parts = []
+        selected_set = selected_set or set()
+        destination_set = destination_set or set()
 
         # 盤面のX座標開始位置
         board_x_start = (
@@ -462,8 +494,15 @@ class SVGBoardRenderer:
                 # 将棋の筋は右から左なので，描画時に列を反転
                 visual_col = 8 - col  # col 0 → visual 8 (右端)
 
-                # マスのハイライト（駒の有無に関係なく描画）
+                # マスの塗り（駒の有無に関係なく描画）
+                fills = []
                 if square_idx in highlight_set:
+                    fills.append((self.COLOR_HIGHLIGHT, 0.5))
+                if square_idx in selected_set:
+                    fills.append((self.COLOR_SELECTED, 1.0))
+                if square_idx in destination_set:
+                    fills.append((self.COLOR_DESTINATION, 1.0))
+                for fill_color, fill_opacity in fills:
                     x_rect = (
                         board_x_start
                         + visual_col * self.CELL_SIZE
@@ -472,7 +511,7 @@ class SVGBoardRenderer:
                     piece_parts.append(
                         f'<rect x="{x_rect}" y="{y_rect}" '
                         f'width="{self.CELL_SIZE}" height="{self.CELL_SIZE}" '
-                        f'fill="{self.COLOR_HIGHLIGHT}" opacity="0.5"/>'
+                        f'fill="{fill_color}" opacity="{fill_opacity}"/>'
                     )
 
                 # 駒がない場合はスキップ
@@ -704,12 +743,15 @@ class SVGBoardRenderer:
         self,
         arrows: list[ArrowSpec],
         pieces_in_hand: list[int],
+        turn: Turn | None = None,
     ) -> str:
         """指し手を表す矢印群を描画する．
 
         Args:
             arrows: 描画する矢印のリスト（空の場合は空文字列を返す）
             pieces_in_hand: 持ち駒配列（駒打ちの矢印の始点計算に使用）
+            turn: 手番．駒打ち矢印の始点をどちらの持ち駒エリアから
+                引くかの判定に使用（None は先手側）
 
         Returns:
             矢印群のSVG文字列（不正なマス番号の矢印はスキップ）
@@ -721,7 +763,7 @@ class SVGBoardRenderer:
         parts: list[str] = []
         for spec in arrows:
             endpoints = self._arrow_endpoints(
-                spec.move, pieces_in_hand
+                spec.move, pieces_in_hand, turn
             )
             if endpoints is None:
                 continue
@@ -758,12 +800,15 @@ class SVGBoardRenderer:
         self,
         move_arrow: MoveArrow,
         pieces_in_hand: list[int],
+        turn: Turn | None = None,
     ) -> tuple[tuple[float, float], tuple[float, float]] | None:
         """矢印の始点・終点のSVG座標を計算する．
 
         Args:
             move_arrow: 対象の指し手
             pieces_in_hand: 持ち駒配列（駒打ちの始点計算に使用）
+            turn: 手番．後手番の駒打ちは後手持ち駒エリア（左側）を
+                始点にする（None は先手側）
 
         Returns:
             ``((from_x, from_y), (to_x, to_y))``．
@@ -813,20 +858,30 @@ class SVGBoardRenderer:
             move_arrow.is_drop
             and move_arrow.from_square is None
         ):
-            # 駒打ちの場合: 持ち駒エリアから矢印を引く
+            # 駒打ちの場合: 手番側の持ち駒エリアから矢印を引く
+            is_white_drop = turn == Turn.WHITE
+            hand_pieces = (
+                pieces_in_hand[7:14]
+                if is_white_drop
+                else pieces_in_hand[:7]
+            )
             display_index = self._get_hand_piece_display_index(
-                pieces_in_hand[:7],  # 先手の持ち駒
+                hand_pieces,
                 move_arrow.drop_piece_type or 0,
             )
-            # 持ち駒エリア（右側）の座標
-            from_x = (
-                self.MARGIN
-                + self.HAND_AREA_WIDTH
-                + self.GAP_BETWEEN_HAND_AND_BOARD
-                + self.BOARD_WIDTH
-                + self.GAP_BETWEEN_HAND_AND_BOARD
-                + self.HAND_AREA_WIDTH / 2
-            )
+            if is_white_drop:
+                # 後手持ち駒エリア（左側）の座標
+                from_x = self.MARGIN + self.HAND_AREA_WIDTH / 2
+            else:
+                # 先手持ち駒エリア（右側）の座標
+                from_x = (
+                    self.MARGIN
+                    + self.HAND_AREA_WIDTH
+                    + self.GAP_BETWEEN_HAND_AND_BOARD
+                    + self.BOARD_WIDTH
+                    + self.GAP_BETWEEN_HAND_AND_BOARD
+                    + self.HAND_AREA_WIDTH / 2
+                )
             # タイトル(30px) + 余白(20px) + 各駒の位置
             from_y = self.MARGIN + 50 + display_index * 30
         else:
@@ -872,3 +927,75 @@ class SVGBoardRenderer:
             if hand_pieces[i] > 0:
                 display_index += 1
         return display_index
+
+    def _draw_click_targets(
+        self, pieces_in_hand: list[int]
+    ) -> str:
+        """クリック標的の透明 rect レイヤーを描画する．
+
+        盤上の各マスに ``data-click="sq:{square}"`` (square は
+        column-major = col * 9 + row)，持ち駒の各表示行に
+        ``data-click="hand:{b|w}:{piece_type}"`` (piece_type は
+        0=歩...6=飛) を持つ透明 rect を重ねる．矢印より後に描画する
+        ことでクリックが常に標的に当たる．値の解釈は interface 層
+        (analysis_gui) が行う．
+
+        Args:
+            pieces_in_hand: 14要素の持ち駒配列（表示行の計算に使用）
+
+        Returns:
+            クリック標的群のSVG文字列
+        """
+        parts: list[str] = []
+        board_x_start = (
+            self.MARGIN
+            + self.HAND_AREA_WIDTH
+            + self.GAP_BETWEEN_HAND_AND_BOARD
+        )
+
+        # 盤上のマス（描画は visual_col = 8 - col で反転）
+        for row in range(9):
+            for col in range(9):
+                square = col * 9 + row  # column-major
+                x = board_x_start + (8 - col) * self.CELL_SIZE
+                y = self.MARGIN + row * self.CELL_SIZE
+                parts.append(
+                    f'<rect x="{x}" y="{y}" '
+                    f'width="{self.CELL_SIZE}" '
+                    f'height="{self.CELL_SIZE}" '
+                    f'fill="transparent" '
+                    f'data-click="sq:{square}" '
+                    f'style="cursor:pointer"/>'
+                )
+
+        # 持ち駒（枚数 > 0 の表示行のみ．_draw_single_hand と同じ配置）
+        hand_areas = [
+            (
+                "b",
+                pieces_in_hand[:7],
+                board_x_start
+                + self.BOARD_WIDTH
+                + self.GAP_BETWEEN_HAND_AND_BOARD,
+            ),
+            ("w", pieces_in_hand[7:14], self.MARGIN),
+        ]
+        for side, pieces, x_base in hand_areas:
+            display_index = 0
+            for piece_type, count in enumerate(pieces):
+                if count == 0:
+                    continue
+                # テキスト行 (y_base + 50 + display_index * 30,
+                # text-anchor=middle) を覆う矩形
+                y_text = self.MARGIN + 50 + display_index * 30
+                parts.append(
+                    f'<rect x="{x_base + 10}" '
+                    f'y="{y_text - 20}" '
+                    f'width="{self.HAND_AREA_WIDTH - 20}" '
+                    f'height="28" '
+                    f'fill="transparent" '
+                    f'data-click="hand:{side}:{piece_type}" '
+                    f'style="cursor:pointer"/>'
+                )
+                display_index += 1
+
+        return "\n".join(parts)

--- a/src/maou/infra/console/analyze_gui.py
+++ b/src/maou/infra/console/analyze_gui.py
@@ -1,7 +1,8 @@
 """棋譜解析 GUI の CLI コマンド (インフラ層)．
 
 `maou analyze-gui` コマンドの実装を提供する．Gradio 依存は遅延 import
-(``uv sync --extra visualize`` で導入)．
+(``uv sync --extra visualize`` で導入)．エンジン系オプションは
+`maou analyze-game` と同一に維持する (docs/design/game-analysis/gui.md §3)．
 """
 
 from pathlib import Path
@@ -41,10 +42,114 @@ from maou.infra.console.common import (
     required=False,
 )
 @click.option(
+    "--model-path",
+    help=(
+        "Path to the ONNX model file for in-GUI analysis. Uses a "
+        "deterministic mock evaluator when omitted (for development "
+        "only; clearly labeled in the UI)."
+    ),
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    required=False,
+)
+@click.option(
+    "--time-ms",
+    help=(
+        "Default time budget per in-GUI analysis in milliseconds "
+        "(default 1000). Mutually exclusive with --playouts."
+    ),
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--playouts",
+    help=(
+        "Default playout budget per in-GUI analysis. Mutually "
+        "exclusive with --time-ms."
+    ),
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
     "--num-candidates",
     help="Maximum number of candidate moves shown in the UI.",
     type=int,
     default=5,
+    required=False,
+)
+@click.option(
+    "--threads",
+    help="Number of search threads.",
+    type=int,
+    default=1,
+    required=False,
+)
+@click.option(
+    "--batch-size",
+    help="Evaluation batch size.",
+    type=int,
+    default=8,
+    required=False,
+)
+@click.option(
+    "--root-dfpn/--no-root-dfpn",
+    help="Run dfpn mate search on each root position in parallel.",
+    default=True,
+    required=False,
+)
+@click.option(
+    "--root-dfpn-nodes",
+    help="Node budget for the root dfpn mate search.",
+    type=int,
+    default=2_000_000,
+    required=False,
+)
+@click.option(
+    "--root-dfpn-depth",
+    help="Search depth limit for the root dfpn mate search (max 2047).",
+    type=int,
+    default=2047,
+    required=False,
+)
+@click.option(
+    "--leaf-mate/--no-leaf-mate",
+    help="Enable short mate search at MCTS leaves (async).",
+    default=True,
+    required=False,
+)
+@click.option(
+    "--leaf-mate-nodes",
+    help="Node budget per leaf-mate df-pn call.",
+    type=int,
+    default=50,
+    required=False,
+)
+@click.option(
+    "--leaf-mate-threads",
+    help="Number of dedicated leaf-mate threads.",
+    type=int,
+    default=1,
+    required=False,
+)
+@click.option(
+    "--cuda/--no-cuda",
+    help="Enable CUDA Execution Provider.",
+    default=False,
+    required=False,
+)
+@click.option(
+    "--tensorrt/--no-tensorrt",
+    help="Enable TensorRT Execution Provider.",
+    default=False,
+    required=False,
+)
+@click.option(
+    "--trt-cache-dir",
+    help="TensorRT engine cache directory.",
+    type=click.Path(path_type=Path),
+    default=None,
     required=False,
 )
 @click.option(
@@ -72,7 +177,21 @@ from maou.infra.console.common import (
 def analyze_gui(
     input_path: Path | None,
     report: Path | None,
+    model_path: Path | None,
+    time_ms: int | None,
+    playouts: int | None,
     num_candidates: int,
+    threads: int,
+    batch_size: int,
+    root_dfpn: bool,
+    root_dfpn_nodes: int,
+    root_dfpn_depth: int,
+    leaf_mate: bool,
+    leaf_mate_nodes: int,
+    leaf_mate_threads: int,
+    cuda: bool,
+    tensorrt: bool,
+    trt_cache_dir: Path | None,
     port: int | None,
     share: bool,
     server_name: str,
@@ -82,11 +201,18 @@ def analyze_gui(
     This command starts a browser UI for reviewing a game record
     (CSA / KIF) together with an analyze-game JSON report: board view
     with candidate-move arrows, win-rate / eval graph from the sente
-    perspective, move list, and per-position candidate table.
+    perspective, move list, and per-position candidate table. It also
+    supports interactive analysis: playing moves on the board (click
+    input with variation branches), analyzing the current position
+    with the resident engine, and analyzing the whole mainline with a
+    downloadable analyze-game compatible JSON report.
 
     Examples:
         # 棋譜と解析レポートを読み込んで起動
         maou analyze-gui --input-path game.csa --report report.json
+
+        # 実モデルで GUI 内解析 (1 局面 1000ms)
+        maou analyze-gui --input-path game.csa --model-path model.onnx
 
         # 空で起動して UI からアップロード
         maou analyze-gui
@@ -94,7 +220,21 @@ def analyze_gui(
     Args:
         input_path: Game record file loaded at startup.
         report: analyze-game JSON report matching the game record.
+        model_path: ONNX model file for in-GUI analysis.
+        time_ms: Default time budget per in-GUI analysis.
+        playouts: Default playout budget per in-GUI analysis.
         num_candidates: Maximum number of candidate moves shown.
+        threads: Number of search threads.
+        batch_size: Evaluation batch size.
+        root_dfpn: Run dfpn mate search on each root position in parallel.
+        root_dfpn_nodes: Node budget for the root dfpn mate search.
+        root_dfpn_depth: Search depth limit for the root dfpn mate search.
+        leaf_mate: Enable short mate search at MCTS leaves (async).
+        leaf_mate_nodes: Node budget per leaf-mate df-pn call.
+        leaf_mate_threads: Number of dedicated leaf-mate threads.
+        cuda: Enable CUDA Execution Provider.
+        tensorrt: Enable TensorRT Execution Provider.
+        trt_cache_dir: TensorRT engine cache directory.
         port: Gradio server port.
         share: Create a public Gradio link.
         server_name: Server bind address.
@@ -107,8 +247,19 @@ def analyze_gui(
         raise click.UsageError(
             "--num-candidates must be a positive integer."
         )
+    if (cuda or tensorrt) and model_path is None:
+        raise click.UsageError(
+            "--cuda / --tensorrt require --model-path."
+        )
+    if time_ms is not None and playouts is not None:
+        raise click.UsageError(
+            "Specify at most one of --time-ms / --playouts."
+        )
 
     try:
+        from maou.app.analysis.interactive_analyzer import (
+            EngineSettings,
+        )
         from maou.infra.visualization.analysis_gui_server import (
             launch_analysis_gui_server,
         )
@@ -128,11 +279,30 @@ def analyze_gui(
             "(localhost not accessible in Colab)"
         )
 
+    engine_settings = EngineSettings(
+        model_path=model_path,
+        threads=threads,
+        batch_size=batch_size,
+        num_candidates=num_candidates,
+        root_dfpn=root_dfpn,
+        root_dfpn_nodes=root_dfpn_nodes,
+        root_dfpn_depth=root_dfpn_depth,
+        leaf_mate=leaf_mate,
+        leaf_mate_nodes=leaf_mate_nodes,
+        leaf_mate_threads=leaf_mate_threads,
+        cuda=cuda,
+        tensorrt=tensorrt,
+        trt_engine_cache_dir=trt_cache_dir,
+    )
+
     try:
         launch_analysis_gui_server(
             kifu_path=input_path,
             report_path=report,
             num_candidates=num_candidates,
+            engine_settings=engine_settings,
+            default_time_ms=time_ms,
+            default_playouts=playouts,
             port=port,
             share=share,
             server_name=server_name,

--- a/src/maou/infra/visualization/analysis_gui_server.py
+++ b/src/maou/infra/visualization/analysis_gui_server.py
@@ -1,14 +1,25 @@
 """棋譜解析 GUI (analyze-gui) の Gradio サーバー (インフラ層)．
 
 gr.Blocks の構築とイベント配線のみを担い，表示整形は interface 層
-(:mod:`maou.interface.analysis_gui`)，セッション状態の構築は app 層に
-委譲する．セッション状態 (:class:`SessionView`) は plain data で
+(:mod:`maou.interface.analysis_gui`)，セッション状態・分岐木・エンジン
+呼び出しは app 層に委譲する (interface 経由)．セッション状態
+(:class:`SessionView` / 分岐木 / クリック状態) は plain data で
 ``gr.State`` に保持する (ブラウザセッションごとに独立)．
+
+エンジン (:class:`InteractiveAnalyzer`) はサーバープロセスで 1 個を
+共有し，探索系イベントは ``concurrency_id="engine"`` +
+``concurrency_limit=1`` で直列化する
+(docs/design/game-analysis/gui.md §11)．
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import tempfile
+import threading
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +27,13 @@ import gradio as gr
 import plotly.graph_objects as go
 
 from maou.interface import analysis_gui
-from maou.interface.analysis_gui import SessionView
+from maou.interface.analysis_gui import (
+    ClickState,
+    EngineSettings,
+    InteractiveAnalyzer,
+    SessionView,
+    VariationTree,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -24,6 +41,57 @@ _EMPTY_BOARD_HTML = (
     "<p>棋譜が読み込まれていません．下の「棋譜/レポートの読み込み」"
     "からファイルを読み込んでください．</p>"
 )
+
+# Gradio 6 では JS から Textbox の値を変更しても .input()/.change() が
+# 発火しない (game_graph_shared.py 参照)．gr.HTML の server_functions +
+# js_on_load で JS → Python を直接呼び出し，trigger("change") で
+# .change() コールバックを発火する．
+_BOARD_CLICK_JS_ON_LOAD = (
+    "window.__maou_board_click = "
+    "{server: server, trigger: trigger};"
+)
+
+# 盤面 SVG のクリック標的 ([data-click] rect) の委譲リスナー．
+# gr.HTML は innerHTML 差し替えのため，永続する外側コンテナ
+# (#board-display) に 1 回だけリスナーを付ける．
+_HEAD_SCRIPTS = """
+<script>
+(function() {
+    function onBoardClick(e) {
+        var target = e.target.closest('[data-click]');
+        if (!target) return;
+        var bridge = window.__maou_board_click;
+        if (!bridge || !bridge.server) {
+            console.warn('[maou] board click bridge not ready');
+            return;
+        }
+        bridge.server.handle_board_click(target.getAttribute('data-click'))
+            .then(function(ok) { if (ok) bridge.trigger('change'); })
+            .catch(function(err) {
+                console.error('[maou] board click failed:', err);
+            });
+    }
+    function attach() {
+        var container = document.getElementById('board-display');
+        if (!container || container._maouClickAttached) return;
+        container._maouClickAttached = true;
+        container.addEventListener('click', onBoardClick);
+    }
+    var observer = new MutationObserver(attach);
+    function start() {
+        observer.observe(document.body, {childList: true, subtree: true});
+        attach();
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();
+</script>
+"""
+
+_CUSTOM_CSS = ".maou-hidden {display: none !important;}"
 
 
 def _empty_figure() -> go.Figure:
@@ -59,6 +127,7 @@ class AnalysisGuiServer:
     Attributes:
         num_candidates: 候補手表示数の上限 (スライダー最大値)．
         initial_view: CLI 引数から構築した初期セッション (任意)．
+        initial_tree: 初期セッションの分岐木 (任意)．
     """
 
     def __init__(
@@ -67,6 +136,9 @@ class AnalysisGuiServer:
         kifu_path: Path | None = None,
         report_path: Path | None = None,
         num_candidates: int = 5,
+        engine_settings: EngineSettings | None = None,
+        default_time_ms: int | None = None,
+        default_playouts: int | None = None,
     ) -> None:
         """CLI 引数から初期状態を構築する．
 
@@ -75,6 +147,11 @@ class AnalysisGuiServer:
             report_path: analyze-game の JSON レポート
                 (kifu_path と併せて指定)．
             num_candidates: 候補手表示数の上限．
+            engine_settings: GUI 内解析のエンジン設定．None なら
+                mock 評価器のデフォルト設定 (開発検証専用)．
+            default_time_ms: GUI 内解析のデフォルト時間予算 (ミリ秒)．
+            default_playouts: GUI 内解析のデフォルト playout 数予算
+                (指定時は時間予算より優先して初期選択)．
 
         Raises:
             ValueError: report_path のみ指定された場合，または棋譜/
@@ -85,7 +162,21 @@ class AnalysisGuiServer:
                 "--report は --input-path と併せて指定してください"
             )
         self.num_candidates = max(1, num_candidates)
+        self._analyzer = InteractiveAnalyzer(
+            engine_settings
+            or EngineSettings(
+                num_candidates=self.num_candidates
+            )
+        )
+        self._default_playouts = default_playouts
+        self._default_time_ms = (
+            default_time_ms
+            if default_time_ms is not None
+            else analysis_gui.DEFAULT_TIME_MS
+        )
+        self._cancel_event = threading.Event()
         self.initial_view: SessionView | None = None
+        self.initial_tree: VariationTree | None = None
         if kifu_path is not None:
             report_json = (
                 report_path.read_text(encoding="utf-8")
@@ -97,46 +188,751 @@ class AnalysisGuiServer:
                 kifu_path.name,
                 report_json,
             )
+            self.initial_tree = (
+                analysis_gui.build_variation_tree(
+                    self.initial_view.document,
+                    self.initial_view.report,
+                )
+            )
 
     # ------------------------------------------------------------------
-    # イベントハンドラ
+    # 表示ヘルパ
     # ------------------------------------------------------------------
 
-    def _render(
+    def _engine_note(self) -> str:
+        """エンジン設定の説明行 (mock 明示) を返す．"""
+        settings = self._analyzer.settings
+        if self._analyzer.is_mock:
+            return (
+                "⚠️ **mock 評価器** (開発検証専用．実モデルは "
+                "`--model-path` で指定)"
+            )
+        return f"エンジン: `{settings.model_path}`"
+
+    def _budget(
+        self, budget_mode: str, budget_value: Any
+    ) -> tuple[int | None, int | None]:
+        """予算 UI の値を (time_ms, max_playouts) にする．"""
+        try:
+            value = int(budget_value)
+        except (TypeError, ValueError):
+            value = 0
+        if value <= 0:
+            return self._default_time_ms, None
+        if budget_mode == "playouts":
+            return None, value
+        return value, None
+
+    def _render_node(
         self,
         view: SessionView | None,
-        ply: Any,
+        tree: VariationTree | None,
+        click: ClickState | None,
         show_arrows: bool,
         show_pv: bool,
         top_n: Any,
         y_mode: str,
-    ) -> tuple[str, go.Figure, list[list[str]], str, str, str]:
-        """現在の状態から表示系出力 (盤面/グラフ/候補手/局面情報) を作る．"""
-        if view is None:
+    ) -> tuple[Any, ...]:
+        """現在ノードの表示系出力 13 要素 (node_outputs) を作る．
+
+        戻り値の順序: (tree, click, board, plot, candidates, sfen,
+        position, note, breadcrumb, dropdown 更新, click 状態表示,
+        成るボタン可視更新, 成らずボタン可視更新)．
+        成/不成の可視は gr.Row でなくボタン単位で更新する
+        (Gradio 6 では Row への visible 更新が効かない)．
+        """
+        if view is None or tree is None:
             return (
+                tree,
+                ClickState(),
                 _EMPTY_BOARD_HTML,
                 _empty_figure(),
                 [],
                 "",
                 "",
                 "",
+                "",
+                gr.update(choices=[], value=None),
+                "",
+                gr.update(visible=False),
+                gr.update(visible=False),
             )
-        ply_int = _clamp_ply(view, ply)
-        board = analysis_gui.board_svg(
-            view,
-            ply_int,
+        click = click or ClickState()
+        snapshot = analysis_gui.current_node(tree).snapshot
+        legal = analysis_gui.node_legal_moves(tree)
+        board = analysis_gui.node_board_svg(
+            tree,
             show_candidates=bool(show_arrows),
             show_pv=bool(show_pv),
             top_n=int(top_n),
+            click_state=click,
+            legal=legal,
+            interactive=True,
         )
-        fig = analysis_gui.eval_figure(view, ply_int, y_mode)
-        candidates = analysis_gui.candidates_table(
-            view, ply_int, int(top_n)
+        fig = analysis_gui.eval_figure(
+            view, analysis_gui.mainline_ply(tree), y_mode
         )
-        sfen, position_str, note = analysis_gui.position_info(
-            view, ply_int
+        candidates = analysis_gui.node_candidates_table(
+            tree, int(top_n)
         )
-        return board, fig, candidates, sfen, position_str, note
+        sfen, position_str, note = (
+            analysis_gui.node_position_info(view, tree)
+        )
+        breadcrumb = analysis_gui.breadcrumb_markdown(tree)
+        dropdown = gr.update(
+            choices=analysis_gui.legal_move_choices(
+                snapshot, legal
+            ),
+            value=None,
+        )
+        click_status = analysis_gui.click_status_text(
+            snapshot, click
+        )
+        promo_visible = bool(click.pending_usis)
+        return (
+            tree,
+            click,
+            board,
+            fig,
+            candidates,
+            sfen,
+            position_str,
+            note,
+            breadcrumb,
+            dropdown,
+            click_status,
+            gr.update(visible=promo_visible),
+            gr.update(visible=promo_visible),
+        )
+
+    def _nav_outputs(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """node_outputs + スライダー更新 (14 要素) を作る．
+
+        現在ノードが本譜上ならスライダー値を追随させ，分岐中は
+        変更しない (スライダーは本譜ナビゲーション専用)．
+        """
+        rendered = self._render_node(
+            view,
+            tree,
+            click,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+        slider: Any = gr.update()
+        if tree is not None:
+            node = analysis_gui.current_node(tree)
+            if node.is_mainline:
+                slider = gr.update(value=node.snapshot.ply)
+        return (*rendered, slider)
+
+    # ------------------------------------------------------------------
+    # ナビゲーション系イベントハンドラ
+    # ------------------------------------------------------------------
+
+    def _on_slider(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        ply: Any,
+    ) -> tuple[Any, ...]:
+        """スライダー操作: 本譜の該当局面へ移動する (選択は解除)．"""
+        if view is not None and tree is not None:
+            ply_int = _clamp_ply(view, ply)
+            analysis_gui.goto_node(
+                tree, tree.mainline_ids[ply_int]
+            )
+        return self._render_node(
+            view,
+            tree,
+            ClickState(),
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_display(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """表示オプション変更: 現在ノードを再描画する．"""
+        return self._render_node(
+            view,
+            tree,
+            click,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _goto_and_render(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        node_id: int | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """指定ノードへ移動して nav_outputs を返す (選択は解除)．"""
+        if tree is not None and node_id is not None:
+            analysis_gui.goto_node(tree, node_id)
+        return self._nav_outputs(
+            view,
+            tree,
+            ClickState(),
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_first(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """最初へ: root (初期局面) に移動する．"""
+        node_id = (
+            tree.mainline_ids[0] if tree is not None else None
+        )
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_last(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """最後へ: 本譜の最終局面に移動する．"""
+        node_id = (
+            tree.mainline_ids[-1] if tree is not None else None
+        )
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_prev(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """前へ: 親ノードに移動する (分岐中もそのまま遡れる)．"""
+        node_id: int | None = None
+        if tree is not None:
+            node = analysis_gui.current_node(tree)
+            node_id = (
+                node.parent_id
+                if node.parent_id is not None
+                else node.node_id
+            )
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_next(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """次へ: 子ノードに移動する (本譜の子を優先)．"""
+        node_id: int | None = None
+        if tree is not None:
+            node = analysis_gui.current_node(tree)
+            if node.children:
+                node_id = next(
+                    (
+                        cid
+                        for cid in node.children
+                        if tree.nodes[cid].is_mainline
+                    ),
+                    node.children[0],
+                )
+            else:
+                node_id = node.node_id
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_back_mainline(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """本譜へ戻る: 分岐点の本譜側ノードに移動する．"""
+        node_id: int | None = None
+        if tree is not None:
+            node_id = analysis_gui.mainline_ancestor(
+                tree
+            ).node_id
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_move_select(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        evt: gr.SelectData,
+    ) -> tuple[Any, ...]:
+        """棋譜テーブルの行クリック: その手の後の本譜局面へ移動する．"""
+        node_id: int | None = None
+        if view is not None and tree is not None:
+            ply = _clamp_ply(view, evt.index[0] + 1)
+            node_id = tree.mainline_ids[ply]
+        return self._goto_and_render(
+            view,
+            tree,
+            node_id,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    # ------------------------------------------------------------------
+    # 指し手入力系イベントハンドラ (分岐)
+    # ------------------------------------------------------------------
+
+    def _play_usi(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        usi: str | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """指し手 1 手を現在ノードから進める (分岐の共通経路)．"""
+        if view is None or tree is None:
+            raise gr.Error("棋譜を読み込んでください")
+        if usi:
+            try:
+                analysis_gui.advance_move(tree, usi)
+            except ValueError as e:
+                raise gr.Error(f"指せません: {e}") from e
+        return self._nav_outputs(
+            view,
+            tree,
+            ClickState(),
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_play_dropdown(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        usi: str | None,
+    ) -> tuple[Any, ...]:
+        """合法手 Dropdown + 「指す」ボタン (フォールバック入力)．"""
+        return self._play_usi(
+            view, tree, usi, show_arrows, show_pv, top_n, y_mode
+        )
+
+    def _on_candidate_select(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        evt: gr.SelectData,
+    ) -> tuple[Any, ...]:
+        """候補手テーブルの行クリック: その手で分岐して進める．"""
+        usi: str | None = None
+        if tree is not None:
+            node = analysis_gui.current_node(tree)
+            usi = analysis_gui.candidate_usi(
+                node.analysis, int(evt.index[0]), int(top_n)
+            )
+        return self._play_usi(
+            view, tree, usi, show_arrows, show_pv, top_n, y_mode
+        )
+
+    def _on_pv_play(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """PV 再生: 現在ノードの解析 PV を分岐として一括で進める．"""
+        if view is None or tree is None:
+            raise gr.Error("棋譜を読み込んでください")
+        node = analysis_gui.current_node(tree)
+        pv = list((node.analysis or {}).get("pv") or [])
+        if not pv:
+            raise gr.Error(
+                "この局面に解析 PV がありません "
+                "(先に「この局面を解析」を実行してください)"
+            )
+        for usi in pv:
+            try:
+                analysis_gui.advance_move(tree, usi)
+            except ValueError:
+                logger.warning(
+                    "PV の指し手を適用できません: %s", usi
+                )
+                break
+        return self._nav_outputs(
+            view,
+            tree,
+            ClickState(),
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _apply_board_click(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        value: str,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+    ) -> tuple[Any, ...]:
+        """盤面クリック 1 回分を状態機械に適用する．"""
+        if view is None or tree is None or not value:
+            return self._nav_outputs(
+                view,
+                tree,
+                click,
+                show_arrows,
+                show_pv,
+                top_n,
+                y_mode,
+            )
+        click = click or ClickState()
+        node = analysis_gui.current_node(tree)
+        legal = analysis_gui.node_legal_moves(tree)
+        new_click, usi = analysis_gui.handle_board_click(
+            legal, click, value, node.snapshot.turn
+        )
+        if usi is not None:
+            try:
+                analysis_gui.advance_move(tree, usi)
+            except ValueError as e:
+                raise gr.Error(f"指せません: {e}") from e
+            new_click = ClickState()
+        return self._nav_outputs(
+            view,
+            tree,
+            new_click,
+            show_arrows,
+            show_pv,
+            top_n,
+            y_mode,
+        )
+
+    def _on_promotion_choice(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        *,
+        promote: bool,
+    ) -> tuple[Any, ...]:
+        """成/不成の確認ボタン: 保留中の指し手を確定する．"""
+        click = click or ClickState()
+        usi: str | None = None
+        if len(click.pending_usis) == 2:
+            usi = click.pending_usis[0 if promote else 1]
+        return self._play_usi(
+            view, tree, usi, show_arrows, show_pv, top_n, y_mode
+        )
+
+    # ------------------------------------------------------------------
+    # 解析系イベントハンドラ (エンジン)
+    # ------------------------------------------------------------------
+
+    def _analyze_current(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        budget_mode: str,
+        budget_value: Any,
+        *,
+        force: bool,
+    ) -> tuple[Any, ...]:
+        """現在ノードの 1 局面解析 (キャッシュ再利用 / force で上書き)．"""
+        if view is None or tree is None:
+            raise gr.Error("棋譜を読み込んでください")
+        node = analysis_gui.current_node(tree)
+        if node.analysis is not None and not force:
+            status = (
+                "この局面は解析済みです (キャッシュ表示中．"
+                "「再解析」で上書きできます)"
+            )
+        else:
+            time_ms, playouts = self._budget(
+                budget_mode, budget_value
+            )
+            try:
+                record = self._analyzer.analyze_position(
+                    view.document,
+                    tree,
+                    node.node_id,
+                    time_ms=time_ms,
+                    max_playouts=playouts,
+                )
+            except ValueError as e:
+                raise gr.Error(
+                    f"解析に失敗しました: {e}"
+                ) from e
+            node.analysis = record
+            status = (
+                f"解析完了: {record['playouts']} playouts / "
+                f"{record['elapsed_ms']} ms"
+            )
+            if self._analyzer.is_mock:
+                status += " ⚠️ mock 評価器 (開発検証専用)"
+        return (
+            *self._nav_outputs(
+                view,
+                tree,
+                click,
+                show_arrows,
+                show_pv,
+                top_n,
+                y_mode,
+            ),
+            status,
+        )
+
+    def _on_analyze_all(
+        self,
+        view: SessionView | None,
+        tree: VariationTree | None,
+        click: ClickState | None,
+        show_arrows: bool,
+        show_pv: bool,
+        top_n: Any,
+        y_mode: str,
+        budget_mode: str,
+        budget_value: Any,
+    ) -> Any:
+        """全局面解析 (ジェネレータ: 進捗を逐次 yield，キャンセル対応)．
+
+        出力順: (state, *nav_outputs, move_df, summary_md,
+        report_download, analyze_status)．
+        """
+        if view is None or tree is None:
+            raise gr.Error("棋譜を読み込んでください")
+        self._cancel_event.clear()
+        time_ms, playouts = self._budget(
+            budget_mode, budget_value
+        )
+        n = view.document.n_moves
+        noop_nav = tuple(gr.update() for _ in range(14))
+
+        def _progress(
+            message: str,
+        ) -> tuple[Any, ...]:
+            return (
+                gr.update(),
+                *noop_nav,
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                message,
+            )
+
+        yield _progress(f"全局面解析を開始します (全 {n} 局面)")
+        positions: list[dict[str, Any]] = []
+        for i, total, record in self._analyzer.analyze_mainline(
+            view.document,
+            time_ms=time_ms,
+            max_playouts=playouts,
+            cancel=self._cancel_event,
+        ):
+            positions.append(record)
+            tree.nodes[tree.mainline_ids[i]].analysis = record
+            yield _progress(
+                f"全局面解析中 … {i + 1}/{total} 局面"
+            )
+
+        if len(positions) < n:
+            status = (
+                f"キャンセルしました ({len(positions)}/{n} 局面まで"
+                "解析済み．結果は各局面のキャッシュに反映されています)"
+            )
+            yield (
+                gr.update(),
+                *self._nav_outputs(
+                    view,
+                    tree,
+                    click,
+                    show_arrows,
+                    show_pv,
+                    top_n,
+                    y_mode,
+                ),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                status,
+            )
+            return
+
+        report = self._analyzer.build_report(
+            view.document,
+            positions,
+            source_name=view.source_name or "uploaded",
+            time_ms=time_ms,
+            max_playouts=playouts,
+        )
+        new_view = replace(view, report=report)
+        report_path = self._write_report_file(report)
+        status = f"全局面解析が完了しました (全 {n} 局面)"
+        if self._analyzer.is_mock:
+            status += " ⚠️ mock 評価器 (開発検証専用)"
+        yield (
+            new_view,
+            *self._nav_outputs(
+                new_view,
+                tree,
+                click,
+                show_arrows,
+                show_pv,
+                top_n,
+                y_mode,
+            ),
+            analysis_gui.move_table(new_view),
+            analysis_gui.summary_markdown(new_view),
+            gr.update(value=report_path, visible=True),
+            status,
+        )
+
+    def _on_cancel(self) -> str:
+        """全局面解析のキャンセル要求 (実行中の 1 局面は完了を待つ)．"""
+        self._cancel_event.set()
+        return "キャンセルを要求しました (実行中の局面の完了後に停止します)"
+
+    @staticmethod
+    def _write_report_file(report: dict[str, Any]) -> str:
+        """レポート JSON をダウンロード用の一時ファイルに書き出す．"""
+        fd, path = tempfile.mkstemp(
+            prefix="maou-analyze-report-", suffix=".json"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(report, f, ensure_ascii=False, indent=2)
+        return path
+
+    # ------------------------------------------------------------------
+    # 読み込み
+    # ------------------------------------------------------------------
 
     def _on_load(
         self,
@@ -147,7 +943,11 @@ class AnalysisGuiServer:
         top_n: Any,
         y_mode: str,
     ) -> tuple[Any, ...]:
-        """棋譜 (+ レポート) を読み込み，全出力を更新する．"""
+        """棋譜 (+ レポート) を読み込み，全出力を更新する．
+
+        出力順: (state, *node_outputs, ply_slider, move_df,
+        summary_md, load_status)．
+        """
         kifu_path = _file_path(kifu_file)
         if kifu_path is None:
             raise gr.Error(
@@ -169,11 +969,8 @@ class AnalysisGuiServer:
             raise gr.Error(
                 f"読み込みに失敗しました: {e}"
             ) from e
-
-        board, fig, candidates, sfen, position_str, note = (
-            self._render(
-                view, 0, show_arrows, show_pv, top_n, y_mode
-            )
+        tree = analysis_gui.build_variation_tree(
+            view.document, view.report
         )
         status = (
             f"読み込みました: {kifu_path.name} "
@@ -187,16 +984,19 @@ class AnalysisGuiServer:
         )
         return (
             view,
+            *self._render_node(
+                view,
+                tree,
+                ClickState(),
+                show_arrows,
+                show_pv,
+                top_n,
+                y_mode,
+            ),
             gr.update(maximum=view.document.n_moves, value=0),
             analysis_gui.move_table(view),
             analysis_gui.summary_markdown(view),
             status,
-            board,
-            fig,
-            candidates,
-            sfen,
-            position_str,
-            note,
         )
 
     # ------------------------------------------------------------------
@@ -206,23 +1006,55 @@ class AnalysisGuiServer:
     def create_demo(self) -> gr.Blocks:
         """gr.Blocks を構築して返す．"""
         view = self.initial_view
+        tree = self.initial_tree
         initial_max = (
             view.document.n_moves if view is not None else 1
         )
         initial_top_n = min(5, self.num_candidates)
         (
+            _tree,
+            _click,
             initial_board,
             initial_fig,
             initial_candidates,
             initial_sfen,
             initial_position,
             initial_note,
-        ) = self._render(
-            view, 0, True, False, initial_top_n, "winrate"
+            initial_breadcrumb,
+            _dd,
+            initial_click_status,
+            _promo1,
+            _promo2,
+        ) = self._render_node(
+            view,
+            tree,
+            ClickState(),
+            True,
+            False,
+            initial_top_n,
+            "winrate",
+        )
+        initial_choices: list[tuple[str, str]] = []
+        if view is not None and tree is not None:
+            snapshot = analysis_gui.current_node(tree).snapshot
+            initial_choices = analysis_gui.legal_move_choices(
+                snapshot, analysis_gui.node_legal_moves(tree)
+            )
+        initial_budget_mode = (
+            "playouts"
+            if self._default_playouts is not None
+            else "time"
+        )
+        initial_budget_value = (
+            self._default_playouts
+            if self._default_playouts is not None
+            else self._default_time_ms
         )
 
         with gr.Blocks(title="maou 棋譜解析") as demo:
             state = gr.State(view)
+            tree_state = gr.State(tree)
+            click_state = gr.State(ClickState())
             gr.Markdown("# maou 棋譜解析 (analyze-gui)")
             summary_md = gr.Markdown(
                 analysis_gui.summary_markdown(view)
@@ -234,18 +1066,44 @@ class AnalysisGuiServer:
                     board_html = gr.HTML(
                         initial_board, elem_id="board-display"
                     )
+                    breadcrumb_md = gr.Markdown(
+                        initial_breadcrumb
+                    )
+                    click_status_md = gr.Markdown(
+                        initial_click_status
+                    )
+                    with gr.Row():
+                        promote_btn = gr.Button(
+                            "成る",
+                            variant="primary",
+                            visible=False,
+                        )
+                        nonpromote_btn = gr.Button(
+                            "成らず", visible=False
+                        )
                     with gr.Row():
                         btn_first = gr.Button("|◀ 最初")
                         btn_prev = gr.Button("◀ 前")
                         btn_next = gr.Button("次 ▶")
                         btn_last = gr.Button("最後 ▶|")
+                        back_main_btn = gr.Button("本譜へ戻る")
                     ply_slider = gr.Slider(
                         minimum=0,
                         maximum=initial_max,
                         step=1,
                         value=0,
-                        label="局面 (0 = 初期局面)",
+                        label="局面 (0 = 初期局面，本譜)",
                     )
+                    with gr.Row():
+                        move_dd = gr.Dropdown(
+                            choices=initial_choices,
+                            value=None,
+                            label=(
+                                "指し手 (盤面クリックの代替入力)"
+                            ),
+                        )
+                        play_btn = gr.Button("指す")
+                        pv_btn = gr.Button("PV を分岐で再生")
                     with gr.Row():
                         arrows_cb = gr.Checkbox(
                             value=True, label="候補手矢印"
@@ -305,7 +1163,49 @@ class AnalysisGuiServer:
                             ),
                             value=initial_candidates,
                             interactive=False,
-                            label="現局面の候補手 (勝率は手番視点)",
+                            label=(
+                                "現局面の候補手 (勝率は手番視点)．"
+                                "行クリックでその手に分岐"
+                            ),
+                        )
+                    with gr.Accordion(
+                        "解析 (エンジン)", open=True
+                    ):
+                        gr.Markdown(self._engine_note())
+                        with gr.Row():
+                            budget_mode = gr.Radio(
+                                choices=[
+                                    ("時間 (ms)", "time"),
+                                    ("playouts", "playouts"),
+                                ],
+                                value=initial_budget_mode,
+                                label="予算の種類",
+                            )
+                            budget_value = gr.Number(
+                                value=initial_budget_value,
+                                precision=0,
+                                label="予算値",
+                            )
+                        with gr.Row():
+                            analyze_btn = gr.Button(
+                                "この局面を解析",
+                                variant="primary",
+                            )
+                            reanalyze_btn = gr.Button(
+                                "再解析 (上書き)"
+                            )
+                        with gr.Row():
+                            analyze_all_btn = gr.Button(
+                                "全局面解析"
+                            )
+                            cancel_btn = gr.Button("キャンセル")
+                        analyze_status = gr.Markdown()
+                        report_download = gr.File(
+                            label=(
+                                "解析レポート JSON (ダウンロード)"
+                            ),
+                            visible=False,
+                            interactive=False,
                         )
             with gr.Accordion(
                 "棋譜/レポートの読み込み",
@@ -327,72 +1227,187 @@ class AnalysisGuiServer:
                 )
                 load_status = gr.Markdown()
 
-            render_inputs = [
+            # --- 盤面クリックブリッジ (server_functions) ---
+            # WARNING: pending_click はクロージャとして全セッションに
+            # 共有される (game_graph_server.py の _pending と同じ制約．
+            # ローカル解析ツールとして単一利用者を前提とする)
+            pending_click: dict[str, str] = {}
+
+            def handle_board_click(value: str) -> bool:
+                """JS から呼ばれる server_function．"""
+                if not value:
+                    return False
+                pending_click["value"] = str(value)
+                return True
+
+            click_bridge = gr.HTML(
+                value="",
+                elem_id="board-click-bridge",
+                elem_classes=["maou-hidden"],
+                server_functions=[handle_board_click],
+                js_on_load=_BOARD_CLICK_JS_ON_LOAD,
+            )
+
+            # --- イベント配線 ---
+
+            ctx_inputs = [
                 state,
-                ply_slider,
+                tree_state,
+                click_state,
                 arrows_cb,
                 pv_cb,
                 topn_slider,
                 y_mode,
             ]
-            render_outputs = [
+            node_outputs = [
+                tree_state,
+                click_state,
                 board_html,
                 plot,
                 cand_df,
                 sfen_box,
                 position_box,
                 note_md,
+                breadcrumb_md,
+                move_dd,
+                click_status_md,
+                promote_btn,
+                nonpromote_btn,
             ]
+            nav_outputs = [*node_outputs, ply_slider]
 
+            ply_slider.release(
+                self._on_slider,
+                inputs=[*ctx_inputs, ply_slider],
+                outputs=node_outputs,
+            )
             for component in (
-                ply_slider,
                 arrows_cb,
                 pv_cb,
                 topn_slider,
                 y_mode,
             ):
                 component.change(
-                    self._render,
-                    inputs=render_inputs,
-                    outputs=render_outputs,
+                    self._on_display,
+                    inputs=ctx_inputs,
+                    outputs=node_outputs,
                 )
 
             btn_first.click(
-                lambda: 0, inputs=None, outputs=ply_slider
+                self._on_first,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
             )
             btn_prev.click(
-                lambda ply: max(0, int(ply) - 1),
-                inputs=ply_slider,
-                outputs=ply_slider,
+                self._on_prev,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
             )
             btn_next.click(
-                lambda view, ply: _clamp_ply(
-                    view, int(ply) + 1
-                ),
-                inputs=[state, ply_slider],
-                outputs=ply_slider,
+                self._on_next,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
             )
             btn_last.click(
-                lambda view: (
-                    view.document.n_moves
-                    if view is not None
-                    else 0
+                self._on_last,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            back_main_btn.click(
+                self._on_back_mainline,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            move_df.select(
+                self._on_move_select,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            cand_df.select(
+                self._on_candidate_select,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            play_btn.click(
+                self._on_play_dropdown,
+                inputs=[*ctx_inputs, move_dd],
+                outputs=nav_outputs,
+            )
+            pv_btn.click(
+                self._on_pv_play,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            # server_functions ブリッジ経由の .change は value 更新のみ
+            # 反映され，gr.update の prop 更新 (visible / choices) が
+            # 適用されない (Gradio 6 実測)．prop 更新を含む再描画を
+            # 通常イベントとして .then で連鎖させて反映する
+            click_bridge.change(
+                lambda *args: self._apply_board_click(
+                    args[0],
+                    args[1],
+                    args[2],
+                    pending_click.pop("value", ""),
+                    *args[3:],
                 ),
-                inputs=state,
-                outputs=ply_slider,
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            ).then(
+                self._on_display,
+                inputs=ctx_inputs,
+                outputs=node_outputs,
+            )
+            promote_btn.click(
+                lambda *args: self._on_promotion_choice(
+                    *args, promote=True
+                ),
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
+            )
+            nonpromote_btn.click(
+                lambda *args: self._on_promotion_choice(
+                    *args, promote=False
+                ),
+                inputs=ctx_inputs,
+                outputs=nav_outputs,
             )
 
-            def _on_move_select(
-                view: SessionView | None,
-                evt: gr.SelectData,
-            ) -> int:
-                # 行 i = i+1 手目 → その手を指した後の局面へ
-                return _clamp_ply(view, evt.index[0] + 1)
-
-            move_df.select(
-                _on_move_select,
-                inputs=state,
-                outputs=ply_slider,
+            analyze_btn.click(
+                lambda *args: self._analyze_current(
+                    *args, force=False
+                ),
+                inputs=[*ctx_inputs, budget_mode, budget_value],
+                outputs=[*nav_outputs, analyze_status],
+                concurrency_limit=1,
+                concurrency_id="engine",
+            )
+            reanalyze_btn.click(
+                lambda *args: self._analyze_current(
+                    *args, force=True
+                ),
+                inputs=[*ctx_inputs, budget_mode, budget_value],
+                outputs=[*nav_outputs, analyze_status],
+                concurrency_limit=1,
+                concurrency_id="engine",
+            )
+            analyze_all_btn.click(
+                self._on_analyze_all,
+                inputs=[*ctx_inputs, budget_mode, budget_value],
+                outputs=[
+                    state,
+                    *nav_outputs,
+                    move_df,
+                    summary_md,
+                    report_download,
+                    analyze_status,
+                ],
+                concurrency_limit=1,
+                concurrency_id="engine",
+            )
+            cancel_btn.click(
+                self._on_cancel,
+                inputs=None,
+                outputs=analyze_status,
             )
 
             load_btn.click(
@@ -407,11 +1422,11 @@ class AnalysisGuiServer:
                 ],
                 outputs=[
                     state,
+                    *node_outputs,
                     ply_slider,
                     move_df,
                     summary_md,
                     load_status,
-                    *render_outputs,
                 ],
             )
 
@@ -423,6 +1438,9 @@ def launch_analysis_gui_server(
     kifu_path: Path | None = None,
     report_path: Path | None = None,
     num_candidates: int = 5,
+    engine_settings: EngineSettings | None = None,
+    default_time_ms: int | None = None,
+    default_playouts: int | None = None,
     port: int | None = None,
     share: bool = False,
     server_name: str = "127.0.0.1",
@@ -433,6 +1451,9 @@ def launch_analysis_gui_server(
         kifu_path: 起動時に読み込む棋譜ファイル．
         report_path: analyze-game の JSON レポート．
         num_candidates: 候補手表示数の上限．
+        engine_settings: GUI 内解析のエンジン設定 (None は mock)．
+        default_time_ms: GUI 内解析のデフォルト時間予算 (ミリ秒)．
+        default_playouts: GUI 内解析のデフォルト playout 数予算．
         port: サーバーポート (None で Gradio の自動選択)．
         share: Gradio 公開リンクを作成するか．
         server_name: バインドアドレス．
@@ -441,6 +1462,9 @@ def launch_analysis_gui_server(
         kifu_path=kifu_path,
         report_path=report_path,
         num_candidates=num_candidates,
+        engine_settings=engine_settings,
+        default_time_ms=default_time_ms,
+        default_playouts=default_playouts,
     )
     demo = server.create_demo()
     logger.info(
@@ -452,4 +1476,6 @@ def launch_analysis_gui_server(
         server_name=server_name,
         server_port=port,
         share=share,
+        head=_HEAD_SCRIPTS,
+        css=_CUSTOM_CSS,
     )

--- a/src/maou/interface/analysis_gui.py
+++ b/src/maou/interface/analysis_gui.py
@@ -18,11 +18,41 @@ from typing import Any
 
 import plotly.graph_objects as go
 
+# infra 層 (analysis_gui_server) が本モジュール経由で使う app 層 API の
+# 再エクスポート (サーバーは interface 層のみを import する)
 from maou.app.analysis.analysis_session import (
     GameDocument,
+    LegalMoveInfo,
     PositionSnapshot,
+    VariationTree,
+)
+from maou.app.analysis.analysis_session import (  # noqa: F401
+    advance_move as advance_move,
+)
+from maou.app.analysis.analysis_session import (
+    build_variation_tree as build_variation_tree,
+)
+from maou.app.analysis.analysis_session import (
+    current_node,
+)
+from maou.app.analysis.analysis_session import (
+    goto_node as goto_node,
+)
+from maou.app.analysis.analysis_session import (
+    legal_move_infos,
     load_game,
+    mainline_ancestor,
+    path_moves_usi,
     validate_report,
+)
+from maou.app.analysis.interactive_analyzer import (  # noqa: F401
+    DEFAULT_TIME_MS as DEFAULT_TIME_MS,
+)
+from maou.app.analysis.interactive_analyzer import (
+    EngineSettings as EngineSettings,
+)
+from maou.app.analysis.interactive_analyzer import (
+    InteractiveAnalyzer as InteractiveAnalyzer,
 )
 from maou.domain.board.shogi import (
     HAND_PIECE_SFEN_CHARS,
@@ -82,11 +112,14 @@ class SessionView:
         document: 棋譜の per-ply スナップショット表現．
         report: analyze-game の JSON レポート (dict)．未読込は None．
         move_labels: 本譜の日本語表記 (▲/△ 付き，手数分)．
+        source_name: 読み込んだ棋譜のファイル名 (GUI 内で生成する
+            レポートの ``input.path`` に記録する)．
     """
 
     document: GameDocument
     report: dict[str, Any] | None
     move_labels: list[str]
+    source_name: str = ""
 
 
 def sente_winrate(winrate: float, side_to_move: str) -> float:
@@ -206,6 +239,7 @@ def load_session(
         document=document,
         report=report,
         move_labels=move_labels,
+        source_name=filename,
     )
 
 
@@ -247,7 +281,41 @@ def board_svg(
     Returns:
         SVG 文字列．
     """
-    snapshot = view.document.snapshots[ply]
+    return snapshot_board_svg(
+        view.document.snapshots[ply],
+        position_analysis(view, ply),
+        show_candidates=show_candidates,
+        show_pv=show_pv,
+        top_n=top_n,
+    )
+
+
+def snapshot_board_svg(
+    snapshot: PositionSnapshot,
+    analysis: dict[str, Any] | None,
+    *,
+    show_candidates: bool = True,
+    show_pv: bool = False,
+    top_n: int = 5,
+    selected_squares: list[int] | None = None,
+    destination_squares: list[int] | None = None,
+    interactive: bool = False,
+) -> str:
+    """スナップショット局面の盤面 SVG を返す (分岐局面にも使える)．
+
+    Args:
+        snapshot: 対象局面のスナップショット．
+        analysis: この局面の解析記録 (候補手矢印の元．None で矢印なし)．
+        show_candidates: 候補手矢印を描画するか．
+        show_pv: 最善手の PV 先頭 3 手を連鎖矢印で描画するか．
+        top_n: 描画する候補手の数．
+        selected_squares: クリック選択中として塗るマス (row-major)．
+        destination_squares: 行き先候補として塗るマス (row-major)．
+        interactive: クリック標的 rect を重ねるか．
+
+    Returns:
+        SVG 文字列．
+    """
     position = BoardPosition(
         board_id_positions=snapshot.board_id_positions,
         pieces_in_hand=snapshot.pieces_in_hand,
@@ -264,7 +332,6 @@ def board_svg(
             )
 
     arrows: list[ArrowSpec] = []
-    analysis = position_analysis(view, ply)
     if analysis is not None and show_candidates:
         arrows = _candidate_arrows(
             analysis, top_n=top_n, show_pv=show_pv
@@ -276,6 +343,9 @@ def board_svg(
         highlight_squares=highlights,
         turn=turn,
         move_arrows=arrows,
+        selected_squares=selected_squares,
+        destination_squares=destination_squares,
+        interactive=interactive,
     )
 
 
@@ -512,10 +582,21 @@ def candidates_table(
     view: SessionView, ply: int, top_n: int = 5
 ) -> list[list[str]]:
     """局面 ply の候補手テーブル (上位 top_n) の行リストを返す．"""
-    analysis = position_analysis(view, ply)
+    return _candidate_rows(
+        view.document.snapshots[ply],
+        position_analysis(view, ply),
+        top_n,
+    )
+
+
+def _candidate_rows(
+    snapshot: PositionSnapshot,
+    analysis: dict[str, Any] | None,
+    top_n: int,
+) -> list[list[str]]:
+    """解析記録から候補手テーブルの行リストを作る．"""
     if analysis is None:
         return []
-    snapshot = view.document.snapshots[ply]
     rows: list[list[str]] = []
     candidates = list(analysis.get("candidates") or [])[
         : max(top_n, 0)
@@ -650,3 +731,365 @@ def position_info(
         ):
             notes.append(f"コメント: {doc.comments[ply - 1]}")
     return sfen, position_str, "\n\n".join(notes)
+
+
+# ----------------------------------------------------------------------
+# 対話解析 (分岐木 + 盤面クリック入力)
+# ----------------------------------------------------------------------
+
+# 段の漢数字 (指し手・マス表記用)
+_RANK_KANJI = "一二三四五六七八九"
+
+
+@dataclass(frozen=True)
+class ClickState:
+    """盤面クリック入力の進行状態 (plain data)．
+
+    2 クリック方式 (docs/design/game-analysis/gui.md §10) の状態機械:
+    選択なし → 自駒/持ち駒クリックで選択 → 行き先クリックで確定．
+    成/不成が両方合法な行き先では ``pending_usis`` に両候補を保持し，
+    UI の確認ボタンで確定する．
+
+    Attributes:
+        selected: 選択中の起点 (``data-click`` 値: "sq:60" /
+            "hand:b:0")．未選択は None．
+        pending_usis: 成/不成の選択待ち USI (成る手, 成らない手)．
+    """
+
+    selected: str | None = None
+    pending_usis: tuple[str, ...] = ()
+
+
+def node_legal_moves(
+    tree: VariationTree,
+) -> list[LegalMoveInfo]:
+    """現在ノードの局面の合法手を列挙する．"""
+    return legal_move_infos(current_node(tree).snapshot)
+
+
+def _moves_from_origin(
+    legal: list[LegalMoveInfo], origin: str, turn: str
+) -> list[LegalMoveInfo]:
+    """クリック値 (起点) に対応する合法手を返す．
+
+    "sq:N" は移動元マス N の手，"hand:{side}:{type}" は手番側の
+    その駒種の駒打ち (相手側の持ち駒は空リスト)．
+    """
+    parts = origin.split(":")
+    try:
+        if parts[0] == "sq" and len(parts) == 2:
+            square = int(parts[1])
+            return [
+                m
+                for m in legal
+                if not m.is_drop and m.from_square == square
+            ]
+        if parts[0] == "hand" and len(parts) == 3:
+            if parts[1] != turn:
+                return []
+            piece_type = int(parts[2])
+            return [
+                m
+                for m in legal
+                if m.is_drop and m.drop_piece_type == piece_type
+            ]
+    except ValueError:
+        logger.warning("不正なクリック値です: %s", origin)
+    return []
+
+
+def handle_board_click(
+    legal: list[LegalMoveInfo],
+    state: ClickState,
+    value: str,
+    turn: str,
+) -> tuple[ClickState, str | None]:
+    """盤面クリック 1 回分の状態遷移を計算する (純関数)．
+
+    Args:
+        legal: 現局面の合法手．
+        state: 現在のクリック状態．
+        value: クリックされた標的の ``data-click`` 値．
+        turn: 手番 ("b" / "w")．
+
+    Returns:
+        ``(新しい ClickState, 指す USI or None)``．成/不成の選択待ちに
+        入った場合は USI は None で ``pending_usis`` に両候補が入る．
+    """
+    value = (value or "").strip()
+    if not value:
+        return ClickState(), None
+    if state.pending_usis:
+        # 確認ボタン以外のクリックはキャンセルし，新規クリックとして解釈
+        state = ClickState()
+
+    clicked_origin_moves = _moves_from_origin(
+        legal, value, turn
+    )
+    if state.selected is None:
+        if clicked_origin_moves:
+            return ClickState(selected=value), None
+        return ClickState(), None
+
+    if value == state.selected:
+        # 同じ起点の再クリックで選択解除
+        return ClickState(), None
+
+    selected_moves = _moves_from_origin(
+        legal, state.selected, turn
+    )
+    if value.startswith("sq:"):
+        try:
+            to_square = int(value.split(":")[1])
+        except ValueError:
+            return ClickState(), None
+        matches = [
+            m
+            for m in selected_moves
+            if m.to_square == to_square
+        ]
+        if len(matches) == 1:
+            return ClickState(), matches[0].usi
+        if len(matches) >= 2:
+            promo = next(
+                (m.usi for m in matches if m.is_promotion),
+                None,
+            )
+            nonpromo = next(
+                (m.usi for m in matches if not m.is_promotion),
+                None,
+            )
+            if promo is not None and nonpromo is not None:
+                return (
+                    ClickState(
+                        selected=state.selected,
+                        pending_usis=(promo, nonpromo),
+                    ),
+                    None,
+                )
+
+    # 行き先ではない → 有効な起点なら選択切替，そうでなければ解除
+    if clicked_origin_moves:
+        return ClickState(selected=value), None
+    return ClickState(), None
+
+
+def click_overlays(
+    legal: list[LegalMoveInfo],
+    state: ClickState,
+    turn: str,
+) -> tuple[list[int], list[int]]:
+    """クリック状態から盤面の塗り分け (選択/行き先) を作る．
+
+    Returns:
+        ``(selected_squares, destination_squares)``．いずれも
+        renderer の row-major 索引．
+    """
+    if state.selected is None:
+        return [], []
+    selected: list[int] = []
+    if state.selected.startswith("sq:"):
+        try:
+            selected.append(
+                _highlight_index(
+                    int(state.selected.split(":")[1])
+                )
+            )
+        except ValueError:
+            return [], []
+    destinations = sorted(
+        {
+            _highlight_index(m.to_square)
+            for m in _moves_from_origin(
+                legal, state.selected, turn
+            )
+        }
+    )
+    return selected, destinations
+
+
+def click_status_text(
+    snapshot: PositionSnapshot, state: ClickState
+) -> str:
+    """クリック状態の説明テキストを返す (手入力状態の表示用)．"""
+    if state.pending_usis:
+        return "成 / 不成を選択してください"
+    if state.selected is None:
+        return (
+            "盤面クリック: 動かす駒 (または持ち駒) をクリック"
+        )
+    parts = state.selected.split(":")
+    if parts[0] == "sq":
+        try:
+            square = int(parts[1])
+        except ValueError:
+            return ""
+        row, col = square % 9, square // 9
+        piece = get_piece_name_ja(
+            snapshot.board_id_positions[row][col]
+        )
+        return (
+            f"選択中: {col + 1}{_RANK_KANJI[row]}{piece} — "
+            "行き先をクリック"
+        )
+    if parts[0] == "hand" and len(parts) == 3:
+        try:
+            piece = get_piece_name_ja(int(parts[2]) + 1)
+        except ValueError:
+            return ""
+        return f"選択中: 持ち駒の{piece} — 打つマスをクリック"
+    return ""
+
+
+def legal_move_choices(
+    snapshot: PositionSnapshot,
+    legal: list[LegalMoveInfo],
+) -> list[tuple[str, str]]:
+    """合法手 Dropdown の選択肢 (日本語表記, USI) を返す．
+
+    盤面クリックが使えない環境向けのフォールバック入力
+    (docs/design/game-analysis/gui.md §10)．
+    """
+    choices: list[tuple[str, str]] = []
+    for move in legal:
+        try:
+            label = _move_label(snapshot, move.usi)
+        except (ValueError, IndexError):
+            label = move.usi
+        choices.append((f"{label} ({move.usi})", move.usi))
+    return choices
+
+
+def breadcrumb_markdown(tree: VariationTree) -> str:
+    """分岐パンくず (本譜 N手目 ▶ △8四飛 ▶ …) の Markdown を返す．"""
+    node = current_node(tree)
+    if node.is_mainline:
+        if node.snapshot.ply == 0:
+            return "**本譜** 初期局面"
+        return f"**本譜** {node.snapshot.ply}手目"
+    chain = []
+    cursor = node
+    while not cursor.is_mainline:
+        assert cursor.parent_id is not None
+        parent = tree.nodes[cursor.parent_id]
+        assert cursor.move_usi is not None
+        try:
+            label = _move_label(
+                parent.snapshot, cursor.move_usi
+            )
+        except (ValueError, IndexError):
+            label = cursor.move_usi
+        chain.append(label)
+        cursor = parent
+    chain.reverse()
+    base = (
+        f"**本譜 {cursor.snapshot.ply}手目**"
+        if cursor.snapshot.ply > 0
+        else "**本譜 初期局面**"
+    )
+    return base + " ▶ " + " ▶ ".join(chain)
+
+
+def mainline_ply(tree: VariationTree) -> int:
+    """現在ノードに最も近い本譜局面の ply を返す．
+
+    分岐中はスライダー・評価値グラフの現在位置線を分岐点に保つ．
+    """
+    return mainline_ancestor(tree).snapshot.ply
+
+
+def node_board_svg(
+    tree: VariationTree,
+    *,
+    show_candidates: bool = True,
+    show_pv: bool = False,
+    top_n: int = 5,
+    click_state: ClickState | None = None,
+    legal: list[LegalMoveInfo] | None = None,
+    interactive: bool = False,
+) -> str:
+    """現在ノードの盤面 SVG (解析キャッシュの候補手矢印付き) を返す．"""
+    node = current_node(tree)
+    selected: list[int] = []
+    destinations: list[int] = []
+    if click_state is not None and legal is not None:
+        selected, destinations = click_overlays(
+            legal, click_state, node.snapshot.turn
+        )
+    return snapshot_board_svg(
+        node.snapshot,
+        node.analysis,
+        show_candidates=show_candidates,
+        show_pv=show_pv,
+        top_n=top_n,
+        selected_squares=selected,
+        destination_squares=destinations,
+        interactive=interactive,
+    )
+
+
+def node_candidates_table(
+    tree: VariationTree, top_n: int = 5
+) -> list[list[str]]:
+    """現在ノードの候補手テーブル (上位 top_n) の行リストを返す．"""
+    node = current_node(tree)
+    return _candidate_rows(node.snapshot, node.analysis, top_n)
+
+
+def candidate_usi(
+    analysis: dict[str, Any] | None,
+    row_index: int,
+    top_n: int,
+) -> str | None:
+    """候補手テーブルの行番号から USI を引く (行クリック → 分岐用)．
+
+    行の並びは :func:`_candidate_rows` と同じ
+    (``candidates`` の先頭 top_n 件)．
+    """
+    if analysis is None:
+        return None
+    candidates = list(analysis.get("candidates") or [])[
+        : max(top_n, 0)
+    ]
+    if 0 <= row_index < len(candidates):
+        usi = candidates[row_index].get("usi")
+        return str(usi) if usi else None
+    return None
+
+
+def node_position_info(
+    view: SessionView, tree: VariationTree
+) -> tuple[str, str, str]:
+    """現在ノードの局面情報 (SFEN / position 文字列 / 注記) を返す．
+
+    本譜ノードは :func:`position_info` に委譲し，分岐ノードは分岐点と
+    分岐手順の注記を作る．
+    """
+    node = current_node(tree)
+    if node.is_mainline:
+        return position_info(view, node.snapshot.ply)
+    doc = view.document
+    path = path_moves_usi(tree, node.node_id)
+    position_str = (
+        f"position sfen {doc.snapshots[0].sfen} "
+        f"moves {' '.join(path)}"
+    )
+    ancestor = mainline_ancestor(tree, node.node_id)
+    notes = [
+        f"**分岐** (本譜 {ancestor.snapshot.ply}手目から "
+        f"{node.snapshot.ply - ancestor.snapshot.ply} 手)"
+    ]
+    assert node.parent_id is not None
+    assert node.move_usi is not None
+    parent = tree.nodes[node.parent_id]
+    try:
+        label = _move_label(parent.snapshot, node.move_usi)
+    except (ValueError, IndexError):
+        label = node.move_usi
+    notes.append(f"**{node.snapshot.ply}手目**: {label}")
+    if node.analysis is None:
+        notes.append(
+            "この局面は未解析です "
+            "(「この局面を解析」で解析できます)"
+        )
+    return node.snapshot.sfen, position_str, "\n\n".join(notes)

--- a/tests/maou/app/analysis/test_analysis_session.py
+++ b/tests/maou/app/analysis/test_analysis_session.py
@@ -8,7 +8,14 @@ import pytest
 from maou.app.analysis.analysis_session import (
     GameDocument,
     _move_info,
+    _snapshot,
+    advance_move,
+    build_variation_tree,
+    goto_node,
+    legal_move_infos,
     load_game,
+    mainline_ancestor,
+    path_moves_usi,
     validate_report,
 )
 from maou.domain.board.shogi import Board, PieceId
@@ -181,3 +188,171 @@ class TestValidateReport:
         )
         with pytest.raises(ValueError, match="SFEN"):
             validate_report(mini_document, report)
+
+
+class TestVariationTree:
+    """分岐木 (VariationTree) のテスト．"""
+
+    def test_build_mainline_chain(
+        self, mini_document: GameDocument
+    ) -> None:
+        """本譜チェーンが ply 順に構築される．"""
+        tree = build_variation_tree(mini_document)
+        assert len(tree.nodes) == 5
+        assert tree.mainline_ids == [0, 1, 2, 3, 4]
+        assert tree.current_id == 0
+        root = tree.nodes[0]
+        assert root.move_usi is None
+        assert root.is_mainline
+        assert root.children == [1]
+        for ply, node_id in enumerate(tree.mainline_ids):
+            node = tree.nodes[node_id]
+            assert node.snapshot.ply == ply
+            assert node.is_mainline
+
+    def test_build_seeds_report(
+        self, mini_document: GameDocument
+    ) -> None:
+        """レポートの positions[i] が本譜ノード i に載る．"""
+        report = {
+            "positions": [
+                {"ply": i + 1, "marker": i}
+                for i in range(mini_document.n_moves)
+            ]
+        }
+        tree = build_variation_tree(mini_document, report)
+        for i in range(mini_document.n_moves):
+            analysis = tree.nodes[tree.mainline_ids[i]].analysis
+            assert analysis is not None
+            assert analysis["marker"] == i
+        # 最終局面 (ply = n_moves) にはレポートが対応しない
+        assert (
+            tree.nodes[tree.mainline_ids[-1]].analysis is None
+        )
+
+    def test_advance_reuses_mainline_child(
+        self, mini_document: GameDocument
+    ) -> None:
+        """本譜と同じ手は本譜ノードを再利用する．"""
+        tree = build_variation_tree(mini_document)
+        node = advance_move(tree, "7g7f")
+        assert node.node_id == tree.mainline_ids[1]
+        assert node.is_mainline
+        assert len(tree.nodes) == 5  # ノードは増えない
+
+    def test_advance_creates_branch(
+        self, mini_document: GameDocument
+    ) -> None:
+        """本譜と違う合法手で分岐ノードが生まれる．"""
+        tree = build_variation_tree(mini_document)
+        node = advance_move(tree, "2g2f")
+        assert not node.is_mainline
+        assert node.parent_id == 0
+        assert node.snapshot.ply == 1
+        assert node.snapshot.turn == "w"
+        assert len(tree.nodes) == 6
+        # 同じ手を root からもう一度指すと同じノードを再利用する
+        goto_node(tree, 0)
+        node2 = advance_move(tree, "2g2f")
+        assert node2.node_id == node.node_id
+        assert len(tree.nodes) == 6
+
+    def test_advance_illegal_raises(
+        self, mini_document: GameDocument
+    ) -> None:
+        """非合法手はエラー．"""
+        tree = build_variation_tree(mini_document)
+        with pytest.raises(ValueError):
+            advance_move(tree, "1a1b")
+
+    def test_goto_invalid_raises(
+        self, mini_document: GameDocument
+    ) -> None:
+        """範囲外のノード ID はエラー．"""
+        tree = build_variation_tree(mini_document)
+        with pytest.raises(ValueError, match="ノード"):
+            goto_node(tree, 99)
+
+    def test_path_moves_usi(
+        self, mini_document: GameDocument
+    ) -> None:
+        """root からの USI 経路が分岐込みで得られる．"""
+        tree = build_variation_tree(mini_document)
+        advance_move(tree, "7g7f")  # 本譜
+        advance_move(tree, "8c8d")  # 分岐 (本譜 2 手目は 3c3d)
+        assert path_moves_usi(tree) == ["7g7f", "8c8d"]
+        assert path_moves_usi(tree, 0) == []
+
+    def test_mainline_ancestor(
+        self, mini_document: GameDocument
+    ) -> None:
+        """分岐から最も近い本譜ノードに戻れる．"""
+        tree = build_variation_tree(mini_document)
+        advance_move(tree, "7g7f")
+        advance_move(tree, "8c8d")
+        advance_move(tree, "2g2f")
+        ancestor = mainline_ancestor(tree)
+        assert ancestor.node_id == tree.mainline_ids[1]
+        # 本譜ノード自身はそのまま返る
+        goto_node(tree, tree.mainline_ids[2])
+        assert (
+            mainline_ancestor(tree).node_id
+            == tree.mainline_ids[2]
+        )
+
+    def test_tree_is_deepcopyable(
+        self, mini_document: GameDocument
+    ) -> None:
+        """gr.State 用に deepcopy 可能な plain data である．"""
+        tree = build_variation_tree(mini_document)
+        advance_move(tree, "2g2f")
+        clone = copy.deepcopy(tree)
+        assert clone.current_id == tree.current_id
+        assert len(clone.nodes) == len(tree.nodes)
+
+
+class TestLegalMoveInfos:
+    """legal_move_infos のテスト．"""
+
+    def test_initial_position_moves(
+        self, mini_document: GameDocument
+    ) -> None:
+        """平手初期局面の合法手 30 手が列挙される．"""
+        infos = legal_move_infos(mini_document.snapshots[0])
+        assert len(infos) == 30
+        usis = {m.usi for m in infos}
+        assert "7g7f" in usis
+        move = next(m for m in infos if m.usi == "7g7f")
+        assert move.from_square == 60  # 7g
+        assert move.to_square == 59  # 7f
+        assert not move.is_drop
+        assert not move.is_promotion
+        assert move.piece_id == PieceId.FU
+
+    def test_promotion_flag(self) -> None:
+        """成/不成の両方が is_promotion 付きで列挙される．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/4P4/9/9/9/9/4K4 b - 1")
+        snapshot = _snapshot(board, 0, None)
+        infos = legal_move_infos(snapshot)
+        pawn_moves = [
+            m
+            for m in infos
+            if m.from_square == 39  # 5d
+        ]
+        usis = {m.usi for m in pawn_moves}
+        assert usis == {"5d5c", "5d5c+"}
+        promo = next(m for m in pawn_moves if m.is_promotion)
+        assert promo.usi == "5d5c+"
+
+    def test_drop_moves(self) -> None:
+        """駒打ちが drop_piece_type 付きで列挙される．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/9/9/9/9/9/4K4 b P 1")
+        snapshot = _snapshot(board, 0, None)
+        infos = legal_move_infos(snapshot)
+        drops = [m for m in infos if m.is_drop]
+        assert drops
+        assert all(m.drop_piece_type == 0 for m in drops)
+        assert all(m.from_square is None for m in drops)
+        assert all(m.usi.startswith("P*") for m in drops)

--- a/tests/maou/app/analysis/test_interactive_analyzer.py
+++ b/tests/maou/app/analysis/test_interactive_analyzer.py
@@ -1,0 +1,222 @@
+"""interactive_analyzer (GUI 常駐の対話解析) のテスト．
+
+mock 評価器 (model_path=None) の SearchEngine を実際に使う
+(決定論的・GPU/モデル不要)．
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from maou.app.analysis.analysis_session import (
+    GameDocument,
+    advance_move,
+    build_variation_tree,
+    load_game,
+)
+from maou.app.analysis.interactive_analyzer import (
+    DEFAULT_TIME_MS,
+    EngineSettings,
+    InteractiveAnalyzer,
+    _normalize_budget,
+)
+
+RESOURCES = Path(__file__).parent / "resources"
+
+# 高速化のためルート dfpn / leaf-mate は無効化
+FAST_SETTINGS = EngineSettings(
+    root_dfpn=False, leaf_mate=False, num_candidates=5
+)
+
+POSITION_KEYS = {
+    "ply",
+    "side_to_move",
+    "sfen",
+    "played_move",
+    "best_move",
+    "match",
+    "winrate",
+    "eval_cp",
+    "played_move_winrate",
+    "winrate_loss",
+    "pv",
+    "candidates",
+    "mate_found",
+    "playouts",
+    "elapsed_ms",
+    "stop",
+    "record_time_s",
+    "record_score",
+    "record_comment",
+}
+
+
+@pytest.fixture
+def mini_document() -> GameDocument:
+    """mini.csa (4 手 + 投了) から GameDocument を構築する．"""
+    data = (RESOURCES / "mini.csa").read_bytes()
+    return load_game(data, "csa")
+
+
+class TestEngineSettings:
+    """EngineSettings のテスト．"""
+
+    def test_describe_matches_analyze_game_schema(self) -> None:
+        """describe が analyze-game の engine セクション互換．"""
+        meta = FAST_SETTINGS.describe()
+        assert set(meta.keys()) == {
+            "model_path",
+            "threads",
+            "batch_size",
+            "cuda",
+            "tensorrt",
+            "root_dfpn",
+            "root_dfpn_nodes",
+            "root_dfpn_depth",
+            "leaf_mate",
+            "leaf_mate_nodes",
+            "leaf_mate_threads",
+        }
+        assert meta["model_path"] is None
+        assert meta["root_dfpn"] is False
+
+    def test_is_mock(self) -> None:
+        """model_path 未指定は mock 評価器扱い．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        assert analyzer.is_mock
+
+
+class TestNormalizeBudget:
+    """予算正規化のテスト．"""
+
+    def test_default(self) -> None:
+        assert _normalize_budget(None, None) == (
+            DEFAULT_TIME_MS,
+            None,
+        )
+
+    def test_passthrough(self) -> None:
+        assert _normalize_budget(500, None) == (500, None)
+        assert _normalize_budget(None, 32) == (None, 32)
+
+
+class TestAnalyzePosition:
+    """analyze_position のテスト (mock 評価器 integration)．"""
+
+    def test_mainline_node_has_played_move(
+        self, mini_document: GameDocument
+    ) -> None:
+        """本譜ノードは実戦手比較付きの記録になる．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        tree = build_variation_tree(mini_document)
+        record = analyzer.analyze_position(
+            mini_document, tree, max_playouts=8
+        )
+        assert set(record.keys()) == POSITION_KEYS
+        assert record["ply"] == 1
+        assert record["side_to_move"] == "b"
+        assert record["played_move"] == "7g7f"
+        assert record["sfen"] == (
+            mini_document.snapshots[0].sfen
+        )
+        assert record["candidates"]
+
+    def test_branch_node_has_no_played_move(
+        self, mini_document: GameDocument
+    ) -> None:
+        """分岐ノードは played_move なし (match=False)．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        tree = build_variation_tree(mini_document)
+        advance_move(tree, "2g2f")
+        record = analyzer.analyze_position(
+            mini_document, tree, max_playouts=8
+        )
+        assert record["ply"] == 2
+        assert record["side_to_move"] == "w"
+        assert record["played_move"] is None
+        assert record["match"] is False
+        assert record["winrate_loss"] is None
+
+    def test_engine_is_reused(
+        self, mini_document: GameDocument
+    ) -> None:
+        """SearchEngine は 1 回だけ構築される．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        tree = build_variation_tree(mini_document)
+        analyzer.analyze_position(
+            mini_document, tree, max_playouts=8
+        )
+        engine = analyzer._engine
+        assert engine is not None
+        analyzer.analyze_position(
+            mini_document, tree, max_playouts=8
+        )
+        assert analyzer._engine is engine
+
+
+class TestAnalyzeMainline:
+    """analyze_mainline / build_report のテスト．"""
+
+    def test_full_run_and_report(
+        self, mini_document: GameDocument
+    ) -> None:
+        """全局面を解析して analyze-game 互換レポートを作れる．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        positions = []
+        for i, n, record in analyzer.analyze_mainline(
+            mini_document, max_playouts=8
+        ):
+            assert n == 4
+            assert record["ply"] == i + 1
+            positions.append(record)
+        assert len(positions) == 4
+        assert [p["played_move"] for p in positions] == (
+            mini_document.moves_usi
+        )
+        report = analyzer.build_report(
+            mini_document,
+            positions,
+            source_name="mini.csa",
+            max_playouts=8,
+        )
+        assert set(report.keys()) == {
+            "input",
+            "engine",
+            "budget",
+            "positions",
+            "summary",
+        }
+        assert report["input"]["path"] == "mini.csa"
+        assert report["input"]["n_moves"] == 4
+        assert report["budget"]["mode"] == "fixed_playouts"
+        assert report["budget"]["per_position"] == {
+            "max_playouts": 8,
+            "time_ms": None,
+        }
+        assert "match_rate" in report["summary"]
+
+    def test_cancel_stops_early(
+        self, mini_document: GameDocument
+    ) -> None:
+        """キャンセルイベントで途中終了する．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        cancel = threading.Event()
+        results = []
+        for i, _n, record in analyzer.analyze_mainline(
+            mini_document, max_playouts=8, cancel=cancel
+        ):
+            results.append(record)
+            if i == 1:
+                cancel.set()
+        assert len(results) == 2
+
+    def test_build_report_count_mismatch_raises(
+        self, mini_document: GameDocument
+    ) -> None:
+        """positions の件数不一致はエラー．"""
+        analyzer = InteractiveAnalyzer(FAST_SETTINGS)
+        with pytest.raises(ValueError, match="件数"):
+            analyzer.build_report(
+                mini_document, [], source_name="x.csa"
+            )

--- a/tests/maou/domain/visualization/test_board_renderer.py
+++ b/tests/maou/domain/visualization/test_board_renderer.py
@@ -487,3 +487,116 @@ class TestHeaderVisibility:
             f"header band (top={header_top}) is clipped: "
             f"viewBox min-y={min_y}"
         )
+
+
+class TestInteractiveRendering:
+    """クリック標的・選択/行き先塗りのテスト．"""
+
+    @staticmethod
+    def _empty_position(
+        hand: list[int] | None = None,
+    ) -> BoardPosition:
+        return BoardPosition(
+            board_id_positions=[[0] * 9 for _ in range(9)],
+            pieces_in_hand=hand or [0] * 14,
+        )
+
+    def test_interactive_click_targets(self) -> None:
+        """interactive=True で盤上 81 マスの標的が付く．"""
+        renderer = SVGBoardRenderer()
+        svg = renderer.render(
+            self._empty_position(), interactive=True
+        )
+        assert svg.count('data-click="sq:') == 81
+        assert 'data-click="sq:0"' in svg
+        assert 'data-click="sq:80"' in svg
+        # 持ち駒なしなら hand 標的は出ない
+        assert 'data-click="hand:' not in svg
+
+    def test_interactive_hand_targets(self) -> None:
+        """枚数 > 0 の持ち駒行にのみ標的が付く．"""
+        hand = [0] * 14
+        hand[0] = 2  # 先手の歩
+        hand[7 + 4] = 1  # 後手の金
+        renderer = SVGBoardRenderer()
+        svg = renderer.render(
+            self._empty_position(hand), interactive=True
+        )
+        assert 'data-click="hand:b:0"' in svg
+        assert 'data-click="hand:w:4"' in svg
+        assert svg.count('data-click="hand:') == 2
+
+    def test_not_interactive_by_default(self) -> None:
+        """デフォルトでは標的なし (後方互換)．"""
+        renderer = SVGBoardRenderer()
+        svg = renderer.render(self._empty_position())
+        assert "data-click" not in svg
+
+    def test_selected_and_destination_fills(self) -> None:
+        """選択マスと行き先マスが専用色で塗られる．"""
+        renderer = SVGBoardRenderer()
+        svg = renderer.render(
+            self._empty_position(),
+            selected_squares=[60],
+            destination_squares=[51],
+        )
+        assert SVGBoardRenderer.COLOR_SELECTED in svg
+        assert SVGBoardRenderer.COLOR_DESTINATION in svg
+
+
+class TestDropArrowSide:
+    """駒打ち矢印の始点が手番側の持ち駒エリアになるテスト．"""
+
+    @staticmethod
+    def _position_with_hands() -> BoardPosition:
+        hand = [0] * 14
+        hand[0] = 1  # 先手の歩
+        hand[7] = 1  # 後手の歩
+        return BoardPosition(
+            board_id_positions=[[0] * 9 for _ in range(9)],
+            pieces_in_hand=hand,
+        )
+
+    def test_black_drop_from_right_area(self) -> None:
+        """先手番の駒打ちは右側 (先手持ち駒) から引く．"""
+        arrow = MoveArrow(
+            from_square=None,
+            to_square=40,
+            is_drop=True,
+            drop_piece_type=0,
+        )
+        svg = SVGBoardRenderer().render(
+            self._position_with_hands(),
+            turn=Turn.BLACK,
+            move_arrow=arrow,
+        )
+        assert 'x1="755.0"' in svg
+
+    def test_white_drop_from_left_area(self) -> None:
+        """後手番の駒打ちは左側 (後手持ち駒) から引く．"""
+        arrow = MoveArrow(
+            from_square=None,
+            to_square=40,
+            is_drop=True,
+            drop_piece_type=0,
+        )
+        svg = SVGBoardRenderer().render(
+            self._position_with_hands(),
+            turn=Turn.WHITE,
+            move_arrow=arrow,
+        )
+        assert 'x1="95.0"' in svg
+
+    def test_no_turn_defaults_to_black_side(self) -> None:
+        """turn なし (後方互換) は先手側から引く．"""
+        arrow = MoveArrow(
+            from_square=None,
+            to_square=40,
+            is_drop=True,
+            drop_piece_type=0,
+        )
+        svg = SVGBoardRenderer().render(
+            self._position_with_hands(),
+            move_arrow=arrow,
+        )
+        assert 'x1="755.0"' in svg

--- a/tests/maou/infra/console/test_analyze_gui_cli.py
+++ b/tests/maou/infra/console/test_analyze_gui_cli.py
@@ -49,6 +49,33 @@ class TestAnalyzeGuiCli:
         assert result.exit_code != 0
         assert "--num-candidates" in result.output
 
+    def test_cuda_requires_model_path(self) -> None:
+        """--cuda はモデル指定が必須．"""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_gui,
+            ["--input-path", str(MINI_CSA), "--cuda"],
+        )
+        assert result.exit_code != 0
+        assert "--model-path" in result.output
+
+    def test_time_ms_and_playouts_exclusive(self) -> None:
+        """--time-ms と --playouts は同時指定不可．"""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_gui,
+            [
+                "--input-path",
+                str(MINI_CSA),
+                "--time-ms",
+                "1000",
+                "--playouts",
+                "100",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--time-ms" in result.output
+
     def test_launch_invoked_with_options(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -71,6 +98,11 @@ class TestAnalyzeGuiCli:
                 str(MINI_CSA),
                 "--num-candidates",
                 "7",
+                "--playouts",
+                "64",
+                "--threads",
+                "2",
+                "--no-root-dfpn",
                 "--port",
                 "7999",
                 "--server-name",
@@ -83,3 +115,10 @@ class TestAnalyzeGuiCli:
         assert recorded["num_candidates"] == 7
         assert recorded["port"] == 7999
         assert recorded["server_name"] == "0.0.0.0"
+        assert recorded["default_playouts"] == 64
+        assert recorded["default_time_ms"] is None
+        settings = recorded["engine_settings"]
+        assert settings.model_path is None
+        assert settings.threads == 2
+        assert settings.root_dfpn is False
+        assert settings.num_candidates == 7

--- a/tests/maou/infra/visualization/test_analysis_gui_server.py
+++ b/tests/maou/infra/visualization/test_analysis_gui_server.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -13,16 +14,30 @@ from maou.app.analysis.game_analyzer import (  # noqa: E402
     FixedPlayoutsAllocator,
     GameAnalyzer,
 )
+from maou.app.analysis.interactive_analyzer import (  # noqa: E402
+    EngineSettings,
+)
 from maou.infra.visualization.analysis_gui_server import (  # noqa: E402
     AnalysisGuiServer,
     _clamp_ply,
     _file_path,
+)
+from maou.interface.analysis_gui import (  # noqa: E402
+    ClickState,
 )
 
 RESOURCES = (
     Path(__file__).parents[2] / "app" / "analysis" / "resources"
 )
 MINI_CSA = RESOURCES / "mini.csa"
+
+# mock 評価器で高速に回すテスト用エンジン設定
+FAST_ENGINE = EngineSettings(
+    root_dfpn=False, leaf_mate=False, num_candidates=5
+)
+
+# ハンドラ共通の表示オプション (arrows, pv, top_n, y_mode)
+OPTS: tuple[bool, bool, int, str] = (True, False, 5, "winrate")
 
 
 @pytest.fixture(scope="module")
@@ -45,19 +60,27 @@ def real_report_path(
     return path
 
 
+def _make_server(**kwargs: Any) -> AnalysisGuiServer:
+    """テスト用の共通エンジン設定でサーバーを作る．"""
+    kwargs.setdefault("engine_settings", FAST_ENGINE)
+    return AnalysisGuiServer(**kwargs)
+
+
 class TestAnalysisGuiServer:
     """AnalysisGuiServer のテスト．"""
 
     def test_demo_builds_empty(self) -> None:
         """棋譜なしでも demo を構築できる．"""
-        demo = AnalysisGuiServer().create_demo()
+        demo = _make_server().create_demo()
         assert len(demo.blocks) > 0
 
     def test_demo_builds_with_kifu(self) -> None:
         """棋譜を初期ロードして demo を構築できる．"""
-        server = AnalysisGuiServer(kifu_path=MINI_CSA)
+        server = _make_server(kifu_path=MINI_CSA)
         assert server.initial_view is not None
         assert server.initial_view.document.n_moves == 4
+        assert server.initial_tree is not None
+        assert len(server.initial_tree.mainline_ids) == 5
         demo = server.create_demo()
         assert len(demo.blocks) > 0
 
@@ -65,12 +88,15 @@ class TestAnalysisGuiServer:
         self, real_report_path: Path
     ) -> None:
         """analyze-game の実レポートを初期ロードできる (integration)．"""
-        server = AnalysisGuiServer(
+        server = _make_server(
             kifu_path=MINI_CSA,
             report_path=real_report_path,
         )
         assert server.initial_view is not None
         assert server.initial_view.report is not None
+        # レポートが本譜ノードのキャッシュに取り込まれる
+        assert server.initial_tree is not None
+        assert server.initial_tree.nodes[0].analysis is not None
         demo = server.create_demo()
         assert len(demo.blocks) > 0
 
@@ -79,78 +105,292 @@ class TestAnalysisGuiServer:
     ) -> None:
         """レポートのみの指定はエラー．"""
         with pytest.raises(ValueError, match="input-path"):
-            AnalysisGuiServer(report_path=real_report_path)
+            _make_server(report_path=real_report_path)
 
-    def test_render_without_view(self) -> None:
+    def test_render_node_without_view(self) -> None:
         """棋譜未読込時はプレースホルダを返す．"""
-        server = AnalysisGuiServer()
-        board, _fig, candidates, sfen, position_str, note = (
-            server._render(None, 0, True, False, 5, "winrate")
+        server = _make_server()
+        outputs = server._render_node(
+            None, None, ClickState(), *OPTS
         )
+        assert len(outputs) == 13
+        board = outputs[2]
         assert "棋譜が読み込まれていません" in board
-        assert candidates == []
-        assert sfen == ""
-        assert position_str == ""
-        assert note == ""
+        assert outputs[4] == []  # candidates
 
-    def test_render_with_view(
+    def test_render_node_with_view(
         self, real_report_path: Path
     ) -> None:
-        """読込済みの状態で盤面 SVG と候補手を返す．"""
-        server = AnalysisGuiServer(
+        """読込済みの状態で盤面 SVG (クリック標的付き) と候補手を返す．"""
+        server = _make_server(
             kifu_path=MINI_CSA,
             report_path=real_report_path,
         )
-        board, fig, candidates, sfen, position_str, _note = (
-            server._render(
-                server.initial_view,
-                0,
-                True,
-                False,
-                5,
-                "winrate",
+        outputs = server._render_node(
+            server.initial_view,
+            server.initial_tree,
+            ClickState(),
+            *OPTS,
+        )
+        board = outputs[2]
+        assert "<svg" in board
+        assert 'data-click="sq:' in board  # interactive
+        assert outputs[4]  # candidates
+        assert outputs[5].endswith("b - 1")  # sfen
+        assert outputs[6].startswith("position sfen")
+        assert "本譜" in outputs[8]  # breadcrumb
+
+    def test_on_slider_clamps(self) -> None:
+        """範囲外の ply は末尾に丸められる．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        tree = server.initial_tree
+        outputs = server._on_slider(
+            server.initial_view,
+            tree,
+            ClickState(),
+            *OPTS,
+            999,
+        )
+        assert tree is not None
+        assert tree.current_id == tree.mainline_ids[-1]
+        assert "<svg" in outputs[2]
+
+    def test_play_dropdown_creates_branch(self) -> None:
+        """本譜と違う手を指すと分岐が生まれる．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        # mini.csa の初手は 7g7f — 別の合法手 2g2f で分岐
+        outputs = server._on_play_dropdown(
+            view, tree, ClickState(), *OPTS, "2g2f"
+        )
+        node = tree.nodes[tree.current_id]
+        assert node.move_usi == "2g2f"
+        assert not node.is_mainline
+        assert "▶" in outputs[8]  # breadcrumb に分岐
+        # スライダーは分岐中は更新しない (gr.update() no-op)
+        # (最後の要素がスライダー更新)
+        assert len(outputs) == 14
+
+    def test_play_dropdown_reuses_mainline(self) -> None:
+        """本譜と同じ手は本譜ノードを再利用する．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        server._on_play_dropdown(
+            view, tree, ClickState(), *OPTS, "7g7f"
+        )
+        node = tree.nodes[tree.current_id]
+        assert node.is_mainline
+        assert node.node_id == tree.mainline_ids[1]
+
+    def test_play_illegal_move_raises(self) -> None:
+        """非合法手はエラー．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        with pytest.raises(gr.Error):
+            server._on_play_dropdown(
+                view, tree, ClickState(), *OPTS, "1a1b"
+            )
+
+    def test_board_click_two_step(self) -> None:
+        """盤面クリック 2 回で 1 手進む (7g 選択 → 7f 確定)．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        # 7g = column-major (7-1)*9 + (7-1) = 60
+        outputs = server._apply_board_click(
+            view, tree, ClickState(), "sq:60", *OPTS
+        )
+        click = outputs[1]
+        assert click.selected == "sq:60"
+        assert "選択中" in outputs[10]
+        # 7f = (7-1)*9 + (6-1) = 59
+        outputs = server._apply_board_click(
+            view, tree, click, "sq:59", *OPTS
+        )
+        node = tree.nodes[tree.current_id]
+        assert node.move_usi == "7g7f"
+        assert outputs[1].selected is None
+
+    def test_back_to_mainline(self) -> None:
+        """本譜へ戻るで分岐点の本譜ノードに復帰する．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        server._on_play_dropdown(
+            view, tree, ClickState(), *OPTS, "2g2f"
+        )
+        assert not tree.nodes[tree.current_id].is_mainline
+        server._on_back_mainline(
+            view, tree, ClickState(), *OPTS
+        )
+        assert tree.current_id == tree.mainline_ids[0]
+
+    def test_prev_next_walk_tree(self) -> None:
+        """前/次は分岐中も木構造を辿る．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        server._on_play_dropdown(
+            view, tree, ClickState(), *OPTS, "2g2f"
+        )
+        branch_id = tree.current_id
+        server._on_prev(view, tree, ClickState(), *OPTS)
+        assert tree.current_id == tree.mainline_ids[0]
+        # 次は本譜の子を優先する
+        server._on_next(view, tree, ClickState(), *OPTS)
+        assert tree.current_id == tree.mainline_ids[1]
+        assert tree.current_id != branch_id
+
+    def test_analyze_current_and_cache(self) -> None:
+        """1 局面解析がキャッシュされ，再解析なしでは再実行しない．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        outputs = server._analyze_current(
+            view,
+            tree,
+            ClickState(),
+            *OPTS,
+            "playouts",
+            8,
+            force=False,
+        )
+        node = tree.nodes[tree.current_id]
+        assert node.analysis is not None
+        assert node.analysis["played_move"] == "7g7f"
+        assert "解析完了" in outputs[-1]
+        assert "mock" in outputs[-1]  # mock 明示
+        # 2 回目はキャッシュ利用
+        cached = node.analysis
+        outputs = server._analyze_current(
+            view,
+            tree,
+            ClickState(),
+            *OPTS,
+            "playouts",
+            8,
+            force=False,
+        )
+        assert node.analysis is cached
+        assert "解析済み" in outputs[-1]
+        # force で上書き
+        outputs = server._analyze_current(
+            view,
+            tree,
+            ClickState(),
+            *OPTS,
+            "playouts",
+            8,
+            force=True,
+        )
+        assert node.analysis is not cached
+
+    def test_analyze_branch_node(self) -> None:
+        """分岐ノードの解析は played_move なしの記録になる．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        server._on_play_dropdown(
+            view, tree, ClickState(), *OPTS, "2g2f"
+        )
+        server._analyze_current(
+            view,
+            tree,
+            ClickState(),
+            *OPTS,
+            "playouts",
+            8,
+            force=False,
+        )
+        node = tree.nodes[tree.current_id]
+        assert node.analysis is not None
+        assert node.analysis["played_move"] is None
+        assert node.analysis["match"] is False
+        assert node.analysis["candidates"]
+
+    def test_analyze_all_generates_report(self) -> None:
+        """全局面解析が analyze-game 互換レポートを生成する．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        results = list(
+            server._on_analyze_all(
+                view,
+                tree,
+                ClickState(),
+                *OPTS,
+                "playouts",
+                8,
             )
         )
-        assert "<svg" in board
-        assert fig.data
-        assert candidates
-        assert sfen.endswith("b - 1")
-        assert position_str.startswith("position sfen")
-
-    def test_render_clamps_ply(self) -> None:
-        """範囲外の ply は末尾に丸められる．"""
-        server = AnalysisGuiServer(kifu_path=MINI_CSA)
-        board, *_ = server._render(
-            server.initial_view, 999, True, False, 5, "winrate"
+        # 開始 + 4 局面 + 最終 = 6 yield
+        assert len(results) == 6
+        final = results[-1]
+        new_view = final[0]
+        assert new_view.report is not None
+        assert (
+            len(new_view.report["positions"])
+            == view.document.n_moves
         )
-        assert "<svg" in board
+        assert "summary" in new_view.report
+        assert new_view.report["input"]["path"] == "mini.csa"
+        # 本譜ノードにもキャッシュが載る
+        assert all(
+            tree.nodes[nid].analysis is not None
+            for nid in tree.mainline_ids[:-1]
+        )
+        # ダウンロードファイルが生成される
+        download_update = final[-2]
+        report_path = Path(download_update["value"])
+        assert report_path.exists()
+        saved = json.loads(
+            report_path.read_text(encoding="utf-8")
+        )
+        assert len(saved["positions"]) == 4
+        assert "完了" in final[-1]
+
+    def test_analyze_all_cancel(self) -> None:
+        """キャンセルで全局面解析が途中終了する．"""
+        server = _make_server(kifu_path=MINI_CSA)
+        view, tree = server.initial_view, server.initial_tree
+        assert view is not None and tree is not None
+        gen = server._on_analyze_all(
+            view, tree, ClickState(), *OPTS, "playouts", 8
+        )
+        next(gen)  # 開始
+        next(gen)  # 1 局面目
+        server._cancel_event.set()
+        results = list(gen)
+        assert "キャンセル" in results[-1][-1]
+        # レポートは生成されない (view 更新なし)
+        assert view.report is None
 
     def test_on_load(self, real_report_path: Path) -> None:
         """_on_load が状態と全出力を返す．"""
-        server = AnalysisGuiServer()
+        server = _make_server()
         outputs = server._on_load(
             str(MINI_CSA),
             str(real_report_path),
-            True,
-            False,
-            5,
-            "winrate",
+            *OPTS,
         )
-        assert len(outputs) == 11
+        assert len(outputs) == 18
         view = outputs[0]
         assert view is not None
         assert view.document.n_moves == 4
         assert view.report is not None
-        # 読み込みステータス
-        assert "4 手" in outputs[4]
+        tree = outputs[1]
+        assert tree is not None
+        assert len(tree.mainline_ids) == 5
+        # 読み込みステータス (末尾)
+        assert "4 手" in outputs[-1]
 
     def test_on_load_without_kifu_raises(self) -> None:
         """棋譜ファイル未指定の読み込みはエラー．"""
-        server = AnalysisGuiServer()
+        server = _make_server()
         with pytest.raises(gr.Error):
-            server._on_load(
-                None, None, True, False, 5, "winrate"
-            )
+            server._on_load(None, None, *OPTS)
 
 
 class TestHelpers:
@@ -162,3 +402,11 @@ class TestHelpers:
     def test_file_path(self) -> None:
         assert _file_path(None) is None
         assert _file_path("/tmp/a.csa") == Path("/tmp/a.csa")
+
+    def test_budget_conversion(self) -> None:
+        server = _make_server(default_time_ms=500)
+        assert server._budget("time", 800) == (800, None)
+        assert server._budget("playouts", 32) == (None, 32)
+        # 不正値はデフォルト時間予算
+        assert server._budget("time", None) == (500, None)
+        assert server._budget("playouts", 0) == (500, None)

--- a/tests/maou/interface/test_analysis_gui.py
+++ b/tests/maou/interface/test_analysis_gui.py
@@ -6,13 +6,34 @@ from typing import Any
 
 import pytest
 
+from maou.app.analysis.analysis_session import (
+    _snapshot,
+    legal_move_infos,
+)
+from maou.domain.board.shogi import Board
 from maou.interface.analysis_gui import (
+    ClickState,
     SessionView,
+    advance_move,
     board_svg,
+    breadcrumb_markdown,
+    build_variation_tree,
+    candidate_usi,
     candidates_table,
+    click_overlays,
+    click_status_text,
+    current_node,
     eval_figure,
+    goto_node,
+    handle_board_click,
+    legal_move_choices,
     load_session,
+    mainline_ply,
     move_table,
+    node_board_svg,
+    node_candidates_table,
+    node_legal_moves,
+    node_position_info,
     position_analysis,
     position_info,
     sente_eval_cp,
@@ -419,3 +440,262 @@ class TestSummaryAndInfo:
         _, _, note = position_info(analyzed_view, 1)
         assert "エンジン最善: ▲2六歩" in note
         assert "0.030" in note
+
+
+@pytest.fixture
+def plain_tree(plain_view: SessionView) -> Any:
+    """レポートなしの分岐木を作る．"""
+    return build_variation_tree(plain_view.document, None)
+
+
+@pytest.fixture
+def analyzed_tree(analyzed_view: SessionView) -> Any:
+    """レポート取込済みの分岐木を作る．"""
+    return build_variation_tree(
+        analyzed_view.document, analyzed_view.report
+    )
+
+
+class TestBoardClickStateMachine:
+    """盤面クリック入力の状態機械のテスト．"""
+
+    def test_select_then_play(self, plain_tree: Any) -> None:
+        """自駒選択 → 行き先クリックで USI が確定する．"""
+        legal = node_legal_moves(plain_tree)
+        state, usi = handle_board_click(
+            legal, ClickState(), "sq:60", "b"
+        )
+        assert usi is None
+        assert state.selected == "sq:60"
+        state, usi = handle_board_click(
+            legal, state, "sq:59", "b"
+        )
+        assert usi == "7g7f"
+        assert state.selected is None
+
+    def test_click_empty_square_noop(
+        self, plain_tree: Any
+    ) -> None:
+        """起点にならないマスのクリックは何も起きない．"""
+        legal = node_legal_moves(plain_tree)
+        state, usi = handle_board_click(
+            legal, ClickState(), "sq:40", "b"
+        )
+        assert usi is None
+        assert state.selected is None
+
+    def test_reclick_deselects(self, plain_tree: Any) -> None:
+        """同じ起点の再クリックで選択解除される．"""
+        legal = node_legal_moves(plain_tree)
+        state, _ = handle_board_click(
+            legal, ClickState(), "sq:60", "b"
+        )
+        state, usi = handle_board_click(
+            legal, state, "sq:60", "b"
+        )
+        assert usi is None
+        assert state.selected is None
+
+    def test_switch_selection(self, plain_tree: Any) -> None:
+        """別の自駒クリックで選択が切り替わる．"""
+        legal = node_legal_moves(plain_tree)
+        state, _ = handle_board_click(
+            legal, ClickState(), "sq:60", "b"
+        )
+        # 2g = (2-1)*9 + (7-1) = 15
+        state, usi = handle_board_click(
+            legal, state, "sq:15", "b"
+        )
+        assert usi is None
+        assert state.selected == "sq:15"
+
+    def test_promotion_pending(self) -> None:
+        """成/不成の両方が合法な行き先で選択待ちに入る．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/4P4/9/9/9/9/4K4 b - 1")
+        snapshot = _snapshot(board, 0, None)
+        legal = legal_move_infos(snapshot)
+        # 5d = 39, 5c = 38
+        state, _ = handle_board_click(
+            legal, ClickState(), "sq:39", "b"
+        )
+        state, usi = handle_board_click(
+            legal, state, "sq:38", "b"
+        )
+        assert usi is None
+        assert state.pending_usis == ("5d5c+", "5d5c")
+
+    def test_pending_cancelled_by_board_click(self) -> None:
+        """選択待ち中の盤面クリックはキャンセルして再解釈する．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/4P4/9/9/9/9/4K4 b - 1")
+        snapshot = _snapshot(board, 0, None)
+        legal = legal_move_infos(snapshot)
+        state, _ = handle_board_click(
+            legal, ClickState(), "sq:39", "b"
+        )
+        state, _ = handle_board_click(
+            legal, state, "sq:38", "b"
+        )
+        assert state.pending_usis
+        state, usi = handle_board_click(
+            legal, state, "sq:39", "b"
+        )
+        assert usi is None
+        assert state.pending_usis == ()
+        assert state.selected == "sq:39"
+
+    def test_hand_drop(self) -> None:
+        """持ち駒クリック → 空きマスで駒打ちが確定する．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/9/9/9/9/9/4K4 b P 1")
+        snapshot = _snapshot(board, 0, None)
+        legal = legal_move_infos(snapshot)
+        state, _ = handle_board_click(
+            legal, ClickState(), "hand:b:0", "b"
+        )
+        assert state.selected == "hand:b:0"
+        # 5e = (5-1)*9 + (5-1) = 40
+        state, usi = handle_board_click(
+            legal, state, "sq:40", "b"
+        )
+        assert usi == "P*5e"
+
+    def test_opponent_hand_ignored(self) -> None:
+        """相手側の持ち駒クリックは選択されない．"""
+        board = Board()
+        board.set_sfen("4k4/9/9/9/9/9/9/9/4K4 b P 1")
+        snapshot = _snapshot(board, 0, None)
+        legal = legal_move_infos(snapshot)
+        state, usi = handle_board_click(
+            legal, ClickState(), "hand:w:0", "b"
+        )
+        assert usi is None
+        assert state.selected is None
+
+    def test_click_overlays(self, plain_tree: Any) -> None:
+        """選択中は選択マスと行き先が row-major で得られる．"""
+        legal = node_legal_moves(plain_tree)
+        state, _ = handle_board_click(
+            legal, ClickState(), "sq:60", "b"
+        )
+        selected, destinations = click_overlays(
+            legal, state, "b"
+        )
+        # 7g: col=6, row=6 → row-major 6*9+6 = 60 (対角なので同値)
+        assert selected == [60]
+        # 7f: col=6, row=5 → 5*9+6 = 51
+        assert destinations == [51]
+        # 未選択は空
+        assert click_overlays(legal, ClickState(), "b") == (
+            [],
+            [],
+        )
+
+    def test_click_status_text(self, plain_tree: Any) -> None:
+        """クリック状態の説明テキスト．"""
+        snapshot = current_node(plain_tree).snapshot
+        assert "クリック" in click_status_text(
+            snapshot, ClickState()
+        )
+        text = click_status_text(
+            snapshot, ClickState(selected="sq:60")
+        )
+        assert "7七歩" in text
+        text = click_status_text(
+            snapshot, ClickState(selected="hand:b:0")
+        )
+        assert "持ち駒の歩" in text
+        text = click_status_text(
+            snapshot,
+            ClickState(pending_usis=("5d5c+", "5d5c")),
+        )
+        assert "成" in text
+
+
+class TestLegalMoveChoices:
+    """合法手 Dropdown 選択肢のテスト．"""
+
+    def test_choices_labels(self, plain_tree: Any) -> None:
+        snapshot = current_node(plain_tree).snapshot
+        legal = node_legal_moves(plain_tree)
+        choices = legal_move_choices(snapshot, legal)
+        assert len(choices) == 30
+        labels = {label for label, _usi in choices}
+        values = {usi for _label, usi in choices}
+        assert "7g7f" in values
+        assert any("▲7六歩" in label for label in labels)
+
+
+class TestVariationNavigation:
+    """分岐木ナビゲーション表示のテスト．"""
+
+    def test_breadcrumb_mainline(self, plain_tree: Any) -> None:
+        assert "初期局面" in breadcrumb_markdown(plain_tree)
+        goto_node(plain_tree, plain_tree.mainline_ids[2])
+        assert "2手目" in breadcrumb_markdown(plain_tree)
+
+    def test_breadcrumb_branch(self, plain_tree: Any) -> None:
+        advance_move(plain_tree, "7g7f")
+        advance_move(plain_tree, "8c8d")  # 分岐
+        text = breadcrumb_markdown(plain_tree)
+        assert "本譜 1手目" in text
+        assert "▶" in text
+        assert "△8四歩" in text
+
+    def test_mainline_ply(self, plain_tree: Any) -> None:
+        advance_move(plain_tree, "7g7f")
+        assert mainline_ply(plain_tree) == 1
+        advance_move(plain_tree, "8c8d")  # 分岐
+        assert mainline_ply(plain_tree) == 1
+
+    def test_node_board_svg_interactive(
+        self, analyzed_tree: Any
+    ) -> None:
+        legal = node_legal_moves(analyzed_tree)
+        svg = node_board_svg(
+            analyzed_tree,
+            click_state=ClickState(selected="sq:60"),
+            legal=legal,
+            interactive=True,
+        )
+        assert 'data-click="sq:60"' in svg
+        assert "rgba(255,152,0,0.35)" in svg  # 選択マス
+        assert "rgba(76,175,80,0.28)" in svg  # 行き先
+
+    def test_node_candidates_table(
+        self, analyzed_tree: Any
+    ) -> None:
+        rows = node_candidates_table(analyzed_tree, top_n=5)
+        assert rows
+        assert rows[0][0] == "1"
+
+    def test_candidate_usi(self, analyzed_tree: Any) -> None:
+        analysis = current_node(analyzed_tree).analysis
+        assert candidate_usi(analysis, 0, 5) == "2g2f"
+        assert candidate_usi(analysis, 99, 5) is None
+        assert candidate_usi(None, 0, 5) is None
+
+    def test_node_position_info_mainline(
+        self, analyzed_view: SessionView, analyzed_tree: Any
+    ) -> None:
+        goto_node(analyzed_tree, analyzed_tree.mainline_ids[1])
+        sfen, position_str, _note = node_position_info(
+            analyzed_view, analyzed_tree
+        )
+        assert position_str.endswith("moves 7g7f")
+        assert sfen == (
+            analyzed_view.document.snapshots[1].sfen
+        )
+
+    def test_node_position_info_branch(
+        self, analyzed_view: SessionView, analyzed_tree: Any
+    ) -> None:
+        advance_move(analyzed_tree, "2g2f")  # 本譜は 7g7f
+        sfen, position_str, note = node_position_info(
+            analyzed_view, analyzed_tree
+        )
+        assert position_str.endswith("moves 2g2f")
+        assert "分岐" in note
+        assert "未解析" in note
+        assert sfen.split(" ")[1] == "w"

--- a/uv.lock
+++ b/uv.lock
@@ -1507,7 +1507,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.44.0"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

棋譜解析 GUI (`maou analyze-gui`) の**マイルストーン 2: 対話解析機能**を実装する (設計: `docs/design/game-analysis/gui.md` §8-11，PR #390 の続き)．

- **継盤 (分岐)**: 本譜と違う手を指すと自動で分岐．パンくず表示 (`本譜 1手目 ▶ △3四歩 ▶ ▲2二角成`) + 「本譜へ戻る」．分岐はセッション中保持
- **盤面クリック入力**: 駒 (または持ち駒) → 行き先の 2 クリック方式．行き先ハイライト，成/不成の確認ボタン，合法手 Dropdown フォールバック
- **1 局面解析**: 常駐 SearchEngine で現在ノード (本譜/分岐) を解析．ノード単位キャッシュ + 明示的「再解析」，「PV を分岐で再生」
- **全局面解析**: 進捗表示 + 協調キャンセル．完走時は analyze-game 互換 JSON をダウンロード可能 (グラフ/棋譜リスト/サマリも更新)
- CLI にエンジン系オプション追加 (`--model-path` / `--time-ms` / `--playouts` / 探索 passthrough / `--cuda` / `--tensorrt`)．モデル未指定時は mock 評価器で UI に「開発検証専用」を明示

## 設計上の判断・注意点 (レビュー観点)

1. **モデル未指定時の解析 UI**: gui.md §3 の旧記述は「CLI ブロック = mock 評価器で可」と「モード表 = 解析ボタン無効化」が矛盾していたため，**mock + UI 明示に一本化**しました (analyze-game の `--model-path` 省略時と同じ扱い)．gui.md に経緯を記載済み — 無効化が意図でしたらお知らせください
2. **Gradio 6 の実測制約**: server_functions ブリッジの `trigger("change")` イベントは **value 更新のみ反映され，`gr.update` の prop 更新 (visible/choices) が適用されない**．`.then()` で通常イベントを連鎖して回避 (gui.md §10 に記録)
3. **pre-existing バグ修正**: 駒打ち矢印の始点が常に先手持ち駒エリアだったのを手番側に修正 (回帰テスト付き)
4. **分岐木は ID 参照 arena** (親子ポインタでなく `nodes[node_id]`)．`gr.State` の deepcopy 制約に対応する plain data
5. `game_analyzer` の `_position_record`/`_summary` をモジュール関数 `position_record`/`summarize_positions` に抽出し GUI と共用 (レポートスキーマの相互運用を保証)

## テスト

- `uv run pytest`: **937 passed / 77 skipped** (ベースライン 876 → 新規 61)
  - 分岐木 (再利用/経路/復帰/deepcopy)，クリック状態機械 (成/不成保留・駒打ち・相手持ち駒無視)，interactive_analyzer (mock 実エンジン integration，キャンセル)，renderer (クリック標的/塗り/駒打ち矢印の手番側)，サーバーハンドラ，CLI 検証
- QA: ruff / isort / mypy すべて green．Rust 不変更
- **playwright 実機検証 (8 手順スクリーンショット目視)**: 初期表示 / 7g 選択 (行き先ハイライト) / ▲7六歩 / 分岐パンくず (△9四歩) / 分岐ノードの 1 局面解析 / 成・不成確認 → ▲2二角成 (馬+持ち駒角) / 全局面解析 44 局面完走 + レポートダウンロード (70.2 KB)

## ドキュメント

- `docs/commands/analyze_gui.md`: オプション表 + 対話解析機能を追記
- `docs/design/game-analysis/gui.md`: §3-13 を実装済みに更新 (living doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrRKHWnRUDutBhFXUWVvrb