### PR TITLE
fix: TRT キャッシュディレクトリの事前作成と致命エラーの info string 通知

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -60,7 +60,7 @@
 | `--leaf-mate-threads INT` | default `1` | Number of dedicated leaf-mate threads. |
 | `--cuda/--no-cuda` | default off | Enable CUDA Execution Provider (requires a wheel built with `onnx-cuda`). |
 | `--tensorrt/--no-tensorrt` | default off | Enable TensorRT Execution Provider (requires a wheel built with `onnx-tensorrt`). |
-| `--trt-cache-dir PATH` | | TensorRT engine cache directory. |
+| `--trt-cache-dir PATH` | | TensorRT engine cache directory. Created automatically if missing; startup fails with a clear error when the parent path is unavailable (e.g. Google Drive not mounted on Colab). |
 
 ## USI options (`setoption`)
 

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/onnx.rs
+++ b/rust/maou_search/src/onnx.rs
@@ -106,6 +106,16 @@ impl OnnxEvaluator {
                 .trt_engine_cache_dir
                 .clone()
                 .unwrap_or_else(|| "trt_cache".to_string());
+            // TensorRT provider はキャッシュディレクトリの親を作らず，不在だと
+            // "filesystem error: cannot create directory" で session 構築ごと
+            // 失敗する (Colab の Drive 未マウントで実際に発生)．ここで作成し，
+            // 作れない場合は原因が分かるエラーにする
+            std::fs::create_dir_all(&cache_dir).map_err(|e| {
+                ort::Error::new(format!(
+                    "TensorRT engine cache dir cannot be created: {cache_dir} ({e}) \
+                     — check that the parent path exists (e.g. Google Drive mounted)"
+                ))
+            })?;
             let ep = TensorRTExecutionProvider::default()
                 .with_fp16(true)
                 .with_engine_cache(true)

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/stdio.rs
+++ b/rust/maou_usi/src/stdio.rs
@@ -69,14 +69,32 @@ where
             }
             Err(e) => {
                 // 致命的エラー (モデルロード失敗・不正局面)．詳細は stderr，
-                // GUI へは ASCII の info string で通知して終了する
+                // GUI へは理由を ASCII 化した info string で通知して終了する
+                // (subprocess の stderr が見えない環境 — Colab 等 — でも
+                // 原因が stdout 側から分かるように)
                 eprintln!("maou usi fatal: {e}");
-                let _ = writeln!(out, "info string ERROR: engine aborted (see stderr)");
+                let _ = writeln!(out, "info string ERROR: {}", sanitize_ascii(&e));
                 let _ = out.flush();
                 return Err(e);
             }
         }
     }
+}
+
+/// `info string` 用にエラーメッセージを 1 行の ASCII へ丸める
+/// (GUI のエンコーディング差と行指向プロトコルの保護)．
+fn sanitize_ascii(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii() && !c.is_ascii_control() {
+                c
+            } else if c.is_whitespace() {
+                ' '
+            } else {
+                '?'
+            }
+        })
+        .collect()
 }
 
 /// 標準入出力で USI エンジンを実行する (quit / EOF まで戻らない)．
@@ -161,6 +179,13 @@ mod tests {
             .expect("探索サマリ info がある");
         let pv_pos = info.find(" pv ").expect("pv がある");
         assert!(!info[pv_pos..].contains(" score "), "pv は末尾に置く");
+    }
+
+    #[test]
+    fn test_sanitize_ascii() {
+        assert_eq!(sanitize_ascii("plain error 123"), "plain error 123");
+        // 非 ASCII は '?'，改行は空白 (1 行の info string を壊さない)
+        assert_eq!(sanitize_ascii("不正な SFEN\nrow2"), "??? SFEN row2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Colab での M1 検証 (PR #393) 中に発覚した堅牢性 2 点の修正 (maou_search 0.18.1 / maou_usi 0.1.1)

## Problem

Colab で `TrtCacheDir` に未マウントの Google Drive パスを指定すると，TensorRT provider が "filesystem error: cannot create directory" で session 構築ごと失敗し，エンジンが exit 1 で終了する．さらに subprocess の stderr が見えない環境 (Colab notebook 等) では原因が全く見えず，「readyok 前後で静かに死ぬ」ように観測される (実際の検証で発生し，切り分けに診断セルを要した)．

## Solution

1. **キャッシュディレクトリの事前作成**: `OnnxEvaluator::from_file` で `create_dir_all` する．通常のパスなら自動作成で解決し，親が存在しない (Drive 未マウント等) 場合は原因の分かるエラーメッセージにする．`maou usi` / `maou search` / analyze 系すべてに効く (単一実装)
2. **致命エラー理由の info string 通知**: USI の fatal 経路で `info string ERROR: <ASCII 化した理由>` を stdout に出す — stderr が見えない環境でも GUI/呼び出し側から原因が分かる

## Testing

- `cargo check -p maou_search --features onnx-tensorrt` (新コードは TRT feature 内)
- Rust 105 テスト green (sanitize_ascii の単体を追加)．clippy/fmt clean
- Colab 実機では回避策 (ローカルキャッシュパス) で TRT 経路の動作確認済み — 本修正は同じ失敗を明示エラー/自動回復に変える

## Review Notes

- 挙動変更は「TRT キャッシュディレクトリが無ければ作る」のみ．既存の正常経路は不変
- docs/commands/usi.md の `--trt-cache-dir` 行に自動作成を追記