### PR TITLE
feat: USI エンジン M2 — 対局戦略一式 (info 随時出力/入玉宣言/投了/DrawValue/MaxMovesToDraw)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.8.2"
+version = "5.9.0"
 dependencies = [
  "arrayvec",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -17,15 +17,20 @@
 - When no model is configured, a deterministic **mock evaluator** is used and
   announced with `info string mock evaluator (development only) ...` on
   `isready` (development/verification only — move quality is meaningless).
-- Supported in milestone M1: full game loop (`usi` / `isready` / `setoption` /
-  `usinewgame` / `position` / `go` with `btime wtime byoyomi binc winc`,
-  `go infinite`, `go nodes`, `go movetime` / `stop` / `gameover` / `quit`),
-  simple time strategy (byoyomi / Fischer / sudden death with a network-delay
-  margin), root-dfpn + leaf-mate search, resign on mated positions.
+- Supported through milestone M2: full game loop (`usi` / `isready` /
+  `setoption` / `usinewgame` / `position` / `go` with
+  `btime wtime byoyomi binc winc`, `go infinite`, `go nodes`, `go movetime` /
+  `stop` / `gameover` / `quit`); time strategy with soft/hard budgets and
+  best-move-instability extension (byoyomi / Fischer / sudden death, network
+  delay margin); streaming `info` during search; draw-value strategy
+  (`DrawValueBlack` / `DrawValueWhite`); nyugyoku declaration win
+  (`bestmove win`, 27-point rule); resign threshold (`ResignValue` /
+  `ResignConsecutive`, off by default); `MaxMovesToDraw` (declaration check +
+  budget narrowing near the limit); root-dfpn + leaf-mate search.
   Not yet implemented (later milestones): ponder (`USI_Ponder` is not
-  declared), nyugyoku declaration win (`bestmove win`), resign threshold,
-  max-move-limit strategy, tournament opening scripts, `go mate`
-  (answers `checkmate notimplemented`).
+  declared) and subtree reuse (M3), tournament opening scripts and the
+  self-play driver (M4), the in-search `MaxMovesToDraw` draw terminal (M4),
+  `go mate` (answers `checkmate notimplemented`).
 
 ## Engine registration in a GUI
 
@@ -52,6 +57,11 @@
 | `--node-capacity INT` | | Node pool capacity (default 2^20 nodes). |
 | `--network-delay-ms INT` | default `1000` | Communication overhead margin in milliseconds. The GUI/server measures elapsed time including transport, so the per-move budget is reduced by this amount. |
 | `--min-think-ms INT` | default `100` | Minimum thinking time in milliseconds. |
+| `--draw-value-black INT` | default `500` | Draw value for Black in permille. Repetition / max-moves draw terminals are valued at this (root side-to-move view). Denryu-sen Black 0.4 win = `400`. |
+| `--draw-value-white INT` | default `500` | Draw value for White in permille (Denryu-sen White 0.6 win = `600`). |
+| `--resign-value INT` | default `0` | Resign when the root win rate stays below this permille for `--resign-consecutive` moves. `0` = never resign. |
+| `--resign-consecutive INT` | default `3` | Consecutive below-threshold moves required to resign (with `--resign-value > 0`). |
+| `--max-moves-to-draw INT` | default `0` | Move count for a drawn game (`0` = disabled; Denryu-sen `512`). At/near the limit the engine always checks nyugyoku declaration and narrows its search budget. |
 | `--root-dfpn/--no-root-dfpn` | **default on** | Run dfpn mate search on the root position in parallel with MCTS. |
 | `--root-dfpn-nodes INT` | default `2000000` | Node budget for the root dfpn mate search. |
 | `--root-dfpn-depth INT` | default `2047` | Search depth limit for the root dfpn mate search (max 2047). |
@@ -75,6 +85,10 @@ Declared in the `usi` response; defaults reflect the CLI flags above.
 | `TrtCacheDir` | string | TensorRT engine cache directory. |
 | `NetworkDelay` | spin (ms) | Communication margin subtracted from each move budget. |
 | `MinimumThinkingTime` | spin (ms) | Minimum thinking time. |
+| `DrawValueBlack` / `DrawValueWhite` | spin (permille) | Draw value per side (default 500; Denryu-sen 400 / 600). Converted to the search's side-to-move `draw_value`. |
+| `ResignValue` | spin (permille) | Resign win-rate threshold (0 = never). |
+| `ResignConsecutive` | spin | Consecutive below-threshold moves required to resign. |
+| `MaxMovesToDraw` | spin | Move count for a drawn game (0 = disabled; Denryu-sen 512). |
 | `RootDfpn` / `LeafMate` | check | Mate search toggles. |
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.47.0"
+version = "0.48.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_usi.rs
+++ b/rust/maou_rust/src/maou_usi.rs
@@ -24,6 +24,11 @@ use maou_usi::{EngineConfig, TimeStrategyConfig};
 /// - `trt_engine_cache_dir` (str, optional): TensorRT エンジンキャッシュ保存先．
 /// - `network_delay_ms` (int, optional): 通信マージン (デフォルト 1000)．
 /// - `min_think_ms` (int, optional): 最低思考時間 (デフォルト 100)．
+/// - `draw_value_black` / `draw_value_white` (int, optional): 先手/後手の引き分け
+///   価値 (千分率，デフォルト 500．電竜戦 0.4/0.6 勝 = 400/600)．
+/// - `resign_value` (int, optional): 投了する root 勝率 (千分率，デフォルト
+///   0 = 投了しない)．`resign_consecutive` (int, optional): 投了に必要な連続手数．
+/// - `max_moves_to_draw` (int, optional): 引き分け最大手数 (デフォルト 0 = 無効)．
 /// - `root_dfpn` / `root_dfpn_nodes` / `root_dfpn_depth`: ルート並行 dfpn．
 /// - `leaf_mate` / `leaf_mate_nodes` / `leaf_mate_threads`: leaf-mate．
 ///
@@ -31,7 +36,7 @@ use maou_usi::{EngineConfig, TimeStrategyConfig};
 ///
 /// モデルロード失敗・不正局面などの致命的エラーは `RuntimeError`．
 #[pyfunction]
-#[pyo3(signature = (*, engine_name=None, engine_author=None, model_path=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, network_delay_ms=None, min_think_ms=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
+#[pyo3(signature = (*, engine_name=None, engine_author=None, model_path=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, network_delay_ms=None, min_think_ms=None, draw_value_black=None, draw_value_white=None, resign_value=None, resign_consecutive=None, max_moves_to_draw=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
 #[allow(clippy::too_many_arguments)]
 fn run_usi(
     py: Python<'_>,
@@ -46,6 +51,11 @@ fn run_usi(
     trt_engine_cache_dir: Option<String>,
     network_delay_ms: Option<u64>,
     min_think_ms: Option<u64>,
+    draw_value_black: Option<u32>,
+    draw_value_white: Option<u32>,
+    resign_value: Option<u32>,
+    resign_consecutive: Option<u32>,
+    max_moves_to_draw: Option<u32>,
     root_dfpn: Option<bool>,
     root_dfpn_nodes: Option<u64>,
     root_dfpn_depth: Option<u32>,
@@ -77,6 +87,21 @@ fn run_usi(
         min_think_ms: min_think_ms.unwrap_or(time_defaults.min_think_ms),
         horizon_moves: time_defaults.horizon_moves,
     };
+    if let Some(v) = draw_value_black {
+        config.draw_value_black = v;
+    }
+    if let Some(v) = draw_value_white {
+        config.draw_value_white = v;
+    }
+    if let Some(v) = resign_value {
+        config.resign_value = v;
+    }
+    if let Some(v) = resign_consecutive {
+        config.resign_consecutive = v.max(1);
+    }
+    if let Some(v) = max_moves_to_draw {
+        config.max_moves_to_draw = v;
+    }
     config.root_dfpn = root_dfpn;
     config.root_dfpn_nodes = root_dfpn_nodes;
     config.root_dfpn_depth = root_dfpn_depth;

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/lib.rs
+++ b/rust/maou_search/src/lib.rs
@@ -53,5 +53,6 @@ pub use onnx::OnnxEvaluator;
 pub use position::{build_board_and_history, PositionSetupError};
 pub use repetition::{HistoryEntry, RepetitionOutcome};
 pub use search::{
-    RootChildStat, SearchLimits, SearchOptions, SearchResult, SearchStats, Searcher, StopCause,
+    RootChildStat, RootSnapshot, SearchLimits, SearchOptions, SearchResult, SearchStats, Searcher,
+    StopCause,
 };

--- a/rust/maou_search/src/search.rs
+++ b/rust/maou_search/src/search.rs
@@ -75,6 +75,11 @@ const DEFAULT_MAX_PLAYOUTS: u64 = 1 << 20;
 /// PV 復元の最大長．
 const MAX_PV_LEN: usize = 64;
 
+/// 進捗スナップショット ([`SearchLimits::progress`]) を発行する playout 間隔．
+/// 1 回の発行は root 辺の走査 + PV 復元 (`MAX_PV_LEN` 上限) のみで安価だが，
+/// 過剰発行を避けるため間引く (エージェント側も `info` を時間 gate する)．
+const PROGRESS_PUBLISH_PLAYOUTS: u64 = 1024;
+
 /// leaf-mate ソルバ 1 回あたりのタイムアウト (秒)．探索は `leaf_mate_nodes`
 /// で node-bound されるので実際には到達しない安全弁 (50 ノード探索は μ 秒オーダ)．
 const LEAF_MATE_TIMEOUT_SECS: u64 = 1;
@@ -142,6 +147,14 @@ pub struct SearchOptions {
     /// 多く解放し，次の GC までの間隔が延びる (刈られたサブツリーの再展開
     /// コストとのトレードオフ)．
     pub gc_keep_ratio: f32,
+    /// 引き分け終端 (千日手・最大手数) の評価値 (**root 手番視点**，既定 0.5)．
+    /// エージェントが先後・持ち時間ルール (電竜戦の 0.4/0.6 勝など) から変換
+    /// して渡す (docs/design/usi-engine/index.md §6-4/§8.2)．葉ノードでは手番の
+    /// パリティに応じて `draw_value` / `1 − draw_value` を用い，backprop の視点
+    /// 反転で root からは常に `draw_value` に集約される．勝敗確定 (AND-OR) の
+    /// 論理値 0.5 (proven::DRAW) はゲーム理論値のまま変えない (探索の選好のみを
+    /// 変える)．0.5 のとき従来と bit-identical．
+    pub draw_value: f64,
     /// ルート局面の dfpn 詰み探索を MCTS と並行実行するか (既定 false)．
     /// 詰みが証明されたら root を勝ち確定にして探索を停止し，詰み手順を
     /// best_move / PV として返す ([`StopCause::RootProven`])．
@@ -176,6 +189,7 @@ impl Default for SearchOptions {
             max_ply: 512,
             gc_enabled: true,
             gc_keep_ratio: 0.5,
+            draw_value: 0.5,
             // 詰み探索はデフォルト有効: root-dfpn は NN 非依存で root/盲点の詰みを，
             // leaf-mate は MCTS が降りる narrow mate を，いずれも余剰 CPU (別スレッド)
             // で捕捉し，詰みのない局面では NPS を落とさない (実測: 静かな局面で dfpn は
@@ -211,6 +225,12 @@ pub struct SearchLimits {
     /// から立てると [`StopCause::External`] で停止する．応答性は worker の
     /// ループ粒度 (評価バッチ 1 回分) に律速される．
     pub stop: Option<Arc<AtomicBool>>,
+    /// 進捗スナップショットの発行先 (`None` = 発行しない)．設定すると worker が
+    /// 一定 playout 間隔で root 統計 ([`RootSnapshot`]) をここへ上書きする
+    /// (docs/design/usi-engine/index.md §6-3)．USI の `info` 随時出力と時間
+    /// 延長判断の入力に使う．発行は読み取り専用 (探索挙動に影響しない) の
+    /// ため，`None` のとき従来と bit-identical．
+    pub progress: Option<Arc<Mutex<Option<RootSnapshot>>>>,
 }
 
 /// 探索が停止した理由．
@@ -300,6 +320,84 @@ fn select_best_root_index(children: &[RootChildStat]) -> usize {
     best_i
 }
 
+/// root 直下の全子の統計を合法手生成順に集める (読み取り専用)．
+///
+/// [`Searcher::collect_result`] (探索終了後) と [`Shared::build_snapshot`]
+/// (探索中の近似) が共有する．
+fn root_children_of(pool: &NodePool) -> Vec<RootChildStat> {
+    pool.get(ROOT_IDX)
+        .edges()
+        .iter()
+        .map(|e| {
+            let (visits, q, proven) = match e.child.load(Ordering::Acquire) {
+                NULL_NODE => (0, 0.0, None),
+                c => {
+                    let child = pool.get(c);
+                    let v = child.visits();
+                    let q = if v == 0 { 0.0 } else { child.wins() / v as f64 };
+                    // 確定値は子ノード手番側視点なのでルート視点へ反転する
+                    (v, q, child.proven_value().map(|pv| 1.0 - pv))
+                }
+            };
+            RootChildStat {
+                mv: e.mv,
+                visits,
+                q,
+                prior: e.prior,
+                proven,
+            }
+        })
+        .collect()
+}
+
+/// robust child を選び，root が確定していれば確定値を達成する子を優先する．
+///
+/// 勝ち確定なら root 視点の確定値 (1) の子，引き分け確定なら 0.5 の子を選ぶ
+/// (訪問回数最大は確定前の探索の偏りを引きずり得る)．負け確定は全子が負け
+/// 確定なので robust child のまま (どれでも同値)．
+fn best_root_index(children: &[RootChildStat], root_proven: Option<f64>) -> usize {
+    let mut best_i = select_best_root_index(children);
+    if let Some(rv) = root_proven {
+        if rv > 0.0 {
+            if let Some(i) = children.iter().position(|c| c.proven == Some(rv)) {
+                best_i = i;
+            }
+        }
+    }
+    best_i
+}
+
+/// best 手を先頭に，以降は訪問回数最大の辺を辿って PV を復元する．
+fn extract_pv(pool: &NodePool, first_mv: Move, first_child: u32) -> Vec<Move> {
+    let mut pv = vec![first_mv];
+    let mut idx = first_child;
+    while idx != NULL_NODE && pv.len() < MAX_PV_LEN {
+        let node = pool.get(idx);
+        if node.state() != node_state::EXPANDED {
+            break;
+        }
+        let edges = node.edges();
+        let mut pv_best: Option<(&Edge, u64)> = None;
+        for e in edges {
+            let c = e.child.load(Ordering::Acquire);
+            if c == NULL_NODE {
+                continue;
+            }
+            let v = pool.get(c).visits();
+            if v == 0 {
+                continue;
+            }
+            if pv_best.is_none_or(|(_, bv)| v > bv) {
+                pv_best = Some((e, v));
+            }
+        }
+        let Some((e, _)) = pv_best else { break };
+        pv.push(e.mv);
+        idx = e.child.load(Ordering::Acquire);
+    }
+    pv
+}
+
 /// 探索の実行統計．
 #[derive(Clone, Debug)]
 pub struct SearchStats {
@@ -364,6 +462,33 @@ pub struct SearchResult {
     pub stats: SearchStats,
 }
 
+/// 探索中の root 進捗スナップショット ([`SearchLimits::progress`] 経由で発行)．
+///
+/// worker が一定間隔で上書きする近似値 (atomic 読みのため未定義動作はないが，
+/// 個々のフィールドは同一瞬間の一貫スナップショットとは限らない)．USI の
+/// `info` 随時出力・時間延長判断・resign 判断の入力に使う．
+#[derive(Clone, Debug, Default)]
+pub struct RootSnapshot {
+    /// これまでの完了 playout 数．
+    pub playouts: u64,
+    /// playout 毎秒 (探索開始からの経過に対する平均)．
+    pub nps: f64,
+    /// 到達最大深さ．
+    pub max_depth: u16,
+    /// 現時点の最有力手 (robust child．root に辺がなければ `None`)．
+    pub best_move: Option<Move>,
+    /// 最有力手の訪問回数．
+    pub best_visits: u64,
+    /// 2 番目に訪問された root 直下手の訪問回数 (延長判断の拮抗度に使う)．
+    pub second_visits: u64,
+    /// 最有力手の root 手番視点勝率 (root 確定時は確定値)．
+    pub winrate: f64,
+    /// 読み筋 (訪問回数最大の経路)．
+    pub pv: Vec<Move>,
+    /// root の確定値 (詰み等)．未確定は `None`．
+    pub proven: Option<f64>,
+}
+
 /// スレッド間共有の探索状態．
 struct Shared<'a, E: Evaluator> {
     pool: NodePool,
@@ -402,6 +527,12 @@ struct Shared<'a, E: Evaluator> {
     /// 世代と現世代が一致するときだけ proof を適用する (compact 後の無効 index
     /// への誤マーク=偽証明を防ぐ)．
     generation: AtomicU64,
+    /// 計測開始時刻 (warmup 完了後)．進捗スナップショットの nps/経過に使う．
+    start: Instant,
+    /// 進捗スナップショットの発行先 ([`SearchLimits::progress`])．
+    progress: Option<Arc<Mutex<Option<RootSnapshot>>>>,
+    /// 次にスナップショットを発行する playout 数の閾値 (CAS で 1 worker のみ発行)．
+    next_publish: AtomicU64,
 }
 
 impl<E: Evaluator> Shared<'_, E> {
@@ -495,6 +626,89 @@ impl<E: Evaluator> Shared<'_, E> {
         let d = depth.min(u16::MAX as usize) as u16;
         self.max_depth.fetch_max(d, Ordering::Relaxed);
     }
+
+    /// 引き分け終端 (千日手・最大手数) の葉手番視点評価値．
+    ///
+    /// `draw_value` は root 手番視点の引き分け価値．葉の手番が root と一致する
+    /// 偶数深さ (root = depth 0) では `draw_value`，相手番の奇数深さでは
+    /// `1 − draw_value` を返す．backprop の視点反転で root からは常に
+    /// `draw_value` に集約される (非対称引き分け 0.4/0.6 を一貫して表現する)．
+    fn draw_leaf_value(&self, path_len: usize) -> f64 {
+        draw_leaf_value_at(self.opts.draw_value, path_len)
+    }
+
+    /// 一定 playout 間隔で root 進捗スナップショットを発行する (worker から呼ぶ)．
+    ///
+    /// [`SearchLimits::progress`] 未設定なら何もしない (従来と bit-identical)．
+    /// 閾値を跨いだ worker のうち CAS で 1 つだけが実際に発行する
+    /// (root 走査 + PV 復元の重複を避ける)．発行内容は atomic 読みの近似値で
+    /// あり，探索の木・playout 会計には一切影響しない．
+    fn maybe_publish_progress(&self) {
+        let Some(cell) = &self.progress else {
+            return;
+        };
+        let done = self.playouts.load(Ordering::Relaxed);
+        let next = self.next_publish.load(Ordering::Relaxed);
+        if done < next {
+            return;
+        }
+        // 跨いだ worker が複数いても発行は 1 つだけ (次閾値へ CAS 前進)
+        if self
+            .next_publish
+            .compare_exchange(
+                next,
+                done + PROGRESS_PUBLISH_PLAYOUTS,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return;
+        }
+        let snapshot = self.build_snapshot();
+        if let Ok(mut slot) = cell.lock() {
+            *slot = Some(snapshot);
+        }
+    }
+
+    /// 現在の木から root 進捗スナップショットを構築する (読み取り専用)．
+    ///
+    /// robust child 選択・root 確定手優先・PV 復元は [`Searcher::collect_result`]
+    /// と同じ関数を共有する (最終結果と同じ基準)．探索中の呼び出しでは
+    /// atomic 読みの近似となる．
+    fn build_snapshot(&self) -> RootSnapshot {
+        let pool = &self.pool;
+        let children = root_children_of(pool);
+        if children.is_empty() {
+            return RootSnapshot::default();
+        }
+        let root_node = pool.get(ROOT_IDX);
+        let root_proven = root_node.proven_value();
+        let best_i = best_root_index(&children, root_proven);
+        let best = &children[best_i];
+        let second_visits = children
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != best_i)
+            .map(|(_, c)| c.visits)
+            .max()
+            .unwrap_or(0);
+        let first_child = root_node.edges()[best_i].child.load(Ordering::Acquire);
+        let pv = extract_pv(pool, best.mv, first_child);
+        let playouts = self.playouts.load(Ordering::Relaxed);
+        let nps = playouts as f64 / self.start.elapsed().as_secs_f64().max(1e-9);
+        RootSnapshot {
+            playouts,
+            nps,
+            max_depth: self.max_depth.load(Ordering::Relaxed),
+            best_move: Some(best.mv),
+            best_visits: best.visits,
+            second_visits,
+            winrate: root_proven.unwrap_or(best.q),
+            pv,
+            proven: root_proven,
+        }
+    }
 }
 
 /// 葉選択の結果．
@@ -529,6 +743,18 @@ fn backprop<E: Evaluator>(shared: &Shared<'_, E>, path: &[u32], leaf_value: f64)
     }
 }
 
+/// 引き分け終端の葉手番視点評価値 (パリティ純関数．[`Shared::draw_leaf_value`]
+/// の実体)．`draw_value` は root 手番視点の引き分け価値．root (depth 0) と同じ
+/// 手番の偶数深さでは `draw_value`，相手番の奇数深さでは `1 − draw_value`．
+fn draw_leaf_value_at(draw_value: f64, path_len: usize) -> f64 {
+    let depth = path_len - 1; // path[0] = root = depth 0
+    if depth.is_multiple_of(2) {
+        draw_value
+    } else {
+        1.0 - draw_value
+    }
+}
+
 /// 終端状態の固定評価値 (そのノードの手番側から見た勝率)．
 fn terminal_value(state: u8) -> f64 {
     match state {
@@ -536,6 +762,15 @@ fn terminal_value(state: u8) -> f64 {
         node_state::TERMINAL_DRAW => 0.5,
         node_state::TERMINAL_WIN => 1.0,
         other => unreachable!("終端状態のみ: {other}"),
+    }
+}
+
+/// 終端状態の葉手番視点評価値 (引き分けのみ `draw_value` を手番視点で適用)．
+fn terminal_leaf_value<E: Evaluator>(shared: &Shared<'_, E>, state: u8, path_len: usize) -> f64 {
+    if state == node_state::TERMINAL_DRAW {
+        shared.draw_leaf_value(path_len)
+    } else {
+        terminal_value(state)
     }
 }
 
@@ -630,7 +865,14 @@ fn select_leaf<E: Evaluator>(shared: &Shared<'_, E>) -> Selection {
         // 降下せず確定値をその場でバックプロパゲーションする
         if let Some(v) = node.proven_value() {
             shared.note_depth(path.len());
-            backprop(shared, &path, v);
+            // 確定引き分け (proven::DRAW = 0.5) は draw_value を手番視点で，
+            // 勝敗確定 (0.0/1.0) は確定値をそのまま backprop する
+            let leaf = if v == 0.5 {
+                shared.draw_leaf_value(path.len())
+            } else {
+                v
+            };
+            backprop(shared, &path, leaf);
             return Selection::Backpropped;
         }
         match node.state() {
@@ -693,7 +935,8 @@ fn select_leaf<E: Evaluator>(shared: &Shared<'_, E>) -> Selection {
 
                 if path.len() > opts.max_ply as usize {
                     shared.note_depth(path.len());
-                    backprop(shared, &path, 0.5);
+                    // 最大深さ打ち切りは引き分け扱い (draw_value を手番視点で適用)
+                    backprop(shared, &path, shared.draw_leaf_value(path.len()));
                     return Selection::Backpropped;
                 }
             }
@@ -712,7 +955,11 @@ fn select_leaf<E: Evaluator>(shared: &Shared<'_, E>) -> Selection {
                     node.mark_terminal(state);
                     shared.repetitions.fetch_add(1, Ordering::Relaxed);
                     shared.note_depth(path.len());
-                    backprop(shared, &path, terminal_value(state));
+                    backprop(
+                        shared,
+                        &path,
+                        terminal_leaf_value(shared, state, path.len()),
+                    );
                     propagate_proven_from(shared, &path);
                     return Selection::Backpropped;
                 }
@@ -753,7 +1000,11 @@ fn select_leaf<E: Evaluator>(shared: &Shared<'_, E>) -> Selection {
             | node_state::TERMINAL_DRAW
             | node_state::TERMINAL_WIN) => {
                 shared.note_depth(path.len());
-                backprop(shared, &path, terminal_value(state));
+                backprop(
+                    shared,
+                    &path,
+                    terminal_leaf_value(shared, state, path.len()),
+                );
                 return Selection::Backpropped;
             }
             other => unreachable!("未知のノード状態: {other}"),
@@ -841,6 +1092,8 @@ fn worker<E: Evaluator>(shared: &Shared<'_, E>) {
         }
         shared.complete_playouts(n);
         shared.check_deadline();
+        // 進捗スナップショットを一定 playout 間隔で発行 (progress 未設定なら no-op)
+        shared.maybe_publish_progress();
     }
 }
 
@@ -1037,6 +1290,9 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
             mate_queue: Arc::new(Mutex::new(VecDeque::new())),
             mate_results: Arc::new(Mutex::new(VecDeque::new())),
             generation: AtomicU64::new(0),
+            start,
+            progress: limits.progress.clone(),
+            next_publish: AtomicU64::new(0),
         };
 
         let gc_keep_target =
@@ -1141,74 +1397,16 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
     ) -> SearchResult {
         let pool = &shared.pool;
         let root_node = pool.get(ROOT_IDX);
-        let root_children: Vec<RootChildStat> = root_node
-            .edges()
-            .iter()
-            .map(|e| {
-                let (visits, q, proven) = match e.child.load(Ordering::Acquire) {
-                    NULL_NODE => (0, 0.0, None),
-                    c => {
-                        let child = pool.get(c);
-                        let v = child.visits();
-                        let q = if v == 0 { 0.0 } else { child.wins() / v as f64 };
-                        // 確定値は子ノード手番側視点なのでルート視点へ反転する
-                        (v, q, child.proven_value().map(|pv| 1.0 - pv))
-                    }
-                };
-                RootChildStat {
-                    mv: e.mv,
-                    visits,
-                    q,
-                    prior: e.prior,
-                    proven,
-                }
-            })
-            .collect();
+        let root_children = root_children_of(pool);
 
-        // 負け確定の手を除外した robust child (select_best_root_index 参照)
-        let mut best_i = select_best_root_index(&root_children);
-
-        // root の勝敗が確定している場合は確定値を達成する子を優先する
-        // (訪問回数最大は確定前の探索の偏りを引きずり得る)．勝ち確定なら
-        // ルート視点の確定値 1 の子，引き分け確定なら 0.5 の子．負け確定は
-        // 全子が負け確定なのでどれでも同じ (robust child のまま)
+        // 負け確定除外の robust child + root 確定手の優先 (build_snapshot と共有)
         let root_proven = root_node.proven_value();
-        if let Some(rv) = root_proven {
-            if rv > 0.0 {
-                if let Some(i) = root_children.iter().position(|c| c.proven == Some(rv)) {
-                    best_i = i;
-                }
-            }
-        }
+        let best_i = best_root_index(&root_children, root_proven);
         let best = &root_children[best_i];
 
         // PV: 先頭は best_move に一致させ，以降は訪問回数最大の辺を辿る
-        let mut pv = vec![best.mv];
-        let mut idx = root_node.edges()[best_i].child.load(Ordering::Acquire);
-        while idx != NULL_NODE && pv.len() < MAX_PV_LEN {
-            let node = pool.get(idx);
-            if node.state() != node_state::EXPANDED {
-                break;
-            }
-            let edges = node.edges();
-            let mut pv_best: Option<(&Edge, u64)> = None;
-            for e in edges {
-                let c = e.child.load(Ordering::Acquire);
-                if c == NULL_NODE {
-                    continue;
-                }
-                let v = pool.get(c).visits();
-                if v == 0 {
-                    continue;
-                }
-                if pv_best.is_none_or(|(_, bv)| v > bv) {
-                    pv_best = Some((e, v));
-                }
-            }
-            let Some((e, _)) = pv_best else { break };
-            pv.push(e.mv);
-            idx = e.child.load(Ordering::Acquire);
-        }
+        let first_child = root_node.edges()[best_i].child.load(Ordering::Acquire);
+        let pv = extract_pv(pool, best.mv, first_child);
 
         let elapsed = start.elapsed();
         let playouts = shared.playouts.load(Ordering::Relaxed);
@@ -2105,5 +2303,70 @@ mod tests {
         );
         assert_eq!(result.stop, StopCause::External);
         assert!(result.best_move.is_some(), "停止時も指し手は返す");
+    }
+
+    #[test]
+    fn test_default_draw_value_is_half() {
+        // 既定 0.5 = 従来と bit-identical (canonical テストが保証)
+        assert_eq!(SearchOptions::default().draw_value, 0.5);
+    }
+
+    #[test]
+    fn test_draw_leaf_value_parity() {
+        // root(depth 0) 手番視点 draw_value=0.25: 偶数深さ=0.25, 奇数深さ=0.75
+        // (0.25/0.75 は f64 で厳密表現可能)
+        assert_eq!(draw_leaf_value_at(0.25, 1), 0.25); // depth 0 (root)
+        assert_eq!(draw_leaf_value_at(0.25, 2), 0.75); // depth 1 (相手番)
+        assert_eq!(draw_leaf_value_at(0.25, 3), 0.25); // depth 2
+        assert_eq!(draw_leaf_value_at(0.25, 4), 0.75); // depth 3
+                                                       // 0.5 は全深さで 0.5 (backprop 視点反転でも不変 = 従来挙動):
+        assert_eq!(draw_leaf_value_at(0.5, 1), 0.5);
+        assert_eq!(draw_leaf_value_at(0.5, 2), 0.5);
+    }
+
+    #[test]
+    fn test_progress_snapshot_published() {
+        // progress を設定すると worker が root スナップショットを発行する
+        let evaluator = MockEvaluator::new(7);
+        let searcher = Searcher::new(&evaluator, pure_mcts_opts());
+        let progress: Arc<Mutex<Option<RootSnapshot>>> = Arc::new(Mutex::new(None));
+        let limits = SearchLimits {
+            // PROGRESS_PUBLISH_PLAYOUTS (1024) を確実に跨ぐ予算
+            max_playouts: Some(4096),
+            progress: Some(Arc::clone(&progress)),
+            ..SearchLimits::default()
+        };
+        let mut board = Board::empty();
+        board.set_sfen(STARTPOS).unwrap();
+        let _ = searcher.search(&board, &limits);
+        let snap = progress
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("進捗スナップショットが少なくとも 1 回発行される");
+        assert!(snap.playouts > 0, "playouts が計上されている");
+        assert!(snap.best_move.is_some(), "best_move が入っている");
+        assert!(!snap.pv.is_empty(), "PV が非空");
+        assert!(
+            snap.best_visits >= snap.second_visits,
+            "best は second 以上の訪問"
+        );
+    }
+
+    #[test]
+    fn test_progress_none_leaves_cell_untouched() {
+        // progress 未設定なら発行しない (従来経路と同一 = bit-identical の担保)
+        let evaluator = MockEvaluator::new(7);
+        let searcher = Searcher::new(&evaluator, pure_mcts_opts());
+        let limits = SearchLimits {
+            max_playouts: Some(4096),
+            ..SearchLimits::default()
+        };
+        let mut board = Board::empty();
+        board.set_sfen(STARTPOS).unwrap();
+        let result = searcher.search(&board, &limits);
+        // progress None でも通常どおり探索は完了する
+        assert!(result.best_move.is_some());
+        assert!(result.stats.playouts >= 4096);
     }
 }

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.8.2"
+version = "5.9.0"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/board.rs
+++ b/rust/maou_shogi/src/board.rs
@@ -40,6 +40,16 @@ pub(crate) fn bump_mate1ply_none_dm() {
     MATE1PLY_NONE_DM.with(|c| c.set(c.get() + 1));
 }
 
+/// 入玉宣言 (27 点法) の駒点数: 大駒 (飛角龍馬) は 5 点，その他小駒は 1 点．
+/// 玉は呼び出し側で除外済みとする ([`Board::nyugyoku_declarable`])．
+#[inline]
+fn nyugyoku_piece_points(pt: PieceType) -> u32 {
+    match pt {
+        PieceType::Rook | PieceType::Bishop | PieceType::Dragon | PieceType::Horse => 5,
+        _ => 1,
+    }
+}
+
 /// `EFFECT_VERIFY` 環境変数の有無を一度だけ読み込みキャッシュする．
 ///
 /// 設定時は `do_move`/`undo_move` 毎に incremental 利き == フルスキャンを検査する
@@ -307,6 +317,71 @@ impl Board {
         } else {
             false
         }
+    }
+
+    /// 入玉宣言勝ち (27 点法) が手番側 (宣言側) について成立するかを判定する．
+    ///
+    /// 電竜戦本戦・CSA の宣言法 (docs/design/usi-engine/index.md §3/§8.3) の
+    /// うち，盤面で完結する 5 条件を判定する:
+    ///
+    /// 1. 玉が敵陣三段目以内にある
+    /// 2. 玉に王手がかかっていない
+    /// 3. 敵陣三段目以内に，玉を除く手番側の駒が 10 枚以上ある
+    /// 4. 点数 (大駒 = 飛角龍馬 5 点・小駒 1 点，玉を除く「敵陣三段目以内の駒
+    ///    ＋持ち駒」) が先手 28 点以上・後手 27 点以上
+    ///
+    /// 「宣言側の手番であること」は手番 (`turn()`) を宣言側とみなすことで満たす
+    /// (手番側しか宣言できない)．残る「持ち時間が残っている」条件は盤面外の
+    /// 情報のため，時間管理レイヤー (USI エージェント) が別途確認する．
+    pub fn nyugyoku_declarable(&self) -> bool {
+        let us = self.turn;
+        // 条件 1: 玉が敵陣三段目以内にある
+        let Some(king_sq) = self.king_square(us) else {
+            return false;
+        };
+        if !king_sq.is_promotion_zone(us) {
+            return false;
+        }
+        // 条件 2: 玉に王手がかかっていない
+        if self.is_in_check(us) {
+            return false;
+        }
+        // 条件 3/4: 敵陣三段目以内の駒 (玉を除く) の枚数と点数を数える
+        let mut camp_count = 0u32;
+        let mut points = 0u32;
+        for i in 0..Square::NUM as u8 {
+            let sq = Square::from_raw_u8(i);
+            if !sq.is_promotion_zone(us) {
+                continue;
+            }
+            let piece = self.squares[sq.index()];
+            if piece.color() != Some(us) {
+                continue;
+            }
+            match piece.piece_type() {
+                // 玉は枚数にも点数にも数えない
+                Some(PieceType::King) | None => continue,
+                Some(pt) => {
+                    camp_count += 1;
+                    points += nyugyoku_piece_points(pt);
+                }
+            }
+        }
+        // 条件 3: 敵陣三段目以内に玉を除き 10 枚以上
+        if camp_count < 10 {
+            return false;
+        }
+        // 条件 4 の持ち駒分: HAND_PIECES 順 (歩香桂銀金角飛) で idx5=角/idx6=飛
+        // が大駒 (5 点)，それ以外は小駒 (1 点)
+        for (i, &count) in self.hand[us.index()].iter().enumerate() {
+            let pts = if i >= 5 { 5 } else { 1 };
+            points += u32::from(count) * pts;
+        }
+        let required = match us {
+            Color::Black => 28,
+            Color::White => 27,
+        };
+        points >= required
     }
 
     /// 指定した玉に王手している相手駒のビットボードを返す．
@@ -3137,5 +3212,52 @@ mod tests {
             output.contains("後手の持駒：角 銀"),
             "should show bishop and silver"
         );
+    }
+
+    /// 入玉宣言 (27 点法) の 5 条件を境界で検証する golden fixture
+    /// (docs/design/usi-engine/index.md §3/§8.3)．合成局面のため駒数の
+    /// 大局的整合 (二歩・在庫上限) は問わない — 判定ロジックの境界のみを見る．
+    fn declarable(sfen: &str) -> bool {
+        let mut board = Board::empty();
+        board.set_sfen(sfen).expect("fixture SFEN must parse");
+        board.nyugyoku_declarable()
+    }
+
+    #[test]
+    fn test_nyugyoku_black_exactly_28_declares() {
+        // 敵陣 (row0-2) の玉除く駒: 龍馬(5+5) 金4 銀2 歩4 = 12 枚 / 20 点
+        // 持ち駒 角(5)+歩3 = 8 点 → 計 28 点 (先手ちょうど閾値)．王手なし
+        assert!(declarable("K+R+BGGGGSS/PPPP5/9/9/9/9/9/9/8k b B3P 1"));
+    }
+
+    #[test]
+    fn test_nyugyoku_black_27_is_one_point_short() {
+        // 同型で持ち駒を 角+歩2 = 7 点にして計 27 点 → 先手は 28 未満で不成立
+        assert!(!declarable("K+R+BGGGGSS/PPPP5/9/9/9/9/9/9/8k b B2P 1"));
+    }
+
+    #[test]
+    fn test_nyugyoku_white_27_declares() {
+        // 後手鏡像: 敵陣 (row6-8) に 12 枚 / 20 点 + 持ち駒 角+歩2 = 7 点 → 27 点
+        // 後手は 27 点で成立
+        assert!(declarable("8K/9/9/9/9/9/9/pppp5/k+r+bggggss w b2p 1"));
+    }
+
+    #[test]
+    fn test_nyugyoku_king_outside_camp_fails() {
+        // 点数は 28 点あるが玉が敵陣にいない (row8) → 不成立
+        assert!(!declarable("+R+BGGGGSS1/PPPP5/9/9/9/9/9/9/K7k b B3P 1"));
+    }
+
+    #[test]
+    fn test_nyugyoku_in_check_fails() {
+        // 玉 (col4,row0) の直下に後手飛車 → 王手中は宣言不成立 (点数・枚数は充足)
+        assert!(!declarable("+R+BGGKGGSS/PPPPrPPP1/9/9/9/9/9/9/8k b B3P 1"));
+    }
+
+    #[test]
+    fn test_nyugyoku_fewer_than_ten_camp_pieces_fails() {
+        // 持ち駒だけで 28 点あるが敵陣の盤上駒 (玉除く) が 0 枚 (< 10) → 不成立
+        assert!(!declarable("4K4/9/9/9/9/9/9/9/8k b 2R2B4G4S 1"));
     }
 }

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -13,7 +13,11 @@ use crate::protocol::{
     BestMoveKind, EngineCommand, GameResult, GoParams, GuiCommand, Info, OptionDecl, OptionKind,
     Score,
 };
-use crate::time::{allocate, TimeStrategyConfig};
+use crate::time::{allocate, should_stop, TimeBudget, TimeStrategyConfig};
+
+/// エンジン応答の逐次出力先．`info` を探索中に随時流すため，`go` 系ハンドラは
+/// 応答を貯めず [`Emit`] へ push する (stdio では書き込み + flush する closure)．
+pub type Emit<'a> = dyn FnMut(EngineCommand) + 'a;
 
 /// 平手初期局面 (USI `position startpos`)．
 pub const STARTPOS_SFEN: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
@@ -22,6 +26,9 @@ pub const STARTPOS_SFEN: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1
 /// (Node 本体 + Edge 配列の平均的な合計．将来 NodePool の実測で較正する —
 /// 設計 doc §12 未決事項 3)．
 const APPROX_BYTES_PER_NODE: u64 = 512;
+
+/// 探索中の `info` 随時出力の最小間隔 (ミリ秒)．過剰な流量を抑える (設計 §10)．
+const INFO_INTERVAL_MS: u64 = 1000;
 
 /// エンジン設定 (CLI 初期値 + `setoption` 上書き)．
 #[derive(Clone, Debug)]
@@ -48,6 +55,19 @@ pub struct EngineConfig {
     pub trt_cache_dir: Option<String>,
     /// 時間戦略の設定．
     pub time: TimeStrategyConfig,
+    /// 先手番の引き分け価値 (千分率，既定 500)．千日手・最大手数の引き分けを
+    /// 手番視点で `draw_value` に変換して探索へ渡す (電竜戦の先手 0.4 勝 = 400)．
+    pub draw_value_black: u32,
+    /// 後手番の引き分け価値 (千分率，既定 500．電竜戦の後手 0.6 勝 = 600)．
+    pub draw_value_white: u32,
+    /// 投了する root 勝率の閾値 (千分率，既定 0 = 投了しない)．root 勝率がこの
+    /// 値未満の手が `resign_consecutive` 手続いたら `bestmove resign`．
+    pub resign_value: u32,
+    /// 投了に必要な連続手数 (`resign_value` > 0 のとき有効)．
+    pub resign_consecutive: u32,
+    /// 引き分けになる最大手数 (既定 0 = 無効．電竜戦は 512)．到達局面では入玉
+    /// 宣言を必ず確認し，可能なら宣言勝ちする．
+    pub max_moves_to_draw: u32,
     /// ルート並行 dfpn (None = maou_search 既定)．
     pub root_dfpn: Option<bool>,
     /// ルート dfpn ノード予算．
@@ -76,6 +96,11 @@ impl Default for EngineConfig {
             use_tensorrt: false,
             trt_cache_dir: None,
             time: TimeStrategyConfig::default(),
+            draw_value_black: 500,
+            draw_value_white: 500,
+            resign_value: 0,
+            resign_consecutive: 3,
+            max_moves_to_draw: 0,
             root_dfpn: None,
             root_dfpn_nodes: None,
             root_dfpn_depth: None,
@@ -100,14 +125,50 @@ impl EngineConfig {
 }
 
 /// 1 回の探索予算 (エージェント → バックエンド)．
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SearchBudget {
-    /// 時間予算 (ミリ秒)．
-    pub time_ms: Option<u64>,
+    /// 時間予算 (soft/hard)．`None` = playout 制または無期限．バックエンドは
+    /// `hard_ms` を探索の絶対上限に，soft 到達時の延長判断は monitor が行う．
+    pub time: Option<TimeBudget>,
     /// playout 予算．
     pub max_playouts: Option<u64>,
     /// 無期限 (stop でのみ停止．`go ponder`/`go infinite`)．
     pub unbounded: bool,
+}
+
+/// 探索中の進捗スナップショット (バックエンド → [`SearchObserver`])．
+/// maou_search の `RootSnapshot` を transport 非依存の USI 表記へ写したもの．
+#[derive(Clone, Debug, Default)]
+pub struct ProgressSnapshot {
+    /// 完了 playout 数．
+    pub playouts: u64,
+    /// playout 毎秒．
+    pub nps: u64,
+    /// 到達最大深さ．
+    pub max_depth: u16,
+    /// 現時点の最有力手 (USI 表記)．
+    pub best_usi: Option<String>,
+    /// 最有力手の訪問回数．
+    pub best_visits: u64,
+    /// 次点手の訪問回数 (延長判断用)．
+    pub second_visits: u64,
+    /// 最有力手の root 手番視点勝率．
+    pub winrate: f64,
+    /// 読み筋 (USI 表記)．
+    pub pv: Vec<String>,
+    /// root 確定値 (詰み等)．未確定は `None`．
+    pub proven: Option<f64>,
+}
+
+/// 探索中の進捗を受け取る観測者 (エージェント実装)．
+///
+/// バックエンドが探索スレッドと並行に，一定間隔で最新スナップショットを渡す．
+/// 実装は `info` の随時出力などの副作用を行い，早期停止したいときに `true` を
+/// 返す (停止フラグを立てる責務はバックエンド側)．
+pub trait SearchObserver {
+    /// 最新スナップショットと計測経過 (ミリ秒) を受け取る．`true` を返すと
+    /// バックエンドが停止フラグを立てて探索を打ち切る．
+    fn on_progress(&mut self, snapshot: &ProgressSnapshot, elapsed_ms: u64) -> bool;
 }
 
 /// 探索結果 (バックエンド → エージェント)．
@@ -136,14 +197,21 @@ pub struct SearchOutcome {
 pub trait SearchBackend {
     /// 局面 (基準 SFEN + USI 経路 = 千日手履歴規約) を予算内で探索する．
     ///
+    /// `draw_value` は root 手番視点の引き分け価値 (千日手戦略)．`observer` は
+    /// 探索中の進捗を受け取り早期停止を要求できる (`info` 随時出力・時間延長)．
     /// `stop` が立てられたら途中で打ち切ってその時点の最有力手を返すこと．
     fn search(
         &mut self,
         sfen: &str,
         moves: &[String],
         budget: &SearchBudget,
+        draw_value: f64,
         stop: &Arc<AtomicBool>,
+        observer: &mut dyn SearchObserver,
     ) -> Result<SearchOutcome, String>;
+
+    /// 現局面 (基準 SFEN + USI 経路) で手番側の入玉宣言 (27 点法) が成立するか．
+    fn nyugyoku_declarable(&self, sfen: &str, moves: &[String]) -> Result<bool, String>;
 
     /// mock 評価器か (isready 時の明示に使う)．
     fn is_mock(&self) -> bool;
@@ -180,6 +248,18 @@ impl GameState {
             base.opponent()
         }
     }
+
+    /// 現局面の手数 (基準 SFEN の手数 + 経路長)．SFEN 第 4 要素が手数
+    /// (startpos は 1)．MaxMovesToDraw 判定に使う．
+    fn move_number(&self) -> u64 {
+        let base: u64 = self
+            .sfen
+            .split_whitespace()
+            .nth(3)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1);
+        base + self.moves.len() as u64
+    }
 }
 
 /// 勝率 → 評価値 (センチポーン) 変換．
@@ -207,6 +287,9 @@ where
     /// 現在の探索の協調停止フラグ．transport (stdio reader) が `go` 行で
     /// false，`stop`/`quit` 行で true にする ([`Agent::stop_handle`])．
     stop: Arc<AtomicBool>,
+    /// root 勝率が投了閾値未満だった連続手数 (`resign_value` 用)．usinewgame /
+    /// gameover でリセットする．
+    resign_streak: u32,
 }
 
 impl<B, F> Agent<B, F>
@@ -222,6 +305,7 @@ where
             backend: None,
             game: GameState::default(),
             stop: Arc::new(AtomicBool::new(false)),
+            resign_streak: 0,
         }
     }
 
@@ -247,6 +331,7 @@ where
             }
             GuiCommand::UsiNewGame => {
                 self.game = GameState::default();
+                self.resign_streak = 0;
                 Ok(Vec::new())
             }
             GuiCommand::Position { sfen, moves } => {
@@ -256,7 +341,13 @@ where
                 };
                 Ok(Vec::new())
             }
-            GuiCommand::Go(params) => self.handle_go(&params),
+            // Go は探索中に info を随時流すため sink 版へ委譲し，収集して返す
+            // (stdio transport は Go を handle_go_stream で直接ストリームする)
+            GuiCommand::Go(params) => {
+                let mut out = Vec::new();
+                self.handle_go_stream(&params, &mut |c| out.push(c))?;
+                Ok(out)
+            }
             // M1: 同期探索のため Stop 処理時点で探索は終わっている
             // (bestmove は Go の応答として送信済み)．ここでは何もしない
             GuiCommand::Stop => Ok(Vec::new()),
@@ -265,6 +356,7 @@ where
             GuiCommand::GameOver(result) => {
                 let _: GameResult = result;
                 self.game = GameState::default();
+                self.resign_streak = 0;
                 Ok(Vec::new())
             }
             GuiCommand::Quit => Ok(Vec::new()),
@@ -375,6 +467,46 @@ where
                     default: c.leaf_mate.unwrap_or(true),
                 },
             },
+            OptionDecl {
+                name: "DrawValueBlack",
+                kind: OptionKind::Spin {
+                    default: i64::from(c.draw_value_black),
+                    min: 0,
+                    max: 1000,
+                },
+            },
+            OptionDecl {
+                name: "DrawValueWhite",
+                kind: OptionKind::Spin {
+                    default: i64::from(c.draw_value_white),
+                    min: 0,
+                    max: 1000,
+                },
+            },
+            OptionDecl {
+                name: "ResignValue",
+                kind: OptionKind::Spin {
+                    default: i64::from(c.resign_value),
+                    min: 0,
+                    max: 1000,
+                },
+            },
+            OptionDecl {
+                name: "ResignConsecutive",
+                kind: OptionKind::Spin {
+                    default: i64::from(c.resign_consecutive),
+                    min: 1,
+                    max: 1000,
+                },
+            },
+            OptionDecl {
+                name: "MaxMovesToDraw",
+                kind: OptionKind::Spin {
+                    default: i64::from(c.max_moves_to_draw),
+                    min: 0,
+                    max: 100_000,
+                },
+            },
         ]
     }
 
@@ -455,6 +587,36 @@ where
                 }
                 invalidate = false;
             }
+            "DrawValueBlack" => {
+                if let Ok(n) = v.parse() {
+                    self.config.draw_value_black = n;
+                }
+                invalidate = false;
+            }
+            "DrawValueWhite" => {
+                if let Ok(n) = v.parse() {
+                    self.config.draw_value_white = n;
+                }
+                invalidate = false;
+            }
+            "ResignValue" => {
+                if let Ok(n) = v.parse() {
+                    self.config.resign_value = n;
+                }
+                invalidate = false;
+            }
+            "ResignConsecutive" => {
+                if let Ok(n) = v.parse::<u32>() {
+                    self.config.resign_consecutive = n.max(1);
+                }
+                invalidate = false;
+            }
+            "MaxMovesToDraw" => {
+                if let Ok(n) = v.parse() {
+                    self.config.max_moves_to_draw = n;
+                }
+                invalidate = false;
+            }
             // 未知のオプションは無視 (GUI 側の拡張への耐性)
             _ => invalidate = false,
         }
@@ -463,46 +625,110 @@ where
         }
     }
 
-    fn handle_go(&mut self, params: &GoParams) -> Result<Vec<EngineCommand>, String> {
+    /// `go` を処理し，探索中の `info` を随時 `emit` へ流して bestmove を返す．
+    ///
+    /// - `go mate` は未対応 (`checkmate notimplemented`)．
+    /// - SpecialRules 前処理: 入玉宣言 (27 点法 + 持ち時間) が成立すれば探索
+    ///   せず `bestmove win`．
+    /// - 千日手戦略: 手番の引き分け価値を探索の `draw_value` へ変換して渡す．
+    /// - 投了: root 勝率が閾値未満の手が `resign_consecutive` 手続いたら
+    ///   `bestmove resign` (`resign_value` = 0 なら投了しない)．
+    pub fn handle_go_stream(&mut self, params: &GoParams, emit: &mut Emit) -> Result<(), String> {
         if params.mate.is_some() {
-            // 詰み探索モードは M1 では未対応 (dfpn 接続は将来対応)
-            return Ok(vec![EngineCommand::CheckmateNotImplemented]);
+            // 詰み探索モードは未対応 (dfpn 接続は将来対応)
+            emit(EngineCommand::CheckmateNotImplemented);
+            return Ok(());
         }
 
         // isready を送らない GUI への防御 (通常は isready で構築済み)
         if self.backend.is_none() {
-            let backend = (self.factory)(&self.config)?;
-            self.backend = Some(backend);
+            self.backend = Some((self.factory)(&self.config)?);
         }
 
-        let budget = self.decide_budget(params);
-        let backend = self.backend.as_mut().expect("直前で構築済み");
-        let outcome = backend.search(&self.game.sfen, &self.game.moves, &budget, &self.stop)?;
+        // SpecialRules: 入玉宣言 (27 点法 + 持ち時間が残っている)
+        if self.should_declare_win(&params.clock)? {
+            emit(EngineCommand::BestMove {
+                mv: BestMoveKind::Win,
+                ponder: None,
+            });
+            return Ok(());
+        }
 
-        let mut out = Vec::new();
-        out.push(EngineCommand::Info(build_info(&outcome)));
-        let mv = match outcome.best_usi {
-            // 合法手なし = 詰まされている → 投了
-            None => BestMoveKind::Resign,
-            Some(usi) => BestMoveKind::Move(usi),
+        let draw_value = self.draw_value_for(self.game.side_to_move());
+        let budget = self.decide_budget(params);
+        let sfen = self.game.sfen.clone();
+        let moves = self.game.moves.clone();
+        let stop = Arc::clone(&self.stop);
+        let outcome = {
+            let backend = self.backend.as_mut().expect("直前で構築済み");
+            let mut observer = GoObserver::new(emit, budget.time);
+            backend.search(&sfen, &moves, &budget, draw_value, &stop, &mut observer)?
         };
-        // M1: ponder 非対応のため bestmove に ponder は付けない
-        out.push(EngineCommand::BestMove { mv, ponder: None });
-        Ok(out)
+
+        // 探索サマリ info (最終) → bestmove
+        emit(EngineCommand::Info(build_info(&outcome)));
+        let mv = self.decide_bestmove(&outcome);
+        emit(EngineCommand::BestMove { mv, ponder: None });
+        Ok(())
+    }
+
+    /// 入玉宣言 (27 点法) が成立し，かつ持ち時間が残っているか．
+    fn should_declare_win(&self, clock: &crate::protocol::ClockParams) -> Result<bool, String> {
+        let backend = self.backend.as_ref().expect("直前で構築済み");
+        if !backend.nyugyoku_declarable(&self.game.sfen, &self.game.moves)? {
+            return Ok(false);
+        }
+        // 盤面 5 条件は backend が判定済み．残る「持ち時間が残っている」条件を確認
+        Ok(has_time_remaining(clock, self.game.side_to_move()))
+    }
+
+    /// 手番側の引き分け価値 (千分率 → 0.0..=1.0)．
+    fn draw_value_for(&self, side: Color) -> f64 {
+        let permille = match side {
+            Color::Black => self.config.draw_value_black,
+            Color::White => self.config.draw_value_white,
+        };
+        f64::from(permille) / 1000.0
+    }
+
+    /// 探索結果から bestmove を決める (投了判断込み，`resign_streak` を更新)．
+    fn decide_bestmove(&mut self, outcome: &SearchOutcome) -> BestMoveKind {
+        let Some(usi) = &outcome.best_usi else {
+            // 合法手なし = 詰まされている → 投了 (対局終了なので streak リセット)
+            self.resign_streak = 0;
+            return BestMoveKind::Resign;
+        };
+        // 投了: 閾値 > 0 かつ勝ち確定でない局面で，root 勝率が閾値未満の手が
+        // resign_consecutive 手続いたら投了する
+        let win_proven = matches!(outcome.proven, Some(v) if v >= 1.0);
+        if self.config.resign_value > 0 && !win_proven {
+            let threshold = f64::from(self.config.resign_value) / 1000.0;
+            if outcome.winrate < threshold {
+                self.resign_streak += 1;
+                if self.resign_streak >= self.config.resign_consecutive {
+                    return BestMoveKind::Resign;
+                }
+            } else {
+                self.resign_streak = 0;
+            }
+        } else {
+            self.resign_streak = 0;
+        }
+        BestMoveKind::Move(usi.clone())
     }
 
     /// go パラメータ → 探索予算 (時間戦略は crate::time)．
     fn decide_budget(&self, params: &GoParams) -> SearchBudget {
         if params.infinite || params.ponder {
             return SearchBudget {
-                time_ms: None,
+                time: None,
                 max_playouts: None,
                 unbounded: true,
             };
         }
         if let Some(nodes) = params.nodes {
             return SearchBudget {
-                time_ms: None,
+                time: None,
                 max_playouts: Some(nodes),
                 unbounded: false,
             };
@@ -512,36 +738,133 @@ where
                 .saturating_sub(self.config.time.network_delay_ms)
                 .max(self.config.time.min_think_ms);
             return SearchBudget {
-                time_ms: Some(ms),
+                // movetime は固定 (延長なし): soft == hard
+                time: Some(TimeBudget {
+                    soft_ms: ms,
+                    hard_ms: ms,
+                }),
                 max_playouts: None,
                 unbounded: false,
             };
         }
-        let budget = allocate(&self.config.time, &params.clock, self.game.side_to_move());
+        let mut budget = allocate(&self.config.time, &params.clock, self.game.side_to_move());
+        // MaxMovesToDraw が近ければ予算を絞る (引き分け目前で深追いしない．§8.3)
+        if let Some(cap) = self.max_moves_draw_cap() {
+            budget.soft_ms = budget.soft_ms.min(cap);
+            budget.hard_ms = budget.hard_ms.min(cap).max(budget.soft_ms);
+        }
         SearchBudget {
-            time_ms: Some(budget.hard_ms),
+            time: Some(budget),
             max_playouts: None,
             unbounded: false,
         }
+    }
+
+    /// MaxMovesToDraw リミットが目前 (残り 4 手以内) なら思考予算の上限
+    /// (ミリ秒) を返す．無効 (0) または十分手数があるなら `None`．
+    /// in-search でのリミット以降 Draw 終端化は M4 (効果計測後)．
+    fn max_moves_draw_cap(&self) -> Option<u64> {
+        let limit = u64::from(self.config.max_moves_to_draw);
+        if limit == 0 {
+            return None;
+        }
+        if self.game.move_number() + 4 >= limit {
+            Some(self.config.time.min_think_ms.max(1))
+        } else {
+            None
+        }
+    }
+}
+
+/// 手番側に持ち時間 (残時間・加算・秒読み) が残っているか — 入玉宣言の時間条件．
+/// clock 情報が皆無 (検討モード等) なら true (時間条件を課さない)．
+fn has_time_remaining(clock: &crate::protocol::ClockParams, side: Color) -> bool {
+    if clock.is_empty() {
+        return true;
+    }
+    let (t, inc) = match side {
+        Color::Black => (clock.btime.unwrap_or(0), clock.binc.unwrap_or(0)),
+        Color::White => (clock.wtime.unwrap_or(0), clock.winc.unwrap_or(0)),
+    };
+    t + inc + clock.byoyomi.unwrap_or(0) > 0
+}
+
+/// `info` を時間 gate で随時出力し，soft 到達時の時間延長を判断する観測者
+/// ([`crate::time::should_stop`])．
+struct GoObserver<'a, 'e> {
+    emit: &'a mut Emit<'e>,
+    /// 時間予算 (`None` = 無期限探索: 時間による停止要求はしない)．
+    budget: Option<TimeBudget>,
+    /// 次に info を出す経過時刻 (ミリ秒)．
+    next_info_ms: u64,
+}
+
+impl<'a, 'e> GoObserver<'a, 'e> {
+    fn new(emit: &'a mut Emit<'e>, budget: Option<TimeBudget>) -> GoObserver<'a, 'e> {
+        GoObserver {
+            emit,
+            budget,
+            next_info_ms: 0,
+        }
+    }
+}
+
+impl SearchObserver for GoObserver<'_, '_> {
+    fn on_progress(&mut self, snapshot: &ProgressSnapshot, elapsed_ms: u64) -> bool {
+        // info 随時出力 (時間 gate — 過剰な流量を抑える，設計 §10)
+        if elapsed_ms >= self.next_info_ms {
+            (self.emit)(EngineCommand::Info(info_from_snapshot(
+                snapshot, elapsed_ms,
+            )));
+            self.next_info_ms = elapsed_ms + INFO_INTERVAL_MS;
+        }
+        // 時間延長判断 (無期限探索なら停止要求しない = 外部 stop のみで止まる)
+        match self.budget {
+            Some(b) => should_stop(
+                &b,
+                elapsed_ms,
+                snapshot.best_visits,
+                snapshot.second_visits,
+                snapshot.proven.is_some(),
+            ),
+            None => false,
+        }
+    }
+}
+
+/// 勝率・確定値・PV 長から `info score` を作る (サマリ/随時出力で共有)．
+fn score_of(proven: Option<f64>, winrate: f64, pv_len: usize) -> Option<Score> {
+    match proven {
+        // 勝ち確定 (詰み発見含む): PV 長を詰み手数として報告する
+        Some(v) if v >= 1.0 => Some(Score::Mate(pv_len.max(1) as i32)),
+        Some(v) if v <= 0.0 => Some(Score::Mate(-(pv_len.max(1) as i32))),
+        Some(_) => Some(Score::Cp(0)),
+        None => Some(Score::Cp(winrate_to_cp(winrate))),
     }
 }
 
 /// 探索結果 → `info` 1 行 (探索サマリ)．
 fn build_info(outcome: &SearchOutcome) -> Info {
-    let score = match outcome.proven {
-        // 勝ち確定 (詰み発見含む): PV 長を詰み手数として報告する
-        Some(v) if v >= 1.0 => Some(Score::Mate(outcome.pv.len().max(1) as i32)),
-        Some(v) if v <= 0.0 => Some(Score::Mate(-(outcome.pv.len().max(1) as i32))),
-        Some(_) => Some(Score::Cp(0)),
-        None => Some(Score::Cp(winrate_to_cp(outcome.winrate))),
-    };
     Info {
         depth: Some(u32::from(outcome.max_depth)),
         time_ms: Some(outcome.elapsed_ms),
         nodes: Some(outcome.playouts),
         nps: Some(outcome.nps),
-        score,
+        score: score_of(outcome.proven, outcome.winrate, outcome.pv.len()),
         pv: outcome.pv.clone(),
+        ..Info::default()
+    }
+}
+
+/// 進捗スナップショット → `info` 1 行 (探索中の随時出力)．
+fn info_from_snapshot(snap: &ProgressSnapshot, elapsed_ms: u64) -> Info {
+    Info {
+        depth: Some(u32::from(snap.max_depth)),
+        time_ms: Some(elapsed_ms),
+        nodes: Some(snap.playouts),
+        nps: Some(snap.nps),
+        score: score_of(snap.proven, snap.winrate, snap.pv.len()),
+        pv: snap.pv.clone(),
         ..Info::default()
     }
 }
@@ -552,10 +875,14 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    /// fake バックエンド: 呼び出しを記録し，決めた応答を返す．
+    /// fake バックエンド: 呼び出しを記録し，決めた応答を返す．observer を
+    /// 1 回駆動して info 随時出力の経路も通す．
     struct FakeBackend {
-        calls: Rc<RefCell<Vec<(String, Vec<String>, SearchBudget)>>>,
+        calls: Calls,
+        draw_values: DrawValues,
         outcome: SearchOutcome,
+        /// `nyugyoku_declarable` の返り値 (入玉宣言テスト用)．
+        nyugyoku: bool,
     }
 
     impl SearchBackend for FakeBackend {
@@ -564,12 +891,32 @@ mod tests {
             sfen: &str,
             moves: &[String],
             budget: &SearchBudget,
+            draw_value: f64,
             _stop: &Arc<AtomicBool>,
+            observer: &mut dyn SearchObserver,
         ) -> Result<SearchOutcome, String> {
             self.calls
                 .borrow_mut()
-                .push((sfen.to_string(), moves.to_vec(), budget.clone()));
+                .push((sfen.to_string(), moves.to_vec(), *budget));
+            self.draw_values.borrow_mut().push(draw_value);
+            // observer を 1 回駆動 (info 随時出力の経路を検証可能にする)
+            let snap = ProgressSnapshot {
+                playouts: self.outcome.playouts,
+                nps: self.outcome.nps,
+                max_depth: self.outcome.max_depth,
+                best_usi: self.outcome.best_usi.clone(),
+                best_visits: 10,
+                second_visits: 1,
+                winrate: self.outcome.winrate,
+                pv: self.outcome.pv.clone(),
+                proven: self.outcome.proven,
+            };
+            let _ = observer.on_progress(&snap, 0);
             Ok(self.outcome.clone())
+        }
+
+        fn nyugyoku_declarable(&self, _sfen: &str, _moves: &[String]) -> Result<bool, String> {
+            Ok(self.nyugyoku)
         }
 
         fn is_mock(&self) -> bool {
@@ -578,6 +925,7 @@ mod tests {
     }
 
     type Calls = Rc<RefCell<Vec<(String, Vec<String>, SearchBudget)>>>;
+    type DrawValues = Rc<RefCell<Vec<f64>>>;
 
     fn agent_with_fake(
         outcome: SearchOutcome,
@@ -585,15 +933,32 @@ mod tests {
         Agent<FakeBackend, impl Fn(&EngineConfig) -> Result<FakeBackend, String>>,
         Calls,
     ) {
+        let (agent, calls, _draws) = agent_with_fake_full(outcome, false);
+        (agent, calls)
+    }
+
+    /// nyugyoku フラグと draw_value 記録も取れる版．
+    fn agent_with_fake_full(
+        outcome: SearchOutcome,
+        nyugyoku: bool,
+    ) -> (
+        Agent<FakeBackend, impl Fn(&EngineConfig) -> Result<FakeBackend, String>>,
+        Calls,
+        DrawValues,
+    ) {
         let calls: Calls = Rc::new(RefCell::new(Vec::new()));
+        let draws: DrawValues = Rc::new(RefCell::new(Vec::new()));
         let calls_for_factory = Rc::clone(&calls);
+        let draws_for_factory = Rc::clone(&draws);
         let agent = Agent::new(EngineConfig::default(), move |_config| {
             Ok(FakeBackend {
                 calls: Rc::clone(&calls_for_factory),
+                draw_values: Rc::clone(&draws_for_factory),
                 outcome: outcome.clone(),
+                nyugyoku,
             })
         });
-        (agent, calls)
+        (agent, calls, draws)
     }
 
     fn default_outcome() -> SearchOutcome {
@@ -671,8 +1036,8 @@ mod tests {
         let (sfen, moves, budget) = &recorded[0];
         assert_eq!(sfen, STARTPOS_SFEN);
         assert_eq!(moves.len(), 2);
-        // 60s/40 + 10s − 1s = 10.5s
-        assert_eq!(budget.time_ms, Some(10_500));
+        // 60s/40 + 10s − 1s = 10.5s (soft)．hard は延長上限 (soft×2)
+        assert_eq!(budget.time.unwrap().soft_ms, 10_500);
     }
 
     #[test]
@@ -699,7 +1064,7 @@ mod tests {
             .unwrap();
         let recorded = calls.borrow();
         // 80s/40 + 2s − 1s = 3s (wtime 基準)．btime 基準なら 11s になるはず
-        assert_eq!(recorded[0].2.time_ms, Some(3_000));
+        assert_eq!(recorded[0].2.time.unwrap().soft_ms, 3_000);
     }
 
     #[test]
@@ -822,5 +1187,221 @@ mod tests {
             .handle(GuiCommand::Unknown("mystery".to_string()))
             .unwrap();
         assert!(out.is_empty());
+    }
+
+    fn set(
+        agent: &mut Agent<FakeBackend, impl Fn(&EngineConfig) -> Result<FakeBackend, String>>,
+        name: &str,
+        value: &str,
+    ) {
+        agent
+            .handle(GuiCommand::SetOption {
+                name: name.to_string(),
+                value: Some(value.to_string()),
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_draw_value_converted_by_side_to_move() {
+        let (mut agent, _calls, draws) = agent_with_fake_full(default_outcome(), false);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        // 電竜戦: 先手 0.4 勝 / 後手 0.6 勝
+        set(&mut agent, "DrawValueBlack", "400");
+        set(&mut agent, "DrawValueWhite", "600");
+        // startpos = 先手番 → draw_value 0.4
+        agent
+            .handle(GuiCommand::Position {
+                sfen: None,
+                moves: vec![],
+            })
+            .unwrap();
+        agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        // 1 手進めて後手番 → draw_value 0.6
+        agent
+            .handle(GuiCommand::Position {
+                sfen: None,
+                moves: vec!["7g7f".to_string()],
+            })
+            .unwrap();
+        agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        let d = draws.borrow();
+        assert!((d[0] - 0.4).abs() < 1e-9, "先手番は 0.4 (got {})", d[0]);
+        assert!((d[1] - 0.6).abs() < 1e-9, "後手番は 0.6 (got {})", d[1]);
+    }
+
+    #[test]
+    fn test_nyugyoku_declares_win_with_time() {
+        let (mut agent, calls, _) = agent_with_fake_full(default_outcome(), true);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent
+            .handle(GuiCommand::Go(GoParams {
+                clock: crate::protocol::ClockParams {
+                    btime: Some(60_000),
+                    ..Default::default()
+                },
+                ..GoParams::default()
+            }))
+            .unwrap();
+        assert_eq!(
+            out,
+            vec![EngineCommand::BestMove {
+                mv: BestMoveKind::Win,
+                ponder: None
+            }]
+        );
+        // 宣言勝ちのため探索は呼ばれない
+        assert!(calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_nyugyoku_not_declared_without_time() {
+        let (mut agent, calls, _) = agent_with_fake_full(default_outcome(), true);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        // 持ち時間ゼロ → 宣言の時間条件を満たさず通常探索
+        let out = agent
+            .handle(GuiCommand::Go(GoParams {
+                clock: crate::protocol::ClockParams {
+                    btime: Some(0),
+                    wtime: Some(0),
+                    ..Default::default()
+                },
+                ..GoParams::default()
+            }))
+            .unwrap();
+        assert!(matches!(
+            out.last(),
+            Some(EngineCommand::BestMove {
+                mv: BestMoveKind::Move(_),
+                ..
+            })
+        ));
+        assert_eq!(calls.borrow().len(), 1, "探索が実行される");
+    }
+
+    #[test]
+    fn test_resign_after_consecutive_low_winrate() {
+        let losing = SearchOutcome {
+            best_usi: Some("7g7f".to_string()),
+            winrate: 0.05,
+            pv: vec!["7g7f".to_string()],
+            proven: None,
+            ..SearchOutcome::default()
+        };
+        let (mut agent, _calls, _) = agent_with_fake_full(losing, false);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        set(&mut agent, "ResignValue", "100"); // 勝率 0.1 未満
+        set(&mut agent, "ResignConsecutive", "2");
+        // 1 手目: streak 1 → まだ指す
+        let out1 = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        assert!(matches!(
+            out1.last(),
+            Some(EngineCommand::BestMove {
+                mv: BestMoveKind::Move(_),
+                ..
+            })
+        ));
+        // 2 手目: streak 2 → 投了
+        let out2 = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        assert_eq!(
+            out2.last(),
+            Some(&EngineCommand::BestMove {
+                mv: BestMoveKind::Resign,
+                ponder: None
+            })
+        );
+    }
+
+    #[test]
+    fn test_resign_disabled_by_default() {
+        let losing = SearchOutcome {
+            best_usi: Some("7g7f".to_string()),
+            winrate: 0.01,
+            pv: vec!["7g7f".to_string()],
+            proven: None,
+            ..SearchOutcome::default()
+        };
+        let (mut agent, _calls, _) = agent_with_fake_full(losing, false);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        // ResignValue 既定 0 → 何手続いても投了しない
+        for _ in 0..5 {
+            let out = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+            assert!(matches!(
+                out.last(),
+                Some(EngineCommand::BestMove {
+                    mv: BestMoveKind::Move(_),
+                    ..
+                })
+            ));
+        }
+    }
+
+    #[test]
+    fn test_max_moves_to_draw_narrows_budget() {
+        let (mut agent, calls, _) = agent_with_fake_full(default_outcome(), false);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        set(&mut agent, "MaxMovesToDraw", "10");
+        // move_number = 1 (startpos) + 6 = 7; 7 + 4 = 11 >= 10 → 予算を絞る
+        agent
+            .handle(GuiCommand::Position {
+                sfen: None,
+                moves: vec![
+                    "7g7f".to_string(),
+                    "3c3d".to_string(),
+                    "2g2f".to_string(),
+                    "8c8d".to_string(),
+                    "2f2e".to_string(),
+                    "8d8e".to_string(),
+                ],
+            })
+            .unwrap();
+        agent
+            .handle(GuiCommand::Go(GoParams {
+                clock: crate::protocol::ClockParams {
+                    btime: Some(600_000),
+                    wtime: Some(600_000),
+                    byoyomi: Some(10_000),
+                    ..Default::default()
+                },
+                ..GoParams::default()
+            }))
+            .unwrap();
+        // 通常なら soft ~ 24s だが，リミット目前で min_think (100ms) に絞られる
+        assert_eq!(calls.borrow()[0].2.time.unwrap().soft_ms, 100);
+    }
+
+    #[test]
+    fn test_streaming_info_before_bestmove() {
+        let (mut agent, _calls, _) = agent_with_fake_full(default_outcome(), false);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        // 随時 info (observer 駆動) + 最終サマリ info の 2 本以上
+        let infos = out
+            .iter()
+            .filter(|c| matches!(c, EngineCommand::Info(_)))
+            .count();
+        assert!(infos >= 2, "随時 info と最終 info が出る (got {infos})");
+        assert!(matches!(out.last(), Some(EngineCommand::BestMove { .. })));
+    }
+
+    #[test]
+    fn test_m2_options_declared() {
+        let (mut agent, _) = agent_with_fake(default_outcome());
+        let out = agent.handle(GuiCommand::Usi).unwrap();
+        for name in [
+            "DrawValueBlack",
+            "DrawValueWhite",
+            "ResignValue",
+            "ResignConsecutive",
+            "MaxMovesToDraw",
+        ] {
+            assert!(
+                out.iter().any(|c| matches!(
+                    c,
+                    EngineCommand::OptionDecl(OptionDecl { name: n, .. }) if *n == name
+                )),
+                "{name} オプションが宣言される"
+            );
+        }
     }
 }

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -4,17 +4,24 @@
 //! (USI `isready` のタイミング．TensorRT のエンジンビルドも warmup として
 //! ここで済ませ，初手の `go` を遅らせない)．
 
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use maou_search::{
-    build_board_and_history, EvalItem, Evaluator, MockEvaluator, SearchLimits, SearchOptions,
-    SearchResult, Searcher, StopCause,
+    build_board_and_history, EvalItem, Evaluator, MockEvaluator, RootSnapshot, SearchLimits,
+    SearchOptions, SearchResult, Searcher, StopCause,
 };
 use maou_shogi::board::Board;
 use maou_shogi::movegen::generate_legal_moves;
 
-use crate::agent::{EngineConfig, SearchBackend, SearchBudget, SearchOutcome, STARTPOS_SFEN};
+use crate::agent::{
+    EngineConfig, ProgressSnapshot, SearchBackend, SearchBudget, SearchObserver, SearchOutcome,
+    STARTPOS_SFEN,
+};
+
+/// 進捗スナップショットを observer へ渡すポーリング間隔．
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// 保持する評価器 (mock または ONNX)．
 enum EngineEvaluator {
@@ -122,9 +129,16 @@ impl SearchBackend for MaouSearchBackend {
         sfen: &str,
         moves: &[String],
         budget: &SearchBudget,
+        draw_value: f64,
         stop: &Arc<AtomicBool>,
+        observer: &mut dyn SearchObserver,
     ) -> Result<SearchOutcome, String> {
         let (board, history) = build_board_and_history(sfen, moves).map_err(|e| e.to_string())?;
+        // 千日手戦略: 手番視点の引き分け価値を探索へ渡す
+        let mut options = self.options.clone();
+        options.draw_value = draw_value;
+        // 進捗スナップショットの発行先 (monitor がポーリングして observer へ渡す)
+        let progress: Arc<Mutex<Option<RootSnapshot>>> = Arc::new(Mutex::new(None));
         let limits = SearchLimits {
             // 無期限 (go ponder / go infinite) は playout 上限 u64::MAX + stop
             // token で表現する (SearchLimits の規約)
@@ -133,26 +147,67 @@ impl SearchBackend for MaouSearchBackend {
             } else {
                 budget.max_playouts
             },
+            // hard_ms を探索の絶対上限 (backstop) に．soft 到達時の延長判断は
+            // monitor が observer 経由で行い stop フラグを立てる
             time_ms: if budget.unbounded {
                 None
             } else {
-                budget.time_ms
+                budget.time.map(|t| t.hard_ms)
             },
             stop: Some(Arc::clone(stop)),
-            ..SearchLimits::default()
+            progress: Some(Arc::clone(&progress)),
         };
-        let result = match &self.evaluator {
-            EngineEvaluator::Mock(e) => Searcher::new(e, self.options.clone())
-                .search_with_history(&board, &history, &limits),
-            #[cfg(feature = "onnx")]
-            EngineEvaluator::Onnx(e) => Searcher::new(e, self.options.clone())
-                .search_with_history(&board, &history, &limits),
-        };
+        // 探索を専用スレッドで走らせ，呼び出しスレッド (dispatcher) が monitor
+        // ループを回す (progress をポーリング → observer 駆動 → 早期停止)．
+        // GIL/GC を挟まない Rust 内で完結する (設計 §5)．
+        let evaluator = &self.evaluator;
+        let result = std::thread::scope(|s| {
+            let handle =
+                s.spawn(|| match evaluator {
+                    EngineEvaluator::Mock(e) => Searcher::new(e, options.clone())
+                        .search_with_history(&board, &history, &limits),
+                    #[cfg(feature = "onnx")]
+                    EngineEvaluator::Onnx(e) => Searcher::new(e, options.clone())
+                        .search_with_history(&board, &history, &limits),
+                });
+            let start = Instant::now();
+            while !handle.is_finished() {
+                std::thread::sleep(POLL_INTERVAL);
+                let latest = progress.lock().ok().and_then(|g| g.clone());
+                if let Some(snap) = latest {
+                    let elapsed = start.elapsed().as_millis() as u64;
+                    if observer.on_progress(&to_progress_snapshot(&snap), elapsed) {
+                        stop.store(true, Ordering::Release);
+                    }
+                }
+            }
+            handle.join().expect("探索スレッドは panic しない")
+        });
         Ok(to_outcome(&result))
+    }
+
+    fn nyugyoku_declarable(&self, sfen: &str, moves: &[String]) -> Result<bool, String> {
+        let (board, _) = build_board_and_history(sfen, moves).map_err(|e| e.to_string())?;
+        Ok(board.nyugyoku_declarable())
     }
 
     fn is_mock(&self) -> bool {
         matches!(self.evaluator, EngineEvaluator::Mock(_))
+    }
+}
+
+/// maou_search の [`RootSnapshot`] → transport 非依存の [`ProgressSnapshot`]．
+fn to_progress_snapshot(snap: &RootSnapshot) -> ProgressSnapshot {
+    ProgressSnapshot {
+        playouts: snap.playouts,
+        nps: snap.nps as u64,
+        max_depth: snap.max_depth,
+        best_usi: snap.best_move.map(|m| m.to_usi()),
+        best_visits: snap.best_visits,
+        second_visits: snap.second_visits,
+        winrate: snap.winrate,
+        pv: snap.pv.iter().map(|m| m.to_usi()).collect(),
+        proven: snap.proven,
     }
 }
 
@@ -190,6 +245,14 @@ mod tests {
         }
     }
 
+    /// 進捗を無視する観測者 (backend 単体テスト用)．
+    struct NoopObserver;
+    impl SearchObserver for NoopObserver {
+        fn on_progress(&mut self, _snapshot: &ProgressSnapshot, _elapsed_ms: u64) -> bool {
+            false
+        }
+    }
+
     #[test]
     fn test_build_and_search_with_mock() {
         let mut backend = MaouSearchBackend::build(&config()).expect("mock 構築は成功する");
@@ -200,11 +263,13 @@ mod tests {
                 STARTPOS_SFEN,
                 &["7g7f".to_string()],
                 &SearchBudget {
-                    time_ms: None,
+                    time: None,
                     max_playouts: Some(200),
                     unbounded: false,
                 },
+                0.5,
                 &stop,
+                &mut NoopObserver,
             )
             .expect("mock 探索は成功する");
         let best = outcome.best_usi.expect("平手 1 手目後に合法手はある");
@@ -233,11 +298,13 @@ mod tests {
                 STARTPOS_SFEN,
                 &[],
                 &SearchBudget {
-                    time_ms: None,
+                    time: None,
                     max_playouts: None,
                     unbounded: true,
                 },
+                0.5,
                 &stop,
+                &mut NoopObserver,
             )
             .expect("mock 探索は成功する");
         setter.join().expect("setter 正常終了");
@@ -253,11 +320,13 @@ mod tests {
                 STARTPOS_SFEN,
                 &["7g7e".to_string()],
                 &SearchBudget {
-                    time_ms: None,
+                    time: None,
                     max_playouts: Some(10),
                     unbounded: false,
                 },
+                0.5,
                 &stop,
+                &mut NoopObserver,
             )
             .err()
             .expect("非合法手はエラー");

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -139,6 +139,7 @@ impl SearchBackend for MaouSearchBackend {
                 budget.time_ms
             },
             stop: Some(Arc::clone(stop)),
+            ..SearchLimits::default()
         };
         let result = match &self.evaluator {
             EngineEvaluator::Mock(e) => Searcher::new(e, self.options.clone())

--- a/rust/maou_usi/src/stdio.rs
+++ b/rust/maou_usi/src/stdio.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::agent::{Agent, EngineConfig, SearchBackend};
 use crate::backend::MaouSearchBackend;
-use crate::protocol::{parse_line, serialize, GuiCommand};
+use crate::protocol::{parse_line, serialize, EngineCommand, GuiCommand};
 
 /// reader: 入力を行単位でパースして送る．`go`/`stop`/`quit` は行順で
 /// 停止フラグへ反映する．EOF (GUI 死亡) では Quit を合成して終了する．
@@ -58,27 +58,43 @@ where
         if matches!(cmd, GuiCommand::Quit) {
             return Ok(());
         }
-        match agent.handle(cmd) {
-            Ok(responses) => {
-                for r in &responses {
-                    writeln!(out, "{}", serialize(r)).map_err(|e| e.to_string())?;
-                }
-                if !responses.is_empty() {
-                    out.flush().map_err(|e| e.to_string())?;
-                }
+        // Go は探索中に info を随時流すため handle_go_stream で直接ストリームする．
+        // それ以外は応答をまとめて書く．
+        if let GuiCommand::Go(params) = cmd {
+            let res = {
+                let mut emit = |c: EngineCommand| {
+                    let _ = writeln!(out, "{}", serialize(&c));
+                    let _ = out.flush();
+                };
+                agent.handle_go_stream(&params, &mut emit)
+            };
+            if let Err(e) = res {
+                return fatal(out, &e);
             }
-            Err(e) => {
-                // 致命的エラー (モデルロード失敗・不正局面)．詳細は stderr，
-                // GUI へは理由を ASCII 化した info string で通知して終了する
-                // (subprocess の stderr が見えない環境 — Colab 等 — でも
-                // 原因が stdout 側から分かるように)
-                eprintln!("maou usi fatal: {e}");
-                let _ = writeln!(out, "info string ERROR: {}", sanitize_ascii(&e));
-                let _ = out.flush();
-                return Err(e);
+        } else {
+            match agent.handle(cmd) {
+                Ok(responses) => {
+                    for r in &responses {
+                        writeln!(out, "{}", serialize(r)).map_err(|e| e.to_string())?;
+                    }
+                    if !responses.is_empty() {
+                        out.flush().map_err(|e| e.to_string())?;
+                    }
+                }
+                Err(e) => return fatal(out, &e),
             }
         }
     }
+}
+
+/// 致命的エラー (モデルロード失敗・不正局面)．詳細は stderr，GUI へは理由を
+/// ASCII 化した `info string` で通知して終了する (subprocess の stderr が
+/// 見えない環境 — Colab 等 — でも原因が stdout 側から分かるように)．
+fn fatal<W: Write>(out: &mut W, e: &str) -> Result<(), String> {
+    eprintln!("maou usi fatal: {e}");
+    let _ = writeln!(out, "info string ERROR: {}", sanitize_ascii(e));
+    let _ = out.flush();
+    Err(e.to_string())
 }
 
 /// `info string` 用にエラーメッセージを 1 行の ASCII へ丸める

--- a/rust/maou_usi/src/time.rs
+++ b/rust/maou_usi/src/time.rs
@@ -4,12 +4,27 @@
 //! (docs/design/usi-engine/index.md §8.1) の上位レイヤー実装．探索側は
 //! ここが決めた予算を消費するだけで時間配分の知識を持たない．
 //!
-//! M1 は固定 horizon の簡易版 (soft == hard)．想定残り手数カーブ・
-//! ベスト不安定時の延長は M2 (設計 §8.1)．
+//! soft (通常打ち切り目標) と hard (絶対上限) を分離し，soft 到達時に root の
+//! 最有力手が不安定 (上位 2 手の訪問が拮抗) なら hard まで延長する (設計 §8.1)．
+//! 延長判断も本モジュール ([`should_stop`]) が持つ．
+//!
+//! 定数 (想定残り手数 `horizon_moves`・延長倍率・安定判定比) は自己対局で
+//! 調整して worklog に記録する (設計 doc §12 未決事項 1)．
 
 use maou_shogi::types::Color;
 
 use crate::protocol::ClockParams;
+
+/// soft から hard への延長倍率 (分子/分母)．soft の `EXT_NUM/EXT_DEN` 倍まで
+/// 延長を許す (ただし残時間の絶対上限 ceiling は超えない)．暫定 2 倍
+/// (自己対局で調整予定 — 設計 §12 未決 1)．
+const EXT_NUM: u64 = 2;
+const EXT_DEN: u64 = 1;
+
+/// 最有力手が「安定」と見なす上位 2 手の訪問比 (best ≥ `STABLE_NUM/STABLE_DEN`
+/// × second)．暫定 1.5 倍 (拮抗していれば延長する)．
+const STABLE_NUM: u64 = 3;
+const STABLE_DEN: u64 = 2;
 
 /// 1 手の思考予算 (ミリ秒)．
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -43,15 +58,19 @@ impl Default for TimeStrategyConfig {
     }
 }
 
-/// 自分の手番の残り時間・加算を取り出して 1 手予算を計算する．
+/// 自分の手番の残り時間・加算を取り出して 1 手予算 (soft/hard) を計算する．
 ///
 /// 三態 (秒読み / フィッシャー / 切れ負け) を扱う:
 /// - 秒読み: `残時間 / horizon + byoyomi − margin`
 /// - フィッシャー: `残時間 / horizon + inc − margin`
 /// - 切れ負け: `残時間 / horizon − margin` (安全側)
 ///
-/// いずれも「今使える時間の上限 (残時間 + byoyomi − margin)」でクランプし，
-/// `min_think_ms` を下回らない．
+/// - `soft_ms` = 通常打ち切り目標 (上記 base 配分)．
+/// - `hard_ms` = 延長上限 = `soft × EXT_NUM/EXT_DEN`．ただし今使える時間の
+///   絶対上限 ceiling (残時間 + 秒読み − マージン) を超えない．
+///
+/// いずれも `min_think_ms` を下回らない．ceiling に張り付く局面 (秒読みのみ・
+/// 残り僅少) では `soft == hard` になり延長余地はない (安全側)．
 pub fn allocate(cfg: &TimeStrategyConfig, clock: &ClockParams, my_color: Color) -> TimeBudget {
     let (my_time, my_inc) = match my_color {
         Color::Black => (clock.btime.unwrap_or(0), clock.binc.unwrap_or(0)),
@@ -68,11 +87,52 @@ pub fn allocate(cfg: &TimeStrategyConfig, clock: &ClockParams, my_color: Color) 
     // (フィッシャー加算は指した後に足されるので上限には入れない)
     let ceiling = (my_time + byoyomi).saturating_sub(cfg.network_delay_ms);
 
-    let ms = budget.min(ceiling).max(cfg.min_think_ms);
+    let soft = budget.min(ceiling).max(cfg.min_think_ms);
+    // 延長上限: soft の EXT 倍．ただし ceiling を超えず，soft を下回らない
+    let hard = soft
+        .saturating_mul(EXT_NUM)
+        .saturating_div(EXT_DEN)
+        .min(ceiling)
+        .max(soft);
     TimeBudget {
-        soft_ms: ms,
-        hard_ms: ms,
+        soft_ms: soft,
+        hard_ms: hard,
     }
+}
+
+/// 探索を今すぐ打ち切るべきか (monitor が一定間隔で呼ぶ延長判断)．
+///
+/// - root が確定 (詰み等) していれば即停止 (探索側も止まるが保険)．
+/// - `hard_ms` 到達で必ず停止．
+/// - `soft_ms` 到達後は，最有力手が安定していれば停止，上位 2 手が拮抗して
+///   いれば `hard_ms` まで延長する ([`is_best_stable`])．
+/// - `soft_ms` 未満なら継続．
+///
+/// `best_visits` / `second_visits` は root 直下の最有力手・次点の訪問回数
+/// (進捗スナップショット由来)．`proven` は root 確定の有無．
+pub fn should_stop(
+    budget: &TimeBudget,
+    elapsed_ms: u64,
+    best_visits: u64,
+    second_visits: u64,
+    proven: bool,
+) -> bool {
+    if proven {
+        return true;
+    }
+    if elapsed_ms >= budget.hard_ms {
+        return true;
+    }
+    if elapsed_ms >= budget.soft_ms {
+        return is_best_stable(best_visits, second_visits);
+    }
+    false
+}
+
+/// 最有力手が安定しているか (best が second の `STABLE_NUM/STABLE_DEN` 倍以上の
+/// 訪問)．拮抗 (未確立) なら延長する側に倒す．
+fn is_best_stable(best_visits: u64, second_visits: u64) -> bool {
+    best_visits.saturating_mul(STABLE_DEN) >= second_visits.saturating_mul(STABLE_NUM)
 }
 
 #[cfg(test)]
@@ -169,5 +229,74 @@ mod tests {
         // 500 − 1000 は負 → 最低思考時間 100ms
         let b = allocate(&cfg(), &clock, Color::Black);
         assert_eq!(b.soft_ms, 100);
+    }
+
+    #[test]
+    fn test_hard_allows_extension_with_main_time() {
+        // 主時間十分: hard = soft × 2 (ceiling 未達で延長余地あり)
+        let clock = ClockParams {
+            btime: Some(400_000),
+            wtime: Some(400_000),
+            byoyomi: Some(10_000),
+            ..ClockParams::default()
+        };
+        let b = allocate(&cfg(), &clock, Color::Black);
+        assert_eq!(b.soft_ms, 19_000);
+        assert_eq!(b.hard_ms, 38_000);
+    }
+
+    #[test]
+    fn test_hard_clamped_to_ceiling_in_byoyomi() {
+        // 秒読みのみ: soft == hard == ceiling (延長余地なし)
+        let clock = ClockParams {
+            btime: Some(0),
+            wtime: Some(0),
+            byoyomi: Some(10_000),
+            ..ClockParams::default()
+        };
+        let b = allocate(&cfg(), &clock, Color::Black);
+        assert_eq!(b.soft_ms, 9_000);
+        assert_eq!(b.hard_ms, 9_000);
+    }
+
+    #[test]
+    fn test_should_stop_before_soft_continues() {
+        let b = TimeBudget {
+            soft_ms: 1_000,
+            hard_ms: 2_000,
+        };
+        assert!(!should_stop(&b, 500, 100, 90, false));
+    }
+
+    #[test]
+    fn test_should_stop_at_soft_when_stable() {
+        let b = TimeBudget {
+            soft_ms: 1_000,
+            hard_ms: 2_000,
+        };
+        // best 200 vs second 100 → 安定 (200×2 ≥ 100×3) → soft で停止
+        assert!(should_stop(&b, 1_000, 200, 100, false));
+    }
+
+    #[test]
+    fn test_should_stop_extends_when_contested() {
+        let b = TimeBudget {
+            soft_ms: 1_000,
+            hard_ms: 2_000,
+        };
+        // best 110 vs second 100 → 拮抗 (110×2 < 100×3) → soft でも延長 (継続)
+        assert!(!should_stop(&b, 1_000, 110, 100, false));
+        // hard 到達なら拮抗でも停止
+        assert!(should_stop(&b, 2_000, 110, 100, false));
+    }
+
+    #[test]
+    fn test_should_stop_on_proven() {
+        let b = TimeBudget {
+            soft_ms: 1_000,
+            hard_ms: 2_000,
+        };
+        // root 確定は soft 未満でも即停止
+        assert!(should_stop(&b, 10, 1, 0, true));
     }
 }

--- a/src/maou/app/usi/run.py
+++ b/src/maou/app/usi/run.py
@@ -33,6 +33,11 @@ class UsiRunner:
             network_delay_ms: 通信マージン (ミリ秒)．探索予算はこの分
                 短くなる．
             min_think_ms: 最低思考時間 (ミリ秒)．
+            draw_value_black: 先手番の引き分け価値 (千分率，既定 500)．
+            draw_value_white: 後手番の引き分け価値 (千分率，既定 500)．
+            resign_value: 投了する root 勝率 (千分率，既定 0 = 投了しない)．
+            resign_consecutive: 投了に必要な連続手数．
+            max_moves_to_draw: 引き分け最大手数 (既定 0 = 無効)．
             root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
             root_dfpn_nodes: ルート dfpn のノード予算．
             root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
@@ -51,6 +56,11 @@ class UsiRunner:
         node_capacity: int | None = None
         network_delay_ms: int = 1000
         min_think_ms: int = 100
+        draw_value_black: int = 500
+        draw_value_white: int = 500
+        resign_value: int = 0
+        resign_consecutive: int = 3
+        max_moves_to_draw: int = 0
         root_dfpn: bool = True
         root_dfpn_nodes: int = 2_000_000
         root_dfpn_depth: int = 2047
@@ -93,6 +103,11 @@ class UsiRunner:
             ),
             network_delay_ms=option.network_delay_ms,
             min_think_ms=option.min_think_ms,
+            draw_value_black=option.draw_value_black,
+            draw_value_white=option.draw_value_white,
+            resign_value=option.resign_value,
+            resign_consecutive=option.resign_consecutive,
+            max_moves_to_draw=option.max_moves_to_draw,
             root_dfpn=option.root_dfpn,
             root_dfpn_nodes=option.root_dfpn_nodes,
             root_dfpn_depth=option.root_dfpn_depth,

--- a/src/maou/infra/console/usi.py
+++ b/src/maou/infra/console/usi.py
@@ -61,6 +61,54 @@ from maou.infra.console.common import (
     required=False,
 )
 @click.option(
+    "--draw-value-black",
+    help="Draw value for Black in permille (default 500). The repetition / "
+    "max-moves draw terminal is valued at this from the side-to-move view "
+    "(Denryu-sen Black 0.4 win = 400). Also `setoption name DrawValueBlack`.",
+    type=int,
+    default=500,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--draw-value-white",
+    help="Draw value for White in permille (default 500. Denryu-sen White "
+    "0.6 win = 600). Also `setoption name DrawValueWhite`.",
+    type=int,
+    default=500,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--resign-value",
+    help="Resign when the root win rate stays below this permille for "
+    "--resign-consecutive moves (default 0 = never resign). Also "
+    "`setoption name ResignValue`.",
+    type=int,
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--resign-consecutive",
+    help="Consecutive below-threshold moves required to resign "
+    "(with --resign-value > 0).",
+    type=int,
+    default=3,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--max-moves-to-draw",
+    help="Move count for a drawn game (default 0 = disabled; Denryu-sen "
+    "512). At/near the limit the engine always checks nyugyoku declaration "
+    "and narrows its budget. Also `setoption name MaxMovesToDraw`.",
+    type=int,
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
     "--root-dfpn/--no-root-dfpn",
     type=bool,
     is_flag=True,
@@ -142,6 +190,11 @@ def usi(
     node_capacity: int | None,
     network_delay_ms: int,
     min_think_ms: int,
+    draw_value_black: int,
+    draw_value_white: int,
+    resign_value: int,
+    resign_consecutive: int,
+    max_moves_to_draw: int,
     root_dfpn: bool,
     root_dfpn_nodes: int,
     root_dfpn_depth: int,
@@ -171,6 +224,11 @@ def usi(
         node_capacity: Node pool capacity.
         network_delay_ms: Communication overhead margin in milliseconds.
         min_think_ms: Minimum thinking time in milliseconds.
+        draw_value_black: Draw value for Black in permille (default 500).
+        draw_value_white: Draw value for White in permille (default 500).
+        resign_value: Resign win-rate threshold in permille (0 = never).
+        resign_consecutive: Consecutive below-threshold moves to resign.
+        max_moves_to_draw: Move count for a drawn game (0 = disabled).
         root_dfpn: Run dfpn mate search on the root position in parallel.
         root_dfpn_nodes: Node budget for the root dfpn mate search.
         root_dfpn_depth: Search depth limit for the root dfpn mate search.
@@ -188,6 +246,11 @@ def usi(
         node_capacity=node_capacity,
         network_delay_ms=network_delay_ms,
         min_think_ms=min_think_ms,
+        draw_value_black=draw_value_black,
+        draw_value_white=draw_value_white,
+        resign_value=resign_value,
+        resign_consecutive=resign_consecutive,
+        max_moves_to_draw=max_moves_to_draw,
         root_dfpn=root_dfpn,
         root_dfpn_nodes=root_dfpn_nodes,
         root_dfpn_depth=root_dfpn_depth,

--- a/src/maou/interface/usi.py
+++ b/src/maou/interface/usi.py
@@ -29,6 +29,11 @@ def usi(
     node_capacity: int | None = None,
     network_delay_ms: int = 1000,
     min_think_ms: int = 100,
+    draw_value_black: int = 500,
+    draw_value_white: int = 500,
+    resign_value: int = 0,
+    resign_consecutive: int = 3,
+    max_moves_to_draw: int = 0,
     root_dfpn: bool = True,
     root_dfpn_nodes: int = 2_000_000,
     root_dfpn_depth: int = 2047,
@@ -52,6 +57,11 @@ def usi(
         node_capacity: ノードプール容量 (None で既定)．
         network_delay_ms: 通信マージン (ミリ秒)．
         min_think_ms: 最低思考時間 (ミリ秒)．
+        draw_value_black: 先手番の引き分け価値 (千分率，既定 500)．
+        draw_value_white: 後手番の引き分け価値 (千分率，既定 500)．
+        resign_value: 投了する root 勝率 (千分率，既定 0 = 投了しない)．
+        resign_consecutive: 投了に必要な連続手数．
+        max_moves_to_draw: 引き分け最大手数 (既定 0 = 無効)．
         root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
         root_dfpn_nodes: ルート dfpn のノード予算．
         root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
@@ -70,6 +80,11 @@ def usi(
         node_capacity=node_capacity,
         network_delay_ms=network_delay_ms,
         min_think_ms=min_think_ms,
+        draw_value_black=draw_value_black,
+        draw_value_white=draw_value_white,
+        resign_value=resign_value,
+        resign_consecutive=resign_consecutive,
+        max_moves_to_draw=max_moves_to_draw,
         root_dfpn=root_dfpn,
         root_dfpn_nodes=root_dfpn_nodes,
         root_dfpn_depth=root_dfpn_depth,

--- a/uv.lock
+++ b/uv.lock
@@ -1507,7 +1507,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- USI 対局エージェントを電竜戦系ルールで実戦運用可能にする milestone **M2**．
- 探索中の `info` 随時出力，soft/hard 分離の時間管理 + best 不安定時の延長，
  千日手戦略 (DrawValue)，入玉宣言 27 点法勝ち，投了，MaxMovesToDraw を実装．
- 設計の正: `docs/design/usi-engine/index.md` §8 (review applied @ 94476af)．
- 版数: maou_shogi 5.9.0 / maou_search 0.19.0 / maou_usi 0.2.0 / maou_rust 0.24.0 / maou 0.48.0．

## Problem

M1 (PR #393/#394) は対局ループ・stop 即応・簡易時間管理までで，対局
エージェントとしての戦略層 (持ち時間の soft/hard・千日手価値・大会特殊ルール・
投了・思考情報の随時出力) が未実装だった．電竜戦系ルールでの実戦運用には
これらが要る (設計 §3/§8)．

## Solution

コミットを 3 つに分割 (探索基盤 → 盤面判定 → エージェント戦略):

1. **`Board::nyugyoku_declarable()`** (maou_shogi): 27 点法の盤面 5 条件
   (玉が敵陣三段目以内 / 王手なし / 敵陣に玉除き 10 枚以上 / 大駒 5 点小駒 1 点で
   先手 28・後手 27 以上) を読み取り専用で判定．
2. **探索基盤** (maou_search): `SearchOptions::draw_value` で引き分け終端を
   可変化 (葉手番のパリティで `draw_value` / `1−draw_value`，backprop の視点
   反転で root からは常に draw_value に集約．勝敗確定 proven::DRAW の論理値
   0.5 は不変)．`SearchLimits::progress` で worker が一定 playout 間隔に root
   スナップショットを発行 (info 随時出力・時間延長・resign の入力)．
3. **エージェント戦略** (maou_usi): `go` を sink ベースの `handle_go_stream`
   へ移行し，backend が探索を専用スレッドで走らせ dispatcher が monitor ループ
   でスナップショットをポーリング → observer 駆動 → 早期停止 (Rust 内完結,
   GIL/GC を挟まない §5)．TimeStrategy soft/hard + `should_stop` 延長判断，
   DrawValueBlack/White，入玉宣言 `bestmove win`，ResignValue/ResignConsecutive，
   MaxMovesToDraw (リミット目前で予算絞り) を実装．

## Changes

- `rust/maou_shogi/src/board.rs`: `nyugyoku_declarable` + 境界 golden 6 件．
- `rust/maou_search/src/search.rs`, `lib.rs`: `draw_value` / `RootSnapshot` /
  `SearchLimits::progress` / worker 発行 / 集計共有関数．
- `rust/maou_usi/src/{agent,backend,stdio,time}.rs`: streaming 化 + monitor loop
  + 戦略モジュール + 新オプション宣言/setoption．
- `rust/maou_rust/src/maou_usi.rs`: `run_usi` に 5 オプションを追加．
- `src/maou/{app/usi/run,interface/usi,infra/console/usi}.py`: CLI フラグ貫通．
- `docs/commands/usi.md`: M2 機能・新オプションを反映．

## Impact

**Breaking Changes**: なし (USI プロトコル互換．新オプションは既定で無害 —
DrawValue 500 = 従来 0.5 / ResignValue 0 = 投了しない / MaxMovesToDraw 0 = 無効)．
**Performance**: `progress` 未設定・`draw_value` 0.5 のとき探索は従来と
bit-identical (下記 canonical で実証)．monitor は別スレッドのポーリングで
探索スループットに影響しない．
**Dependencies**: 追加なし．wheel 可搬性・CPU-only 動作を維持 (pure Rust)．

## Testing

- **STRICT-VERIFY canonical RAN (bit-identical)**: 29te = 396,516 nodes /
  Some(29)，39te = 17,593,615 nodes / Some(39) — search.rs 接触の TRIPWIRE を
  discharge．
- **Rust**: maou_usi 57 / maou_shogi 196 / maou_search 66 tests green，
  clippy + fmt clean．
- **Python**: 945 passed / 77 skipped，ruff/isort/mypy clean．
- **E2E 実駆動 (mock)**: `go byoyomi 2000` → nodes 92,937 / depth 9 / streaming
  info 4 本 (各 score cp + pv) / 自然な bestmove を確認．

## Review Notes

- **draw_value のパリティ**: `draw_leaf_value_at` (search.rs)．root 手番視点の
  引き分け価値を葉手番へ変換する箇所．AND-OR proven 論理値 (0.5) は変えず
  heuristic backprop のみを変える設計．
- **monitor loop の並行性** (backend.rs): 探索を scoped thread で走らせ，
  progress は worker が atomic 読みの近似スナップショットとして発行 (GC compact
  の `&mut pool` と競合しないよう `&shared` を跨がない設計)．
- **0-playout footgun**: 一括 pipe + `quit` は stop を先に立てるため E2E/スモークは
  「bestmove を待ってから quit」で駆動すること (compass 既知)．

**後続 milestone (本 PR 対象外)**:
- M3: ponder 一式 + subtree 再利用 (USI_Ponder は未宣言のまま)．
- M4: OpeningScript + 自己対局 driver + MaxMovesToDraw の in-search Draw 終端化．
- ローカル GUI 検証 (将棋所/ShogiGUI/ShogiHome) は user 決定で全 M 終了後に実施．

## Checklist

- [x] Rust fmt + clippy clean / Python ruff + isort + mypy clean
- [x] All tests pass (Rust 57+196+66, Python 945)
- [x] Canonical 29te/39te bit-identical (TRIPWIRE discharged)
- [x] 新機能・回帰テスト追加 (nyugyoku 6, draw/snapshot 4, agent M2 8, time 6)
- [x] docstring / docs/commands/usi.md 更新
- [x] 版数 bump (semver: feat → minor，crate ごと独立)
- [x] wheel 可搬性・CPU-only 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)