### PR TITLE
feat: USI エンジン M3 — ponder 一式 + subtree 再利用

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -30,10 +30,12 @@
   (`USI_Ponder`, `go ponder` / `ponderhit`, and `bestmove <move> ponder
   <reply>` with the predicted reply = PV's 2nd move) — a ponder hit *continues*
   the same unbounded search under a fresh time budget, so the tree built while
-  pondering carries over (the main ponder benefit).
-  Not yet implemented (later milestones): general MCTS subtree reuse across
-  root advances (still under evaluation per the design's open item — a ponder
-  *miss* re-searches from scratch), tournament opening scripts and the
+  pondering carries over (the main ponder benefit); and **subtree reuse across
+  moves** — when the game advances along an explored line, the retained search
+  tree is rerooted to the new position so its subtree warm-starts the next
+  search instead of rebuilding from scratch (a ponder *miss*, or any advance
+  the tree did not explore, falls back to a fresh search).
+  Not yet implemented (later milestones): tournament opening scripts and the
   self-play driver (M4), the in-search `MaxMovesToDraw` draw terminal (M4),
   `go mate` (answers `checkmate notimplemented`).
 

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -17,7 +17,7 @@
 - When no model is configured, a deterministic **mock evaluator** is used and
   announced with `info string mock evaluator (development only) ...` on
   `isready` (development/verification only — move quality is meaningless).
-- Supported through milestone M2: full game loop (`usi` / `isready` /
+- Supported through milestone M3: full game loop (`usi` / `isready` /
   `setoption` / `usinewgame` / `position` / `go` with
   `btime wtime byoyomi binc winc`, `go infinite`, `go nodes`, `go movetime` /
   `stop` / `gameover` / `quit`); time strategy with soft/hard budgets and
@@ -26,9 +26,14 @@
   (`DrawValueBlack` / `DrawValueWhite`); nyugyoku declaration win
   (`bestmove win`, 27-point rule); resign threshold (`ResignValue` /
   `ResignConsecutive`, off by default); `MaxMovesToDraw` (declaration check +
-  budget narrowing near the limit); root-dfpn + leaf-mate search.
-  Not yet implemented (later milestones): ponder (`USI_Ponder` is not
-  declared) and subtree reuse (M3), tournament opening scripts and the
+  budget narrowing near the limit); root-dfpn + leaf-mate search; **pondering**
+  (`USI_Ponder`, `go ponder` / `ponderhit`, and `bestmove <move> ponder
+  <reply>` with the predicted reply = PV's 2nd move) — a ponder hit *continues*
+  the same unbounded search under a fresh time budget, so the tree built while
+  pondering carries over (the main ponder benefit).
+  Not yet implemented (later milestones): general MCTS subtree reuse across
+  root advances (still under evaluation per the design's open item — a ponder
+  *miss* re-searches from scratch), tournament opening scripts and the
   self-play driver (M4), the in-search `MaxMovesToDraw` draw terminal (M4),
   `go mate` (answers `checkmate notimplemented`).
 
@@ -62,6 +67,7 @@
 | `--resign-value INT` | default `0` | Resign when the root win rate stays below this permille for `--resign-consecutive` moves. `0` = never resign. |
 | `--resign-consecutive INT` | default `3` | Consecutive below-threshold moves required to resign (with `--resign-value > 0`). |
 | `--max-moves-to-draw INT` | default `0` | Move count for a drawn game (`0` = disabled; Denryu-sen `512`). At/near the limit the engine always checks nyugyoku declaration and narrows its search budget. |
+| `--usi-ponder/--no-usi-ponder` | **default on** | Enable pondering (thinking on the opponent's turn). When on, the engine declares `USI_Ponder` and appends the predicted reply to `bestmove` so the GUI sends `go ponder`. |
 | `--root-dfpn/--no-root-dfpn` | **default on** | Run dfpn mate search on the root position in parallel with MCTS. |
 | `--root-dfpn-nodes INT` | default `2000000` | Node budget for the root dfpn mate search. |
 | `--root-dfpn-depth INT` | default `2047` | Search depth limit for the root dfpn mate search (max 2047). |
@@ -89,6 +95,7 @@ Declared in the `usi` response; defaults reflect the CLI flags above.
 | `ResignValue` | spin (permille) | Resign win-rate threshold (0 = never). |
 | `ResignConsecutive` | spin | Consecutive below-threshold moves required to resign. |
 | `MaxMovesToDraw` | spin | Move count for a drawn game (0 = disabled; Denryu-sen 512). |
+| `USI_Ponder` | check | Enable pondering (default on). Declared so the GUI sends `go ponder`; `bestmove` carries the predicted reply (PV's 2nd move). |
 | `RootDfpn` / `LeafMate` | check | Mate search toggles. |
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.48.0"
+version = "0.49.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_usi.rs
+++ b/rust/maou_rust/src/maou_usi.rs
@@ -29,6 +29,9 @@ use maou_usi::{EngineConfig, TimeStrategyConfig};
 /// - `resign_value` (int, optional): 投了する root 勝率 (千分率，デフォルト
 ///   0 = 投了しない)．`resign_consecutive` (int, optional): 投了に必要な連続手数．
 /// - `max_moves_to_draw` (int, optional): 引き分け最大手数 (デフォルト 0 = 無効)．
+/// - `usi_ponder` (bool, optional): ponder (先読み) を有効にするか (デフォルト
+///   true)．true のとき `USI_Ponder` option を宣言し `bestmove` に予想相手手を
+///   付ける (`setoption name USI_Ponder` で上書き可)．
 /// - `root_dfpn` / `root_dfpn_nodes` / `root_dfpn_depth`: ルート並行 dfpn．
 /// - `leaf_mate` / `leaf_mate_nodes` / `leaf_mate_threads`: leaf-mate．
 ///
@@ -36,7 +39,7 @@ use maou_usi::{EngineConfig, TimeStrategyConfig};
 ///
 /// モデルロード失敗・不正局面などの致命的エラーは `RuntimeError`．
 #[pyfunction]
-#[pyo3(signature = (*, engine_name=None, engine_author=None, model_path=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, network_delay_ms=None, min_think_ms=None, draw_value_black=None, draw_value_white=None, resign_value=None, resign_consecutive=None, max_moves_to_draw=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
+#[pyo3(signature = (*, engine_name=None, engine_author=None, model_path=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, network_delay_ms=None, min_think_ms=None, draw_value_black=None, draw_value_white=None, resign_value=None, resign_consecutive=None, max_moves_to_draw=None, usi_ponder=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
 #[allow(clippy::too_many_arguments)]
 fn run_usi(
     py: Python<'_>,
@@ -56,6 +59,7 @@ fn run_usi(
     resign_value: Option<u32>,
     resign_consecutive: Option<u32>,
     max_moves_to_draw: Option<u32>,
+    usi_ponder: Option<bool>,
     root_dfpn: Option<bool>,
     root_dfpn_nodes: Option<u64>,
     root_dfpn_depth: Option<u32>,
@@ -101,6 +105,9 @@ fn run_usi(
     }
     if let Some(v) = max_moves_to_draw {
         config.max_moves_to_draw = v;
+    }
+    if let Some(v) = usi_ponder {
+        config.usi_ponder = v;
     }
     config.root_dfpn = root_dfpn;
     config.root_dfpn_nodes = root_dfpn_nodes;

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/lib.rs
+++ b/rust/maou_search/src/lib.rs
@@ -53,6 +53,6 @@ pub use onnx::OnnxEvaluator;
 pub use position::{build_board_and_history, PositionSetupError};
 pub use repetition::{HistoryEntry, RepetitionOutcome};
 pub use search::{
-    RootChildStat, RootSnapshot, SearchLimits, SearchOptions, SearchResult, SearchStats, Searcher,
-    StopCause,
+    ReusableTree, RootChildStat, RootSnapshot, SearchLimits, SearchOptions, SearchResult,
+    SearchStats, Searcher, StopCause,
 };

--- a/rust/maou_search/src/search.rs
+++ b/rust/maou_search/src/search.rs
@@ -63,6 +63,7 @@ use maou_shogi::movegen::generate_legal_moves;
 use maou_shogi::moves::Move;
 
 use crate::evaluator::{EvalItem, Evaluator};
+use crate::position::{build_board_and_history, PositionSetupError};
 use crate::repetition::{find_repetition, HistoryEntry, RepetitionOutcome};
 use crate::tree::{node_state, proven, Edge, NodePool, NULL_NODE};
 
@@ -487,6 +488,52 @@ pub struct RootSnapshot {
     pub pv: Vec<Move>,
     /// root の確定値 (詰み等)．未確定は `None`．
     pub proven: Option<f64>,
+}
+
+/// 対局手番間で保持する探索木 (subtree 再利用のための不透明ハンドル)．
+///
+/// [`Searcher::search_reusing`] が返し，次回に渡すと前回 root からの指し手で
+/// reroot して再利用する ([`NodePool::reroot`])．内部プールは maou_search が
+/// 管理し，呼び出し側は中身に触れない (index/ノード表現に依存させない)．
+pub struct ReusableTree {
+    /// 保持する探索木．
+    pool: NodePool,
+    /// この木の root に対応する基準 SFEN．
+    sfen: String,
+    /// 基準 SFEN からこの木の root までの USI 指し手列 (reroot の advance 計算用)．
+    moves: Vec<String>,
+}
+
+/// 保持木 `prev` を今回の局面 (`sfen` + `moves`) に再利用できるか判定し，
+/// できれば reroot 済みプールを返す (できなければ `None` = fresh 探索)．
+///
+/// 再利用条件: 基準 SFEN が一致し，`moves` が保持木の経路を prefix 拡張して
+/// いる (= root が手番進行で前進した関係)．差分の手を保持木の root 局面から
+/// パースして [`NodePool::reroot`] する (辺は生成順の `Move` で照合するため，
+/// 同一局面の movegen が同一 `Move` を返す決定性に依存する)．
+fn reuse_pool(prev: ReusableTree, sfen: &str, moves: &[String]) -> Option<NodePool> {
+    // 同一基準局面で，今回の経路が前回の経路を真に prefix 拡張していること
+    if prev.sfen != sfen || moves.len() <= prev.moves.len() {
+        return None;
+    }
+    if moves[..prev.moves.len()] != prev.moves[..] {
+        return None;
+    }
+    let advance_usi = &moves[prev.moves.len()..];
+    // 差分の手を保持木の root 局面から `Move` へパースする (辺照合に必要)．
+    // 前回経路は探索済みで合法なので build は成功するはず
+    let (mut board, _) = build_board_and_history(sfen, &prev.moves).ok()?;
+    let mut advance: Vec<Move> = Vec::with_capacity(advance_usi.len());
+    for usi in advance_usi {
+        let mut probe = board.clone();
+        let mv = generate_legal_moves(&mut probe)
+            .into_iter()
+            .find(|m| m.to_usi() == *usi)?;
+        advance.push(mv);
+        board.do_move(mv);
+    }
+    let mut pool = prev.pool;
+    pool.reroot(&advance).then_some(pool)
 }
 
 /// スレッド間共有の探索状態．
@@ -1190,6 +1237,24 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
         game_history: &[HistoryEntry],
         limits: &SearchLimits,
     ) -> SearchResult {
+        self.run_search(root_board, game_history, limits, None).0
+    }
+
+    /// [`Searcher::search_with_history`] の本体 + subtree 再利用の入口．
+    ///
+    /// `reused` に前回探索の (reroot 済み) プールを渡すと，その root が展開済み
+    /// なら root の同期評価を省いて warm start する (統計・辺を引き継ぐ = 対局
+    /// 手番間の subtree 再利用)．`None` または root 未展開なら従来どおり新規
+    /// プールで root を同期評価する — このとき挙動は `reused` 導入前と
+    /// **bit-identical** (canonical 29te/39te で担保)．戻り値のプールは次回に
+    /// `reused` として渡せる (呼び出し側で保持する)．
+    fn run_search(
+        &self,
+        root_board: &Board,
+        game_history: &[HistoryEntry],
+        limits: &SearchLimits,
+        reused: Option<NodePool>,
+    ) -> (SearchResult, NodePool) {
         // ルート評価 (初回推論 = TensorRT エンジンビルド等) は 1 回限りの固定
         // コストなので計測区間の外で済ませ，warmup_ms として別掲する
         // (onnx_bench の out-of-timer warmup と同義)．計測 (start/deadline) は
@@ -1201,7 +1266,7 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
         let mut probe = root_board.clone();
         let root_moves = generate_legal_moves(&mut probe);
         if root_moves.is_empty() {
-            return SearchResult {
+            let result = SearchResult {
                 best_move: None,
                 winrate: 0.0,
                 pv: Vec::new(),
@@ -1226,37 +1291,49 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
                     gc_freed_nodes: 0,
                 },
             };
+            // 終端局面の木は再利用価値がない (次回は fresh になる)．大きな
+            // 空プールを確保しないため最小プールを返す
+            return (result, reused.unwrap_or_else(|| NodePool::new(1)));
         }
 
-        // ルートを同期的に評価して展開する
-        let pool = NodePool::new(opts.node_capacity);
-        let root_idx = pool.alloc().expect("capacity >= 1 なので必ず確保できる");
-        debug_assert_eq!(root_idx, ROOT_IDX);
-        let root_item = [EvalItem {
-            board: root_board.clone(),
-            moves: root_moves,
-        }];
-        let mut root_results = self.evaluator.evaluate_batch(&root_item);
-        let root_result = root_results.pop().expect("バッチ 1 件の結果");
-        let [root_item] = root_item;
-        assert_eq!(
-            root_result.priors.len(),
-            root_item.moves.len(),
-            "evaluator は moves と同数の priors を返すこと"
-        );
-        let edges: Box<[Edge]> = root_item
-            .moves
-            .iter()
-            .zip(root_result.priors.iter())
-            .map(|(&mv, &p)| Edge::new(mv, p))
-            .collect();
-        {
-            let root_node = pool.get(ROOT_IDX);
-            root_node.finish_expansion(edges);
-            root_node.add_visit();
-        }
+        // プール準備: 再利用可能 (保持木の root が展開済み) なら warm start —
+        // root の同期評価を省き，引き継いだ統計・辺から探索を継続する．さもなくば
+        // 新規プールで root を同期評価して展開する (従来経路 = bit-identical)．
+        let pool = match reused {
+            Some(p) if p.used() > 0 && p.get(ROOT_IDX).state() == node_state::EXPANDED => p,
+            _ => {
+                let pool = NodePool::new(opts.node_capacity);
+                let root_idx = pool.alloc().expect("capacity >= 1 なので必ず確保できる");
+                debug_assert_eq!(root_idx, ROOT_IDX);
+                let root_item = [EvalItem {
+                    board: root_board.clone(),
+                    moves: root_moves,
+                }];
+                let mut root_results = self.evaluator.evaluate_batch(&root_item);
+                let root_result = root_results.pop().expect("バッチ 1 件の結果");
+                let [root_item] = root_item;
+                assert_eq!(
+                    root_result.priors.len(),
+                    root_item.moves.len(),
+                    "evaluator は moves と同数の priors を返すこと"
+                );
+                let edges: Box<[Edge]> = root_item
+                    .moves
+                    .iter()
+                    .zip(root_result.priors.iter())
+                    .map(|(&mv, &p)| Edge::new(mv, p))
+                    .collect();
+                {
+                    let root_node = pool.get(ROOT_IDX);
+                    root_node.finish_expansion(edges);
+                    root_node.add_visit();
+                }
+                pool
+            }
+        };
 
-        // ルート評価 (初回推論のエンジンビルド含む) はここで完了．計測を開始する
+        // ルート評価 (初回推論のエンジンビルド含む) はここで完了 (warm start なら
+        // 評価は走っていない)．計測を開始する
         let warmup_ms = warmup_start.elapsed().as_millis() as u64;
         let start = Instant::now();
 
@@ -1380,7 +1457,39 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
             dfpn_stop.store(true, Ordering::Release);
         });
 
-        self.collect_result(&shared, warmup_ms, start, gc_runs, gc_freed_nodes)
+        let result = self.collect_result(&shared, warmup_ms, start, gc_runs, gc_freed_nodes);
+        // 更新後のプールを取り出して返す (次回の subtree 再利用に渡せる)
+        let Shared { pool, .. } = shared;
+        (result, pool)
+    }
+
+    /// 局面 (基準 SFEN + USI 経路) を，前回の保持木を可能なら再利用して探索する．
+    ///
+    /// `prev` が「同一基準 SFEN で `moves` がその経路を prefix 拡張している」=
+    /// root が手番進行で前進した関係なら，差分の手で保持木を reroot して
+    /// warm start する (subtree 再利用)．できなければ fresh 探索する．結果と
+    /// 更新後の保持木を返す (次回に `prev` として渡すと再利用される)．
+    ///
+    /// 保持木の各ノードはゲーム開始からの完全な局面列が reroot 前後で不変な
+    /// ため，千日手由来の終端・確定値も含め健全性が保たれる ([`NodePool::reroot`])．
+    pub fn search_reusing(
+        &self,
+        sfen: &str,
+        moves: &[String],
+        limits: &SearchLimits,
+        prev: Option<ReusableTree>,
+    ) -> Result<(SearchResult, ReusableTree), PositionSetupError> {
+        let (board, history) = build_board_and_history(sfen, moves)?;
+        let reused = prev.and_then(|t| reuse_pool(t, sfen, moves));
+        let (result, pool) = self.run_search(&board, &history, limits, reused);
+        Ok((
+            result,
+            ReusableTree {
+                pool,
+                sfen: sfen.to_string(),
+                moves: moves.to_vec(),
+            },
+        ))
     }
 
     /// 探索終了後の木からベストムーブ・PV・統計を集計する．
@@ -2368,5 +2477,77 @@ mod tests {
         // progress None でも通常どおり探索は完了する
         assert!(result.best_move.is_some());
         assert!(result.stats.playouts >= 4096);
+    }
+
+    #[test]
+    fn test_search_reusing_warm_starts_and_stays_sound() {
+        // 単一スレッド + mock なので決定論的．手番進行で subtree を再利用する
+        let evaluator = MockEvaluator::new(0);
+        let opts = SearchOptions {
+            threads: 1,
+            batch_size: 4,
+            node_capacity: 1 << 14,
+            ..pure_mcts_opts()
+        };
+        let searcher = Searcher::new(&evaluator, opts);
+        let big = SearchLimits {
+            max_playouts: Some(5000),
+            ..SearchLimits::default()
+        };
+
+        // 1 手目後の局面を探索して木を保持する
+        let (r1, tree1) = searcher
+            .search_reusing(STARTPOS, &["7g7f".to_string()], &big, None)
+            .expect("正当な局面");
+        assert!(r1.pv.len() >= 2, "PV は 2 手以上 (継承できる筋がある)");
+        // PV 先頭 2 手で前進 = 探索済みの筋 → reroot が成功する経路
+        let moves = vec!["7g7f".to_string(), r1.pv[0].to_usi(), r1.pv[1].to_usi()];
+
+        let small = SearchLimits {
+            max_playouts: Some(400),
+            ..SearchLimits::default()
+        };
+        // warm: tree1 を再利用 / cold: 同一局面を fresh 探索
+        let (r_warm, _tree2) = searcher
+            .search_reusing(STARTPOS, &moves, &small, Some(tree1))
+            .expect("正当");
+        let (r_cold, _) = searcher
+            .search_reusing(STARTPOS, &moves, &small, None)
+            .expect("正当");
+
+        // soundness: どちらも新局面の合法手を返す
+        let (board, _) = build_board_and_history(STARTPOS, &moves).unwrap();
+        let legal = generate_legal_moves(&mut board.clone());
+        for r in [&r_warm, &r_cold] {
+            let best = r.best_move.expect("合法手がある");
+            assert!(legal.contains(&best), "best は合法手: {}", best.to_usi());
+        }
+        // warm start は継承した訪問を持つので，同じ予算でも root 直下の総訪問が多い
+        let warm: u64 = r_warm.root_children.iter().map(|c| c.visits).sum();
+        let cold: u64 = r_cold.root_children.iter().map(|c| c.visits).sum();
+        assert!(
+            warm > cold,
+            "warm start は継承分だけ訪問が多い (warm={warm}, cold={cold})"
+        );
+    }
+
+    #[test]
+    fn test_search_reusing_falls_back_when_position_diverges() {
+        // 経路が prefix 拡張でない (別局面) なら再利用せず fresh になる
+        let evaluator = MockEvaluator::new(0);
+        let searcher = Searcher::new(&evaluator, pure_mcts_opts());
+        let limits = SearchLimits {
+            max_playouts: Some(500),
+            ..SearchLimits::default()
+        };
+        let (_r1, tree1) = searcher
+            .search_reusing(STARTPOS, &["7g7f".to_string()], &limits, None)
+            .expect("正当");
+        // 全く別の初手経路 → prefix 不一致 → fresh (crash せず正当な結果)
+        let (r2, _t2) = searcher
+            .search_reusing(STARTPOS, &["2g2f".to_string()], &limits, Some(tree1))
+            .expect("正当");
+        assert!(r2.best_move.is_some(), "fresh 探索でも best が出る");
+        assert!(r2.stats.playouts >= 500);
     }
 }

--- a/rust/maou_search/src/tree.rs
+++ b/rust/maou_search/src/tree.rs
@@ -420,6 +420,108 @@ impl NodePool {
         }
     }
 
+    /// 保持木を `path` (旧 root からの指し手列) が指す局面へ reroot して，
+    /// 到達可能なサブツリーだけを index 0 起点に詰め直す (reachability
+    /// mark-compact — 対局手番間の subtree 再利用)．成功で `true`．
+    ///
+    /// 旧 root (index 0) から `path` の各手に対応する辺を辿って新 root を求め，
+    /// そこから到達可能なノードを BFS 順 (新 root = 0) に前方へ move する．
+    /// 刈られたノードへの辺は [`NULL_NODE`] に戻る．新 root の統計 (visits /
+    /// wins / proven / edges) はそのまま保存され，次の探索で warm start する．
+    ///
+    /// 再利用しない (= `false` を返し木を変更しない) のは:
+    /// - 経路の途中/末尾のノードが [`node_state::EXPANDED`] でない (未評価・終端)
+    /// - 経路の手に対応する辺が無い / 子が未生成 ([`NULL_NODE`]) = その筋は未探索
+    ///
+    /// 保存されるサブツリーの各ノードは，ゲーム開始からの完全な局面列が reroot
+    /// 前後で不変 (`path` の手が探索経路から対局履歴側へ移るだけ) なため，千日手
+    /// 由来の終端・確定値も含めて健全性が保たれる — 呼び出し側は新 root の完全な
+    /// 対局履歴を渡すこと (`build_board_and_history` が自動で満たす)．
+    ///
+    /// # 前提
+    ///
+    /// 全探索スレッドが停止した quiescent 状態でのみ呼べる (`&mut self` を
+    /// 要求するためコンパイル時に強制される．[`NodePool::compact`] と同じ)．
+    pub fn reroot(&mut self, path: &[Move]) -> bool {
+        // 1. 旧 root から path を辿って新 root index を求める
+        let mut cur: u32 = 0;
+        for &mv in path {
+            let node = &self.nodes[cur as usize];
+            if node.state.load(Ordering::Acquire) != node_state::EXPANDED {
+                return false;
+            }
+            let Some(edge) = node.edges().iter().find(|e| e.mv == mv) else {
+                return false;
+            };
+            let child = edge.child.load(Ordering::Acquire);
+            if child == NULL_NODE {
+                return false;
+            }
+            cur = child;
+        }
+        let new_root = cur;
+        // 新 root は展開済みでなければ MCTS を回せない (終端は edges を持たない)
+        if self.nodes[new_root as usize].state.load(Ordering::Acquire) != node_state::EXPANDED {
+            return false;
+        }
+
+        // 2. 新 root から到達可能なノードを BFS でマークする (旧 index → 新 index)．
+        //    新 root が新 index 0．EXPANDED ノードのみ子を辿る (終端は葉)
+        let cap = self.nodes.len();
+        let mut map = vec![NULL_NODE; cap];
+        let mut order: Vec<u32> = Vec::with_capacity(self.used() as usize);
+        map[new_root as usize] = 0;
+        order.push(new_root);
+        let mut head = 0usize;
+        while head < order.len() {
+            let old = order[head] as usize;
+            head += 1;
+            if self.nodes[old].state.load(Ordering::Acquire) == node_state::EXPANDED {
+                for e in self.nodes[old].edges() {
+                    let c = e.child.load(Ordering::Acquire);
+                    if c != NULL_NODE && map[c as usize] == NULL_NODE {
+                        map[c as usize] = order.len() as u32;
+                        order.push(c);
+                    }
+                }
+            }
+        }
+        let kept = order.len();
+
+        // 3. 生存ノードを BFS 順に新しい配列へ move する (Node は非 Clone なので
+        //    mem::replace で取り出す)．残りは新規ノードで埋めて容量を維持する
+        let old_nodes = std::mem::replace(&mut self.nodes, Vec::new().into_boxed_slice());
+        let mut old_vec: Vec<Node> = old_nodes.into_vec();
+        let mut new_vec: Vec<Node> = Vec::with_capacity(cap);
+        for &old_idx in &order {
+            new_vec.push(std::mem::replace(
+                &mut old_vec[old_idx as usize],
+                Node::new(),
+            ));
+        }
+        for _ in kept..cap {
+            new_vec.push(Node::new());
+        }
+
+        // 4. 生存ノードの辺を新 index に張り替える (刈られた子は NULL_NODE)．
+        //    排他参照下なので Relaxed で十分 (探索再開側との happens-before は
+        //    スレッド spawn が与える — compact と同じ)
+        for node in &new_vec[..kept] {
+            if let Some(edges) = node.edges.get() {
+                for e in edges.iter() {
+                    let c = e.child.load(Ordering::Relaxed);
+                    if c != NULL_NODE {
+                        e.child.store(map[c as usize], Ordering::Relaxed);
+                    }
+                }
+            }
+        }
+
+        self.nodes = new_vec.into_boxed_slice();
+        self.next.store(kept as u32, Ordering::Relaxed);
+        true
+    }
+
     /// プール容量を返す．
     pub fn capacity(&self) -> u32 {
         self.nodes.len() as u32
@@ -555,5 +657,115 @@ mod tests {
         assert_eq!(st.freed, 0);
         assert_eq!(pool.used(), 1);
         assert_eq!(pool.get(0).state(), node_state::UNEXPANDED);
+    }
+
+    /// reroot テスト用の木を作る: root(v10) ──mv0── a(v6) ──mv0── c(v4, win.75)，
+    /// root ──mv1── b(v1)．(a, b, c) = pool index (1, 2, 3)．
+    fn build_reroot_pool() -> (NodePool, Vec<maou_shogi::moves::Move>) {
+        use maou_shogi::board::Board;
+        use maou_shogi::movegen::generate_legal_moves;
+
+        let mut board = Board::empty();
+        board
+            .set_sfen("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("正当な SFEN");
+        let mvs = generate_legal_moves(&mut board);
+
+        let pool = NodePool::new(8);
+        let root = pool.alloc().unwrap();
+        let a = pool.alloc().unwrap();
+        let b = pool.alloc().unwrap();
+        let c = pool.alloc().unwrap();
+
+        let e_a = Edge::new(mvs[0], 0.6);
+        e_a.child.store(a, Ordering::Relaxed);
+        let e_b = Edge::new(mvs[1], 0.4);
+        e_b.child.store(b, Ordering::Relaxed);
+        pool.get(root).finish_expansion(Box::new([e_a, e_b]));
+        let e_c = Edge::new(mvs[0], 1.0);
+        e_c.child.store(c, Ordering::Relaxed);
+        pool.get(a).finish_expansion(Box::new([e_c]));
+        pool.get(c).finish_expansion(Box::new([])); // 展開済みの葉
+
+        for _ in 0..10 {
+            pool.get(root).add_visit();
+        }
+        for _ in 0..6 {
+            pool.get(a).add_visit();
+        }
+        pool.get(b).add_visit();
+        for _ in 0..4 {
+            pool.get(c).add_visit();
+        }
+        pool.get(c).add_win(0.75);
+        (pool, mvs)
+    }
+
+    #[test]
+    fn test_reroot_keeps_subtree_and_prunes_siblings() {
+        let (mut pool, mvs) = build_reroot_pool();
+        // mv0 で前進 → 新 root = a．到達可能は {a, c}，b は刈られる
+        assert!(pool.reroot(&[mvs[0]]));
+        assert_eq!(pool.used(), 2, "a, c のみ残る");
+
+        // 新 root (index 0) = 旧 a: 統計と辺が保存され，辺は c の新 index を指す
+        let new_root = pool.get(0);
+        assert_eq!(new_root.visits(), 6, "a の visits が保存される");
+        assert_eq!(new_root.state(), node_state::EXPANDED);
+        let edges = new_root.edges();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].mv, mvs[0]);
+        let c_idx = edges[0].child.load(Ordering::Relaxed);
+        assert_eq!(c_idx, 1, "c は新 index 1 に再配置される");
+
+        // c の統計も保存される
+        let c_node = pool.get(1);
+        assert_eq!(c_node.visits(), 4);
+        assert!((c_node.wins() - 0.75).abs() < 1e-3);
+
+        // 解放スロットは再割り当てできる
+        assert_eq!(pool.alloc(), Some(2));
+    }
+
+    #[test]
+    fn test_reroot_two_ply() {
+        let (mut pool, mvs) = build_reroot_pool();
+        // mv0, mv0 で 2 手前進 → 新 root = c (葉，子なし)
+        assert!(pool.reroot(&[mvs[0], mvs[0]]));
+        assert_eq!(pool.used(), 1, "c のみ残る");
+        let new_root = pool.get(0);
+        assert_eq!(new_root.visits(), 4);
+        assert!((new_root.wins() - 0.75).abs() < 1e-3);
+        assert_eq!(new_root.state(), node_state::EXPANDED);
+        assert!(new_root.edges().is_empty());
+    }
+
+    #[test]
+    fn test_reroot_fails_on_unexplored_move() {
+        let (mut pool, mvs) = build_reroot_pool();
+        // mvs[2] は root の辺に無い (未探索の筋) → 再利用不能，木は不変
+        assert!(!pool.reroot(&[mvs[2]]));
+        assert_eq!(pool.used(), 4, "木は変更されない");
+        assert_eq!(pool.get(0).visits(), 10);
+    }
+
+    #[test]
+    fn test_reroot_fails_on_null_child() {
+        use maou_shogi::board::Board;
+        use maou_shogi::movegen::generate_legal_moves;
+
+        let mut board = Board::empty();
+        board
+            .set_sfen("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("正当な SFEN");
+        let mvs = generate_legal_moves(&mut board);
+        // root は展開済みだが辺の子は未生成 (NULL_NODE) = その筋は未探索
+        let mut pool = NodePool::new(4);
+        let _root = pool.alloc().unwrap();
+        let e = Edge::new(mvs[0], 1.0); // child は NULL_NODE のまま
+        pool.get(0).finish_expansion(Box::new([e]));
+        pool.get(0).add_visit();
+        assert!(!pool.reroot(&[mvs[0]]), "子未生成の筋は再利用不能");
+        assert_eq!(pool.used(), 1);
     }
 }

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -220,6 +220,11 @@ pub trait SearchBackend {
 
     /// mock 評価器か (isready 時の明示に使う)．
     fn is_mock(&self) -> bool;
+
+    /// 対局リセット時に保持している探索状態 (subtree 再利用の木など) を破棄する
+    /// (`usinewgame` / `gameover`)．次の探索は fresh になる．保持状態を持たない
+    /// 実装は既定の no-op でよい．
+    fn reset(&mut self) {}
 }
 
 /// 対局状態．
@@ -351,6 +356,11 @@ where
             GuiCommand::UsiNewGame => {
                 self.game = GameState::default();
                 self.resign_streak = 0;
+                // 保持している探索木 (subtree 再利用) を破棄する (別対局の木を
+                // 引き継がない)
+                if let Some(b) = self.backend.as_mut() {
+                    b.reset();
+                }
                 Ok(Vec::new())
             }
             GuiCommand::Position { sfen, moves } => {
@@ -380,6 +390,9 @@ where
                 let _: GameResult = result;
                 self.game = GameState::default();
                 self.resign_streak = 0;
+                if let Some(b) = self.backend.as_mut() {
+                    b.reset();
+                }
                 Ok(Vec::new())
             }
             GuiCommand::Quit => Ok(Vec::new()),

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -4,7 +4,7 @@
 //! 探索は [`SearchBackend`] trait 越しに呼ぶため，fake backend で状態機械を
 //! 単体テストできる．時間管理は [`crate::time`] (戦略レイヤー) に委譲する．
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use maou_shogi::types::Color;
@@ -68,6 +68,10 @@ pub struct EngineConfig {
     /// 引き分けになる最大手数 (既定 0 = 無効．電竜戦は 512)．到達局面では入玉
     /// 宣言を必ず確認し，可能なら宣言勝ちする．
     pub max_moves_to_draw: u32,
+    /// ponder (先読み) を有効にするか (既定 true)．true のとき `USI_Ponder`
+    /// option を宣言し，`bestmove` に予想相手手 (自探索 PV の 2 手目) を付ける．
+    /// GUI はこれを見て相手番中に `go ponder` を送る (設計 doc §8.4)．
+    pub usi_ponder: bool,
     /// ルート並行 dfpn (None = maou_search 既定)．
     pub root_dfpn: Option<bool>,
     /// ルート dfpn ノード予算．
@@ -101,6 +105,7 @@ impl Default for EngineConfig {
             resign_value: 0,
             resign_consecutive: 3,
             max_moves_to_draw: 0,
+            usi_ponder: true,
             root_dfpn: None,
             root_dfpn_nodes: None,
             root_dfpn_depth: None,
@@ -290,6 +295,11 @@ where
     /// root 勝率が投了閾値未満だった連続手数 (`resign_value` 用)．usinewgame /
     /// gameover でリセットする．
     resign_streak: u32,
+    /// ponder 的中シグナル．transport (stdio reader) が行の到着順で更新する:
+    /// `go` 行で false，`ponderhit` 行で true (stop フラグと同じ race-free 規約)．
+    /// 探索中の [`GoObserver`] がポーリングし，的中したら無期限の ponder 探索を
+    /// 時間予算へ切り替える (探索木はそのまま引き継がれる — ponder の主利得)．
+    ponderhit: Arc<AtomicBool>,
 }
 
 impl<B, F> Agent<B, F>
@@ -306,6 +316,7 @@ where
             game: GameState::default(),
             stop: Arc::new(AtomicBool::new(false)),
             resign_streak: 0,
+            ponderhit: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -315,6 +326,14 @@ where
     /// `go` 行を読んだら false，`stop`/`quit` 行を読んだら true を store する．
     pub fn stop_handle(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.stop)
+    }
+
+    /// ponder 的中フラグのハンドル ([`Agent::ponderhit`] の規約参照)．
+    ///
+    /// transport 側の規約 (stop フラグと同じ行順更新): `go` 行で false，
+    /// `ponderhit` 行で true を store する．探索中の observer がこれを拾う．
+    pub fn ponderhit_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.ponderhit)
     }
 
     /// コマンドを 1 つ処理して応答列を返す．
@@ -348,10 +367,14 @@ where
                 self.handle_go_stream(&params, &mut |c| out.push(c))?;
                 Ok(out)
             }
-            // M1: 同期探索のため Stop 処理時点で探索は終わっている
-            // (bestmove は Go の応答として送信済み)．ここでは何もしない
+            // Stop は探索中に transport (reader スレッド) が stop フラグへ即
+            // 反映する (行の到着順規約)．dispatcher が Go でブロック中に処理
+            // されるのはブロック解除後 = 探索終了後で，bestmove は Go の応答
+            // として送信済み．ここでは何もしない
             GuiCommand::Stop => Ok(Vec::new()),
-            // M1: ponder 未対応 (USI_Ponder を宣言しないため通常来ない)
+            // PonderHit も reader スレッドが ponderhit フラグへ反映し，探索中の
+            // GoObserver が拾って時間予算へ切り替える (agent 内で完結する)．
+            // dispatcher へ届く頃には探索終了後なので，ここでは何もしない
             GuiCommand::PonderHit(_) => Ok(Vec::new()),
             GuiCommand::GameOver(result) => {
                 let _: GameResult = result;
@@ -437,6 +460,12 @@ where
                 name: "TrtCacheDir",
                 kind: OptionKind::String {
                     default: c.trt_cache_dir.clone().unwrap_or_default(),
+                },
+            },
+            OptionDecl {
+                name: "USI_Ponder",
+                kind: OptionKind::Check {
+                    default: c.usi_ponder,
                 },
             },
             OptionDecl {
@@ -617,6 +646,10 @@ where
                 }
                 invalidate = false;
             }
+            "USI_Ponder" => {
+                self.config.usi_ponder = parse_bool();
+                invalidate = false;
+            }
             // 未知のオプションは無視 (GUI 側の拡張への耐性)
             _ => invalidate = false,
         }
@@ -656,19 +689,29 @@ where
 
         let draw_value = self.draw_value_for(self.game.side_to_move());
         let budget = self.decide_budget(params);
+        // ponder (`go ponder`) は無期限探索で始め，`ponderhit` を拾ったら時間
+        // 予算へ切り替える (探索木は引き継がれる)．的中後に使う予算 = この局面を
+        // 通常 go したときと同じ配分をここで計算して observer へ渡す．
+        let ponder_switch = params.ponder.then(|| {
+            (
+                Arc::clone(&self.ponderhit),
+                self.timed_budget(&params.clock),
+            )
+        });
         let sfen = self.game.sfen.clone();
         let moves = self.game.moves.clone();
         let stop = Arc::clone(&self.stop);
         let outcome = {
             let backend = self.backend.as_mut().expect("直前で構築済み");
-            let mut observer = GoObserver::new(emit, budget.time);
+            let mut observer = GoObserver::new(emit, budget.time, ponder_switch);
             backend.search(&sfen, &moves, &budget, draw_value, &stop, &mut observer)?
         };
 
-        // 探索サマリ info (最終) → bestmove
+        // 探索サマリ info (最終) → bestmove (予想相手手 = 自探索 PV の 2 手目)
         emit(EngineCommand::Info(build_info(&outcome)));
         let mv = self.decide_bestmove(&outcome);
-        emit(EngineCommand::BestMove { mv, ponder: None });
+        let ponder = self.ponder_move(&mv, &outcome);
+        emit(EngineCommand::BestMove { mv, ponder });
         Ok(())
     }
 
@@ -717,6 +760,18 @@ where
         BestMoveKind::Move(usi.clone())
     }
 
+    /// bestmove に付ける予想相手手 (ponder 対象 = 自探索 PV の 2 手目)．
+    ///
+    /// `USI_Ponder` が無効・指し手が resign/win・PV が 2 手未満なら `None`
+    /// (設計 doc §8.4)．GUI はこの手を相手が指すと仮定して相手番中に
+    /// `go ponder` を送る．
+    fn ponder_move(&self, mv: &BestMoveKind, outcome: &SearchOutcome) -> Option<String> {
+        if !self.config.usi_ponder || !matches!(mv, BestMoveKind::Move(_)) {
+            return None;
+        }
+        outcome.pv.get(1).cloned()
+    }
+
     /// go パラメータ → 探索予算 (時間戦略は crate::time)．
     fn decide_budget(&self, params: &GoParams) -> SearchBudget {
         if params.infinite || params.ponder {
@@ -747,17 +802,23 @@ where
                 unbounded: false,
             };
         }
-        let mut budget = allocate(&self.config.time, &params.clock, self.game.side_to_move());
+        SearchBudget {
+            time: Some(self.timed_budget(&params.clock)),
+            max_playouts: None,
+            unbounded: false,
+        }
+    }
+
+    /// 持ち時間 → 時間予算 (soft/hard)．`allocate` に MaxMovesToDraw 目前の絞り
+    /// (§8.3) を重ねたもの．通常 go と ponderhit 後の予算計算で共有する．
+    fn timed_budget(&self, clock: &crate::protocol::ClockParams) -> TimeBudget {
+        let mut budget = allocate(&self.config.time, clock, self.game.side_to_move());
         // MaxMovesToDraw が近ければ予算を絞る (引き分け目前で深追いしない．§8.3)
         if let Some(cap) = self.max_moves_draw_cap() {
             budget.soft_ms = budget.soft_ms.min(cap);
             budget.hard_ms = budget.hard_ms.min(cap).max(budget.soft_ms);
         }
-        SearchBudget {
-            time: Some(budget),
-            max_playouts: None,
-            unbounded: false,
-        }
+        budget
     }
 
     /// MaxMovesToDraw リミットが目前 (残り 4 手以内) なら思考予算の上限
@@ -793,18 +854,31 @@ fn has_time_remaining(clock: &crate::protocol::ClockParams, side: Color) -> bool
 /// ([`crate::time::should_stop`])．
 struct GoObserver<'a, 'e> {
     emit: &'a mut Emit<'e>,
-    /// 時間予算 (`None` = 無期限探索: 時間による停止要求はしない)．
+    /// 現在有効な時間予算 (`None` = 無期限: `go infinite` / ponder 中で未的中)．
     budget: Option<TimeBudget>,
     /// 次に info を出す経過時刻 (ミリ秒)．
     next_info_ms: u64,
+    /// ponder (`go ponder`) 用の的中スイッチ: (的中フラグ, 的中後の時間予算)．
+    /// 非 ponder go は `None`．的中フラグが立ったら `budget` を的中後予算へ
+    /// 切り替える (探索木はそのまま引き継がれる — ponder の主利得)．
+    ponder: Option<(Arc<AtomicBool>, TimeBudget)>,
+    /// 時間計測の起点 (ミリ秒)．ponder 的中時に「今」へ更新する — 的中後の
+    /// 予算は的中時点から計測する (ponder 中の思考は相手の持ち時間ゆえ無料)．
+    baseline_ms: u64,
 }
 
 impl<'a, 'e> GoObserver<'a, 'e> {
-    fn new(emit: &'a mut Emit<'e>, budget: Option<TimeBudget>) -> GoObserver<'a, 'e> {
+    fn new(
+        emit: &'a mut Emit<'e>,
+        budget: Option<TimeBudget>,
+        ponder: Option<(Arc<AtomicBool>, TimeBudget)>,
+    ) -> GoObserver<'a, 'e> {
         GoObserver {
             emit,
             budget,
             next_info_ms: 0,
+            ponder,
+            baseline_ms: 0,
         }
     }
 }
@@ -818,11 +892,24 @@ impl SearchObserver for GoObserver<'_, '_> {
             )));
             self.next_info_ms = elapsed_ms + INFO_INTERVAL_MS;
         }
-        // 時間延長判断 (無期限探索なら停止要求しない = 外部 stop のみで止まる)
+        // ponder 的中: 無期限探索を時間予算へ切り替え，計測起点を的中時点に置く
+        // (それまでに積んだ playout = 探索木はそのまま活きる = ponder の主利得)
+        if self.budget.is_none() {
+            let hit = self
+                .ponder
+                .as_ref()
+                .is_some_and(|(flag, _)| flag.load(Ordering::Acquire));
+            if hit {
+                self.budget = self.ponder.as_ref().map(|(_, b)| *b);
+                self.baseline_ms = elapsed_ms;
+            }
+        }
+        // 時間延長判断 (無期限探索なら停止要求しない = 外部 stop のみで止まる)．
+        // 経過は計測起点 (通常 0，ponder 的中後は的中時点) からの差分で見る
         match self.budget {
             Some(b) => should_stop(
                 &b,
-                elapsed_ms,
+                elapsed_ms.saturating_sub(self.baseline_ms),
                 snapshot.best_visits,
                 snapshot.second_visits,
                 snapshot.proven.is_some(),
@@ -1022,13 +1109,13 @@ mod tests {
                 ..GoParams::default()
             }))
             .unwrap();
-        // info (pv 付き) → bestmove の順
+        // info (pv 付き) → bestmove の順．PV = [7g7f, 3c3d] → 予想相手手 3c3d
         assert!(matches!(&out[0], EngineCommand::Info(i) if !i.pv.is_empty()));
         assert_eq!(
             out.last(),
             Some(&EngineCommand::BestMove {
                 mv: BestMoveKind::Move("7g7f".to_string()),
-                ponder: None
+                ponder: Some("3c3d".to_string())
             })
         );
         // バックエンドへは SFEN + USI 経路 (千日手履歴規約) が渡る
@@ -1403,5 +1490,117 @@ mod tests {
                 "{name} オプションが宣言される"
             );
         }
+    }
+
+    #[test]
+    fn test_usi_ponder_option_declared() {
+        let (mut agent, _) = agent_with_fake(default_outcome());
+        let out = agent.handle(GuiCommand::Usi).unwrap();
+        // M3: USI_Ponder は check 型・既定 true で宣言される (GUI が ponder を
+        // 送る trigger)．M1/M2 では宣言していなかった
+        assert!(out.iter().any(|c| matches!(
+            c,
+            EngineCommand::OptionDecl(OptionDecl {
+                name: "USI_Ponder",
+                kind: OptionKind::Check { default: true }
+            })
+        )));
+    }
+
+    #[test]
+    fn test_bestmove_carries_ponder_move() {
+        // default_outcome の PV = [7g7f, 3c3d] → 予想相手手 = 3c3d
+        let (mut agent, _) = agent_with_fake(default_outcome());
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        assert_eq!(
+            out.last(),
+            Some(&EngineCommand::BestMove {
+                mv: BestMoveKind::Move("7g7f".to_string()),
+                ponder: Some("3c3d".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn test_no_ponder_when_disabled() {
+        let (mut agent, _) = agent_with_fake(default_outcome());
+        agent.handle(GuiCommand::IsReady).unwrap();
+        set(&mut agent, "USI_Ponder", "false");
+        let out = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        assert_eq!(
+            out.last(),
+            Some(&EngineCommand::BestMove {
+                mv: BestMoveKind::Move("7g7f".to_string()),
+                ponder: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_no_ponder_when_pv_too_short() {
+        // PV が 1 手のみ → 予想相手手なし
+        let short = SearchOutcome {
+            best_usi: Some("7g7f".to_string()),
+            winrate: 0.6,
+            pv: vec!["7g7f".to_string()],
+            ..SearchOutcome::default()
+        };
+        let (mut agent, _) = agent_with_fake(short);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent.handle(GuiCommand::Go(GoParams::default())).unwrap();
+        assert!(matches!(
+            out.last(),
+            Some(EngineCommand::BestMove {
+                mv: BestMoveKind::Move(_),
+                ponder: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_go_ponder_is_unbounded() {
+        // go ponder は無期限探索 (的中/stop まで止まらない)
+        let (mut agent, calls) = agent_with_fake(default_outcome());
+        agent.handle(GuiCommand::IsReady).unwrap();
+        agent
+            .handle(GuiCommand::Go(GoParams {
+                ponder: true,
+                clock: crate::protocol::ClockParams {
+                    btime: Some(60_000),
+                    wtime: Some(60_000),
+                    byoyomi: Some(10_000),
+                    ..Default::default()
+                },
+                ..GoParams::default()
+            }))
+            .unwrap();
+        assert!(calls.borrow()[0].2.unbounded);
+    }
+
+    #[test]
+    fn test_go_observer_ponderhit_switches_to_timed() {
+        // ponder observer の核心: 未的中は無期限 (停止しない)，的中したら以後は
+        // 「的中時点からの経過」で時間予算を判定する (それまでの木は活きる)
+        let hit = Arc::new(AtomicBool::new(false));
+        let budget = TimeBudget {
+            soft_ms: 1_000,
+            hard_ms: 2_000,
+        };
+        let mut sink = |_c: EngineCommand| {};
+        let mut obs = GoObserver::new(&mut sink, None, Some((Arc::clone(&hit), budget)));
+        let snap = ProgressSnapshot {
+            best_visits: 100,
+            second_visits: 90,
+            ..ProgressSnapshot::default()
+        };
+        // 未的中: 経過が長くても無期限のまま停止しない
+        assert!(!obs.on_progress(&snap, 5_000));
+        // 的中: 計測起点が的中時点 (5000ms) に更新される
+        hit.store(true, Ordering::Release);
+        // 的中直後 (since = 0) はまだ停止しない
+        assert!(!obs.on_progress(&snap, 5_000));
+        // since = 7000 − 5000 = 2000 ≥ hard → 停止する
+        assert!(obs.on_progress(&snap, 7_000));
     }
 }

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use maou_search::{
-    build_board_and_history, EvalItem, Evaluator, MockEvaluator, RootSnapshot, SearchLimits,
-    SearchOptions, SearchResult, Searcher, StopCause,
+    build_board_and_history, EvalItem, Evaluator, MockEvaluator, ReusableTree, RootSnapshot,
+    SearchLimits, SearchOptions, SearchResult, Searcher, StopCause,
 };
 use maou_shogi::board::Board;
 use maou_shogi::movegen::generate_legal_moves;
@@ -34,6 +34,9 @@ enum EngineEvaluator {
 pub struct MaouSearchBackend {
     evaluator: EngineEvaluator,
     options: SearchOptions,
+    /// 対局手番間で保持する探索木 (subtree 再利用)．手番進行で局面が前進した
+    /// ときに reroot して warm start する．`reset` (usinewgame/gameover) で破棄．
+    retained: Option<ReusableTree>,
 }
 
 impl MaouSearchBackend {
@@ -96,7 +99,11 @@ impl MaouSearchBackend {
             }
         };
 
-        let backend = MaouSearchBackend { evaluator, options };
+        let backend = MaouSearchBackend {
+            evaluator,
+            options,
+            retained: None,
+        };
         backend.warmup()?;
         Ok(backend)
     }
@@ -133,7 +140,6 @@ impl SearchBackend for MaouSearchBackend {
         stop: &Arc<AtomicBool>,
         observer: &mut dyn SearchObserver,
     ) -> Result<SearchOutcome, String> {
-        let (board, history) = build_board_and_history(sfen, moves).map_err(|e| e.to_string())?;
         // 千日手戦略: 手番視点の引き分け価値を探索へ渡す
         let mut options = self.options.clone();
         options.draw_value = draw_value;
@@ -157,18 +163,21 @@ impl SearchBackend for MaouSearchBackend {
             stop: Some(Arc::clone(stop)),
             progress: Some(Arc::clone(&progress)),
         };
+        // 前回の探索木を取り出す — 手番進行で局面が前進していれば search_reusing
+        // が reroot して warm start する (前進していなければ fresh)．
+        let retained = self.retained.take();
         // 探索を専用スレッドで走らせ，呼び出しスレッド (dispatcher) が monitor
         // ループを回す (progress をポーリング → observer 駆動 → 早期停止)．
         // GIL/GC を挟まない Rust 内で完結する (設計 §5)．
         let evaluator = &self.evaluator;
-        let result = std::thread::scope(|s| {
+        let outcome = std::thread::scope(|s| {
             let handle =
-                s.spawn(|| match evaluator {
+                s.spawn(move || match evaluator {
                     EngineEvaluator::Mock(e) => Searcher::new(e, options.clone())
-                        .search_with_history(&board, &history, &limits),
+                        .search_reusing(sfen, moves, &limits, retained),
                     #[cfg(feature = "onnx")]
                     EngineEvaluator::Onnx(e) => Searcher::new(e, options.clone())
-                        .search_with_history(&board, &history, &limits),
+                        .search_reusing(sfen, moves, &limits, retained),
                 });
             let start = Instant::now();
             while !handle.is_finished() {
@@ -183,6 +192,9 @@ impl SearchBackend for MaouSearchBackend {
             }
             handle.join().expect("探索スレッドは panic しない")
         });
+        // 更新後の木を保持して次回の subtree 再利用に備える (fresh でも保持する)
+        let (result, tree) = outcome.map_err(|e| e.to_string())?;
+        self.retained = Some(tree);
         Ok(to_outcome(&result))
     }
 
@@ -193,6 +205,11 @@ impl SearchBackend for MaouSearchBackend {
 
     fn is_mock(&self) -> bool {
         matches!(self.evaluator, EngineEvaluator::Mock(_))
+    }
+
+    fn reset(&mut self) {
+        // 対局リセット: 保持木を破棄する (次の探索は fresh)
+        self.retained = None;
     }
 }
 
@@ -331,5 +348,65 @@ mod tests {
             .err()
             .expect("非合法手はエラー");
         assert!(err.contains("7g7e"));
+    }
+
+    #[test]
+    fn test_reuse_across_moves_stays_sound_and_resets() {
+        let mut backend = MaouSearchBackend::build(&config()).expect("mock 構築は成功する");
+        let stop = Arc::new(AtomicBool::new(false));
+        let budget = SearchBudget {
+            time: None,
+            max_playouts: Some(500),
+            unbounded: false,
+        };
+        // 1 手目後を探索して木を保持する
+        let o1 = backend
+            .search(
+                STARTPOS_SFEN,
+                &["7g7f".to_string()],
+                &budget,
+                0.5,
+                &stop,
+                &mut NoopObserver,
+            )
+            .expect("探索成功");
+        let best1 = o1.best_usi.expect("合法手がある");
+        // best1 と PV の続きで前進 = 探索済みの筋 → reroot して再利用する経路
+        let mut moves = vec!["7g7f".to_string(), best1];
+        if let Some(reply) = o1.pv.get(1) {
+            moves.push(reply.clone());
+        }
+        let o2 = backend
+            .search(
+                STARTPOS_SFEN,
+                &moves,
+                &budget,
+                0.5,
+                &stop,
+                &mut NoopObserver,
+            )
+            .expect("再利用探索成功");
+        // soundness: 新局面の合法手を返す
+        let best2 = o2.best_usi.expect("合法手がある");
+        let (board, _) = build_board_and_history(STARTPOS_SFEN, &moves).expect("正当");
+        let legal: Vec<String> = generate_legal_moves(&mut board.clone())
+            .into_iter()
+            .map(|m| m.to_usi())
+            .collect();
+        assert!(legal.contains(&best2), "{best2} は合法手であるべき");
+
+        // reset (usinewgame 相当) 後も fresh 探索が正当に動く
+        backend.reset();
+        let o3 = backend
+            .search(
+                STARTPOS_SFEN,
+                &["2g2f".to_string()],
+                &budget,
+                0.5,
+                &stop,
+                &mut NoopObserver,
+            )
+            .expect("reset 後の探索成功");
+        assert!(o3.best_usi.is_some());
     }
 }

--- a/rust/maou_usi/src/stdio.rs
+++ b/rust/maou_usi/src/stdio.rs
@@ -17,16 +17,30 @@ use crate::agent::{Agent, EngineConfig, SearchBackend};
 use crate::backend::MaouSearchBackend;
 use crate::protocol::{parse_line, serialize, EngineCommand, GuiCommand};
 
-/// reader: 入力を行単位でパースして送る．`go`/`stop`/`quit` は行順で
-/// 停止フラグへ反映する．EOF (GUI 死亡) では Quit を合成して終了する．
-fn read_commands<R: BufRead>(input: R, stop: &Arc<AtomicBool>, tx: &Sender<GuiCommand>) {
+/// reader: 入力を行単位でパースして送る．`go`/`stop`/`quit`/`ponderhit` は
+/// 行順でフラグへ反映する — フラグの変化が行の到着順と一致するため race が
+/// なく，dispatcher が探索でブロック中でも即応する (設計 §4/§7)．EOF (GUI
+/// 死亡) では Quit を合成して終了する．
+fn read_commands<R: BufRead>(
+    input: R,
+    stop: &Arc<AtomicBool>,
+    ponderhit: &Arc<AtomicBool>,
+    tx: &Sender<GuiCommand>,
+) {
     for line in input.lines() {
         let Ok(line) = line else { break };
         let Some(cmd) = parse_line(&line) else {
             continue;
         };
         match &cmd {
-            GuiCommand::Go(_) => stop.store(false, Ordering::Release),
+            // go: 停止フラグを下ろし，前手の ponderhit も下ろす (次が go ponder
+            // ならここから的中待ち，通常 go なら未使用)
+            GuiCommand::Go(_) => {
+                stop.store(false, Ordering::Release);
+                ponderhit.store(false, Ordering::Release);
+            }
+            // ponderhit: 探索中の observer が拾い，無期限探索を時間予算へ切替え
+            GuiCommand::PonderHit(_) => ponderhit.store(true, Ordering::Release),
             GuiCommand::Stop | GuiCommand::Quit => stop.store(true, Ordering::Release),
             _ => {}
         }
@@ -120,10 +134,11 @@ fn sanitize_ascii(s: &str) -> String {
 pub fn run_stdio(config: EngineConfig) -> Result<(), String> {
     let mut agent = Agent::new(config, MaouSearchBackend::build);
     let stop = agent.stop_handle();
+    let ponderhit = agent.ponderhit_handle();
     let (tx, rx) = std::sync::mpsc::channel::<GuiCommand>();
     std::thread::spawn(move || {
         let stdin = std::io::stdin();
-        read_commands(stdin.lock(), &stop, &tx);
+        read_commands(stdin.lock(), &stop, &ponderhit, &tx);
     });
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
@@ -148,10 +163,11 @@ mod tests {
         };
         let mut agent = Agent::new(config, MaouSearchBackend::build);
         let stop = agent.stop_handle();
+        let ponderhit = agent.ponderhit_handle();
         let (tx, rx) = std::sync::mpsc::channel::<GuiCommand>();
         let input = Cursor::new(script.to_string());
         let reader = std::thread::spawn(move || {
-            read_commands(input, &stop, &tx);
+            read_commands(input, &stop, &ponderhit, &tx);
         });
         let mut out: Vec<u8> = Vec::new();
         run_loop(&rx, &mut out, &mut agent).expect("セッションは正常終了する");
@@ -215,9 +231,10 @@ mod tests {
     fn test_stop_flag_follows_line_order() {
         // reader が go → stop の行順でフラグを false → true にする
         let stop = Arc::new(AtomicBool::new(false));
+        let ponderhit = Arc::new(AtomicBool::new(false));
         let (tx, rx) = std::sync::mpsc::channel::<GuiCommand>();
         let input = Cursor::new("go infinite\nstop\n".to_string());
-        read_commands(input, &stop, &tx);
+        read_commands(input, &stop, &ponderhit, &tx);
         // 最終状態は stop = true (stop 行が最後)
         assert!(stop.load(Ordering::Acquire));
         let mut received = Vec::new();
@@ -226,5 +243,123 @@ mod tests {
         }
         assert!(matches!(received[0], GuiCommand::Go(_)));
         assert!(matches!(received[1], GuiCommand::Stop));
+    }
+
+    #[test]
+    fn test_ponder_flag_follows_line_order() {
+        // (1) go は前手の残り ponderhit を必ず下ろす
+        {
+            let stop = Arc::new(AtomicBool::new(false));
+            let ponderhit = Arc::new(AtomicBool::new(true)); // 前手の残り
+            let (tx, rx) = std::sync::mpsc::channel::<GuiCommand>();
+            read_commands(
+                Cursor::new("go ponder\n".to_string()),
+                &stop,
+                &ponderhit,
+                &tx,
+            );
+            assert!(
+                !ponderhit.load(Ordering::Acquire),
+                "go が前手の ponderhit を下ろす"
+            );
+            drop(rx);
+        }
+        // (2) ponderhit 行で立つ (行順が最終状態 = race-free の根拠)
+        {
+            let stop = Arc::new(AtomicBool::new(false));
+            let ponderhit = Arc::new(AtomicBool::new(false));
+            let (tx, rx) = std::sync::mpsc::channel::<GuiCommand>();
+            read_commands(
+                Cursor::new("go ponder\nponderhit\n".to_string()),
+                &stop,
+                &ponderhit,
+                &tx,
+            );
+            assert!(ponderhit.load(Ordering::Acquire), "ponderhit が立つ");
+            let mut received = Vec::new();
+            while let Ok(c) = rx.try_recv() {
+                received.push(c);
+            }
+            assert!(matches!(received[0], GuiCommand::Go(_)));
+            assert!(matches!(received[1], GuiCommand::PonderHit(_)));
+        }
+    }
+
+    #[test]
+    fn test_ponderhit_switches_and_inherits_tree() {
+        // ponder の主利得の実駆動確認: go ponder で無期限探索を走らせ playout を
+        // 積み，別スレッドから ponderhit を立てて時間予算へ切り替える．的中前に
+        // 積んだ木がそのまま活きて (再スタートせず) bestmove へ至る．
+        use crate::protocol::{BestMoveKind, ClockParams, GoParams};
+
+        let config = EngineConfig {
+            root_dfpn: Some(false),
+            leaf_mate: Some(false),
+            node_capacity: Some(1 << 14),
+            ..EngineConfig::default()
+        };
+        let mut agent = Agent::new(config, MaouSearchBackend::build);
+        let ponderhit = agent.ponderhit_handle();
+        // ponder 局面 (平手 1 手目後)
+        agent
+            .handle(GuiCommand::Position {
+                sfen: None,
+                moves: vec!["7g7f".to_string()],
+            })
+            .unwrap();
+        // ponder を少し走らせてから的中させる (相手が予想手を指した相当)
+        let ph = Arc::clone(&ponderhit);
+        let setter = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            ph.store(true, Ordering::Release);
+        });
+        // go ponder = 無期限探索．的中後は byoyomi 由来の時間予算で停止する
+        let mut out: Vec<EngineCommand> = Vec::new();
+        agent
+            .handle_go_stream(
+                &GoParams {
+                    ponder: true,
+                    clock: ClockParams {
+                        byoyomi: Some(1_200),
+                        ..ClockParams::default()
+                    },
+                    ..GoParams::default()
+                },
+                &mut |c| out.push(c),
+            )
+            .expect("ponder 探索は成功する");
+        setter.join().unwrap();
+        // 的中後の時間予算で停止し bestmove が返る
+        assert!(
+            out.iter().any(|c| matches!(
+                c,
+                EngineCommand::BestMove {
+                    mv: BestMoveKind::Move(_),
+                    ..
+                }
+            )),
+            "的中後に bestmove が返る"
+        );
+        // ponder + 的中後の探索で木を積んでいる (最終サマリ info の nodes > 0)
+        let nodes = out.iter().rev().find_map(|c| match c {
+            EngineCommand::Info(i) => i.nodes,
+            _ => None,
+        });
+        assert!(nodes.unwrap_or(0) > 0, "playout > 0");
+    }
+
+    #[test]
+    fn test_ponder_miss_then_real_go_no_hang() {
+        // go ponder → stop (外れ) → 実 go の順でどちらも bestmove を返し，
+        // セッションがハングせずクリーン終了する
+        let lines = run_session(
+            "usi\nisready\nposition startpos moves 7g7f\ngo ponder\nstop\n\
+             position startpos moves 7g7f 8c8d\ngo btime 0 wtime 0 byoyomi 800\nquit\n",
+        );
+        let bestmoves = lines.iter().filter(|l| l.starts_with("bestmove ")).count();
+        assert!(
+            bestmoves >= 2,
+            "ponder 外れと実 go の 2 つ以上の bestmove (got {bestmoves})"
+        );
     }
 }

--- a/src/maou/app/usi/run.py
+++ b/src/maou/app/usi/run.py
@@ -38,6 +38,9 @@ class UsiRunner:
             resign_value: 投了する root 勝率 (千分率，既定 0 = 投了しない)．
             resign_consecutive: 投了に必要な連続手数．
             max_moves_to_draw: 引き分け最大手数 (既定 0 = 無効)．
+            usi_ponder: ponder (先読み) を有効にするか (既定 True)．True の
+                とき `USI_Ponder` option を宣言し `bestmove` に予想相手手を
+                付ける (GUI からの `setoption name USI_Ponder` が上書きする)．
             root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
             root_dfpn_nodes: ルート dfpn のノード予算．
             root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
@@ -61,6 +64,7 @@ class UsiRunner:
         resign_value: int = 0
         resign_consecutive: int = 3
         max_moves_to_draw: int = 0
+        usi_ponder: bool = True
         root_dfpn: bool = True
         root_dfpn_nodes: int = 2_000_000
         root_dfpn_depth: int = 2047
@@ -108,6 +112,7 @@ class UsiRunner:
             resign_value=option.resign_value,
             resign_consecutive=option.resign_consecutive,
             max_moves_to_draw=option.max_moves_to_draw,
+            usi_ponder=option.usi_ponder,
             root_dfpn=option.root_dfpn,
             root_dfpn_nodes=option.root_dfpn_nodes,
             root_dfpn_depth=option.root_dfpn_depth,

--- a/src/maou/infra/console/usi.py
+++ b/src/maou/infra/console/usi.py
@@ -109,6 +109,17 @@ from maou.infra.console.common import (
     required=False,
 )
 @click.option(
+    "--usi-ponder/--no-usi-ponder",
+    type=bool,
+    is_flag=True,
+    help="Enable pondering (thinking on the opponent's turn). When on, the "
+    "engine declares the USI_Ponder option and appends the predicted reply "
+    "to bestmove so the GUI sends `go ponder` (default on). Also "
+    "`setoption name USI_Ponder`.",
+    default=True,
+    required=False,
+)
+@click.option(
     "--root-dfpn/--no-root-dfpn",
     type=bool,
     is_flag=True,
@@ -195,6 +206,7 @@ def usi(
     resign_value: int,
     resign_consecutive: int,
     max_moves_to_draw: int,
+    usi_ponder: bool,
     root_dfpn: bool,
     root_dfpn_nodes: int,
     root_dfpn_depth: int,
@@ -229,6 +241,7 @@ def usi(
         resign_value: Resign win-rate threshold in permille (0 = never).
         resign_consecutive: Consecutive below-threshold moves to resign.
         max_moves_to_draw: Move count for a drawn game (0 = disabled).
+        usi_ponder: Enable pondering on the opponent's turn (default on).
         root_dfpn: Run dfpn mate search on the root position in parallel.
         root_dfpn_nodes: Node budget for the root dfpn mate search.
         root_dfpn_depth: Search depth limit for the root dfpn mate search.
@@ -251,6 +264,7 @@ def usi(
         resign_value=resign_value,
         resign_consecutive=resign_consecutive,
         max_moves_to_draw=max_moves_to_draw,
+        usi_ponder=usi_ponder,
         root_dfpn=root_dfpn,
         root_dfpn_nodes=root_dfpn_nodes,
         root_dfpn_depth=root_dfpn_depth,

--- a/src/maou/interface/usi.py
+++ b/src/maou/interface/usi.py
@@ -34,6 +34,7 @@ def usi(
     resign_value: int = 0,
     resign_consecutive: int = 3,
     max_moves_to_draw: int = 0,
+    usi_ponder: bool = True,
     root_dfpn: bool = True,
     root_dfpn_nodes: int = 2_000_000,
     root_dfpn_depth: int = 2047,
@@ -62,6 +63,7 @@ def usi(
         resign_value: 投了する root 勝率 (千分率，既定 0 = 投了しない)．
         resign_consecutive: 投了に必要な連続手数．
         max_moves_to_draw: 引き分け最大手数 (既定 0 = 無効)．
+        usi_ponder: ponder (先読み) を有効にするか (既定 True)．
         root_dfpn: ルート並行 dfpn 詰み探索を有効にするか．
         root_dfpn_nodes: ルート dfpn のノード予算．
         root_dfpn_depth: ルート dfpn の探索深さ上限 (最大 2047)．
@@ -85,6 +87,7 @@ def usi(
         resign_value=resign_value,
         resign_consecutive=resign_consecutive,
         max_moves_to_draw=max_moves_to_draw,
+        usi_ponder=usi_ponder,
         root_dfpn=root_dfpn,
         root_dfpn_nodes=root_dfpn_nodes,
         root_dfpn_depth=root_dfpn_depth,

--- a/tests/maou/infra/console/test_usi_cli.py
+++ b/tests/maou/infra/console/test_usi_cli.py
@@ -189,6 +189,66 @@ def test_usi_ponder_session_e2e() -> None:
     )
 
 
+def test_usi_multi_turn_reuse_e2e() -> None:
+    """複数手番の連続 go で subtree 再利用経路が full-stack で動く．
+
+    局面が探索済みの筋を前進すれば保持木を reroot して warm start，さもなくば
+    fresh 探索にフォールバックする．どちらでも合法手を返しクリーン終了する．
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _ENTRY],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    bestmoves: list[str] = []
+    try:
+        proc.stdin.write(
+            "usi\n"
+            "setoption name RootDfpn value false\n"
+            "setoption name LeafMate value false\n"
+            "setoption name NodeCapacity value 16384\n"
+            "setoption name NetworkDelay value 0\n"
+            "isready\n"
+            "usinewgame\n"
+        )
+        proc.stdin.flush()
+        # 手番を進めながら 3 回思考する (each go の後 bestmove を待つ)
+        turns = [
+            "position startpos moves 7g7f 3c3d\n"
+            "go btime 0 wtime 0 byoyomi 250\n",
+            "position startpos moves 7g7f 3c3d 2g2f 8c8d\n"
+            "go btime 0 wtime 0 byoyomi 250\n",
+            "position startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e 8d8e\n"
+            "go btime 0 wtime 0 byoyomi 250\n",
+        ]
+        for turn in turns:
+            proc.stdin.write(turn)
+            proc.stdin.flush()
+            for line in proc.stdout:
+                if line.startswith("bestmove "):
+                    bestmoves.append(line.rstrip("\n"))
+                    break
+        proc.stdin.write("quit\n")
+        proc.stdin.flush()
+        proc.wait(timeout=30)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    assert proc.returncode == 0
+    assert len(bestmoves) == 3, (
+        f"3 手番ぶんの bestmove が返る: {bestmoves}"
+    )
+    for bm in bestmoves:
+        move = bm.split()[1]
+        assert move not in ("resign", "win"), (
+            f"序盤で投了/宣言しない: {bm}"
+        )
+
+
 def test_usi_stop_responds_quickly() -> None:
     """go infinite 中の stop に短時間で bestmove が返り quit で終了する．"""
     proc = subprocess.Popen(

--- a/tests/maou/infra/console/test_usi_cli.py
+++ b/tests/maou/infra/console/test_usi_cli.py
@@ -121,8 +121,72 @@ def test_usi_option_declarations() -> None:
         "NetworkDelay",
         "USI_Hash",
     } <= names
-    # M3 (ponder) まで USI_Ponder は宣言しない (設計 doc §8.4)
-    assert "USI_Ponder" not in names
+    # M3: USI_Ponder を宣言する (GUI が go ponder を送る trigger．設計 doc §8.4)
+    assert "USI_Ponder" in names
+
+
+def test_usi_ponder_session_e2e() -> None:
+    """go ponder → ponderhit で先読み木を引き継いで bestmove を返す．
+
+    ponder を実時間で少し走らせてから ponderhit を送る (GUI の実挙動と同じ)．
+    的中後は byoyomi 由来の時間予算で停止し，合法手の bestmove を返す．
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _ENTRY],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    lines: list[str] = []
+    try:
+        proc.stdin.write(
+            "usi\n"
+            "setoption name RootDfpn value false\n"
+            "setoption name LeafMate value false\n"
+            "setoption name NodeCapacity value 16384\n"
+            "setoption name NetworkDelay value 0\n"
+            "isready\n"
+            "usinewgame\n"
+            "position startpos moves 7g7f\n"
+            "go ponder btime 0 wtime 0 byoyomi 500\n"
+        )
+        proc.stdin.flush()
+        # ponder を実時間で走らせて木を積む
+        time.sleep(0.3)
+        # 予想手が指された = ponder 的中 → 時間予算へ切り替わる
+        proc.stdin.write(
+            "ponderhit btime 0 wtime 0 byoyomi 500\n"
+        )
+        proc.stdin.flush()
+        for line in proc.stdout:
+            lines.append(line.rstrip("\n"))
+            if line.startswith("bestmove "):
+                break
+        proc.stdin.write("quit\n")
+        proc.stdin.flush()
+        proc.wait(timeout=30)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    assert proc.returncode == 0
+    bestmove = next(
+        line for line in lines if line.startswith("bestmove ")
+    )
+    move = bestmove.split()[1]
+    assert move not in ("resign", "win"), "平手序盤で投了しない"
+    # 的中後の探索で木を積んでいる (playout > 0)
+    info = next(
+        line
+        for line in lines
+        if line.startswith("info ") and " nodes " in line
+    )
+    nodes = int(info.split(" nodes ")[1].split()[0])
+    assert nodes > 0, (
+        f"ponder + 的中後に実思考していない: {info}"
+    )
 
 
 def test_usi_stop_responds_quickly() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1507,7 +1507,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.48.0"
+version = "0.49.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

USI エンジン campaign のマイルストーン **M3** を実装する (設計: `docs/design/usi-engine/index.md`)．2 機能から成る:

1. **ponder 一式** — 先読み (相手番中の思考)
2. **subtree 再利用** — 対局手番間で探索木を引き継ぐ warm start

## 1. ponder 一式

- `USI_Ponder` option (check, 既定 true) を宣言し，`bestmove <move> ponder <reply>` に予想相手手 (自探索 PV の 2 手目) を付ける (M1/M2 では未宣言だった)
- `go ponder` = 無期限探索で開始 → `ponderhit` で「無期限 → 時間予算」へ切替．**探索を再スタートせず継続**するため，ponder 中に積んだ木がそのまま活きる (= ponder の主利得，M3 完了条件「ponder 的中で木が引き継がれる」を達成)
- ponderhit シグナルは stop フラグと同じ **reader 行順更新** 規約 (race-free)．dispatcher がブロック中でも探索中の `GoObserver` がポーリングして切替え，計測起点を的中時点へ置く
- 外れ (`stop`) は従来どおり bestmove 返却 (読み捨て)
- CLI `--usi-ponder/--no-usi-ponder` を 4 層貫通 (console → interface → app → maou_rust)

## 2. subtree 再利用

- **`NodePool::reroot`**: 旧 root から指し手列を辿って新 root を求め，到達可能サブツリーを index 0 起点に **reachability mark-compact** する (既存 compact の visit 閾値 prune とは別機構)．未展開・未探索の前進は再利用せず fresh へフォールバック
- **soundness**: 保持サブツリーの各ノードは，ゲーム開始からの完全な局面列が reroot 前後で不変 (advance の手が探索経路 → 対局履歴へ移るだけ) なため，**千日手由来の終端・確定値も含め健全性が保たれる** (max_ply 打ち切りは非永続マークで無害)
- **`Searcher::run_search` を抽出**し reused プールを受け取れるように (root 展開済みなら同期評価を省いて warm start)．`reused=None` の従来経路は **bit-identical**
- **`ReusableTree` (不透明ハンドル) + `Searcher::search_reusing`**: 同一基準 SFEN で経路が prefix 拡張なら差分手で reroot して再利用．maou_usi backend が手番間で保持し，`reset` (usinewgame / gameover) で破棄

## 検証

- **STRICT-VERIFY canonical** (search.rs 接触の TRIPWIRE を discharge): 29te = **396,516 nodes** / 39te = **17,593,615 nodes** — bit-identical
- Rust: maou_search **72** / maou_usi **67** tests，clippy 0 warnings，fmt clean
- Python: **949 passed** / 77 skipped (ponder session E2E + multi-turn reuse E2E を実 subprocess 駆動)．ruff / isort / mypy clean

## 版数

| crate | 変更 |
|---|---|
| `maou_search` | 0.19.0 → **0.20.0** (feat: subtree 再利用) |
| `maou_usi` | 0.2.0 → **0.4.0** (feat: ponder / reuse) |
| `maou_rust` | 0.24.0 → **0.25.0** (feat: usi_ponder passthrough) |
| `maou` (Python) | → **0.49.0** |

## 補足

- **効果計測 (設計 未決 6)**: subtree 再利用の soundness 検証と warm-start (訪問継承) の単体実証は完了．**棋力への A/B 効果計測は M4 の自己対局 driver 待ち**．現状は on-by-default (strictly-additive + 自動 fallback ゆえ棋力を下げない)
- `main` の collect_files 修正 (#396) を merge 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)