### PR TITLE
fix: collect_files でクラウドDL一時ファイル (.gstmp 等) を除外

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.48.0"
+version = "0.48.1"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/infra/file_system/path_utils.py
+++ b/src/maou/infra/file_system/path_utils.py
@@ -7,16 +7,40 @@ torch不要なコマンドから安全にインポートできる．
 
 from pathlib import Path
 
+# クラウドストレージ (gcsfuse / gsutil 等) がダウンロード中・中断で残す一時
+# ファイルのサフィックス．これらは不完全なことがあり，データファイルとして
+# 読むと壊れる (例: `foo.feather_.gstmp` を Arrow IPC として読むと
+# ``OSError: failed to fill whole buffer``)．ディレクトリ走査時に除外する．
+_TEMP_ARTIFACT_SUFFIXES: tuple[str, ...] = (
+    ".gstmp",  # gcsfuse ダウンロード一時ファイル
+    ".tmp",  # 汎用一時ファイル
+    ".partial",  # 部分ダウンロード
+    ".crc",  # gsutil / hadoop チェックサム副産物
+)
+
+
+def _is_temp_artifact(f: Path) -> bool:
+    """クラウドストレージのダウンロード一時ファイル (不完全な可能性) か．
+
+    ``foo.feather_.gstmp`` のような一時ファイルはデータとして読むと壊れるため，
+    ディレクトリ収集から除外する．拡張子 (ファイル名末尾) で判定する．
+    """
+    return f.name.endswith(_TEMP_ARTIFACT_SUFFIXES)
+
 
 def collect_files(
     p: Path, ext: str | None = None
 ) -> list[Path]:
     """指定パスからファイルを収集する．
 
+    ディレクトリ走査時は，クラウドストレージのダウンロード一時ファイル
+    (``.gstmp`` など，[`_TEMP_ARTIFACT_SUFFIXES`] 参照) を除外する
+    (不完全なファイルをデータとして読むと壊れるため)．
+
     Args:
         p: ファイルまたはディレクトリのパス
         ext: フィルタする拡張子(例: ".feather")．
-            ``None`` の場合は全ファイルを返す．
+            ``None`` の場合は(一時ファイルを除く)全ファイルを返す．
 
     Returns:
         マッチしたファイルパスのリスト
@@ -39,6 +63,7 @@ def collect_files(
             for f in p.glob("**/*")
             if f.is_file()
             and (ext is None or ext in f.suffixes)
+            and not _is_temp_artifact(f)
         ]
     else:
         msg = (

--- a/tests/maou/infra/file_system/test_path_utils.py
+++ b/tests/maou/infra/file_system/test_path_utils.py
@@ -70,3 +70,39 @@ class TestCollectFiles:
     def test_empty_directory(self, tmp_path: Path) -> None:
         """空ディレクトリでは空リストを返す．"""
         assert collect_files(tmp_path) == []
+
+    def test_directory_excludes_gcs_temp_files(
+        self, tmp_path: Path
+    ) -> None:
+        """ダウンロード一時ファイル (.gstmp 等) を除外する．
+
+        gcsfuse/gsutil の転送中/中断で残る不完全ファイルをデータとして
+        読むと壊れる (OSError: failed to fill whole buffer) ため，収集時に
+        除外する．
+        """
+        good = tmp_path / "transformed_chunk0000.feather"
+        good.touch()
+        # gcsfuse ダウンロード一時ファイル (実データではない)
+        (
+            tmp_path / "transformed_chunk0001.feather_.gstmp"
+        ).touch()
+        (tmp_path / "partial.feather.tmp").touch()
+        (tmp_path / "download.partial").touch()
+        (tmp_path / ".data.feather.crc").touch()
+
+        result = collect_files(tmp_path)
+        assert result == [good], (
+            f"一時ファイルは除外され本体のみ残る: {result}"
+        )
+
+    def test_ext_filter_and_temp_exclusion_compose(
+        self, tmp_path: Path
+    ) -> None:
+        """拡張子フィルタと一時ファイル除外は両立する．"""
+        good = tmp_path / "a.feather"
+        good.touch()
+        (tmp_path / "b.npy").touch()  # ext 不一致で除外
+        (tmp_path / "a.feather_.gstmp").touch()  # 一時で除外
+
+        result = collect_files(tmp_path, ext=".feather")
+        assert result == [good]


### PR DESCRIPTION
## 問題

Colab (GCS マウント) で `maou learn-model --stage 3 --stage3-data-path preprocess/floodgate ...` を実行すると，学習の行数スキャン中に次のエラーでクラッシュする:

```
File preprocess/floodgate/transformed_chunk0029.feather_.gstmp is Arrow IPC Stream format. Reading full data for row count ...
OSError: failed to fill whole buffer
  ... scan_row_count -> pl.read_ipc_stream(file_path)
```

## 原因

`.gstmp` は **gcsfuse/gsutil がダウンロード中・中断で残す一時ファイル**で，実データではなく不完全なことがある．`FileSystem.collect_files(stage3_data_path)` は `ext` 無指定 (`path_utils.collect_files`) で呼ばれ，`glob("**/*")` の**全ファイル**を収集していたため，`transformed_chunk0029.feather_.gstmp` のような転送途中のファイルまで拾い，`StreamingFileSource` がそれを Arrow IPC として読んでバッファを満たせずクラッシュしていた．

## 修正

`path_utils.collect_files` のディレクトリ走査から，クラウドストレージのダウンロード一時ファイルのサフィックス (`.gstmp` / `.tmp` / `.partial` / `.crc`) を除外する．

- `converter` / `preprocess` / `learn` の全 caller に共通で効く (収集口が一箇所)．
- 既存の拡張子フィルタ (`ext`) とも両立する．
- `is_file()` で明示指定したパスは従来どおり尊重する (glob の自動収集のみ対象)．

## テスト

- `test_directory_excludes_gcs_temp_files`: `.gstmp` / `.tmp` / `.partial` / `.crc` を除外し `.feather` 本体のみ残ることを検証．
- `test_ext_filter_and_temp_exclusion_compose`: `ext=".feather"` フィルタと一時ファイル除外の併用を検証．
- 全 Python スイート green (ruff / isort / mypy clean)．

## 影響

- 版数: `maou` 0.48.1 (patch)．
- 破壊的変更なし．一時ファイルが混入しない通常のデータディレクトリでは挙動不変．

## 備考

これは USI エンジン (M3) の作業とは独立した学習パイプラインの robustness 修正．なお同 Colab セッションで別途遭遇した「stage2 データが空 (0 files) → `total_steps must be positive`」は，`--stage all` が stage2 データ必須のためデータ設定側の問題であり，本 PR には含めていない．

🤖 Generated with [Claude Code](https://claude.com/claude-code)