### PR TITLE
feat: visualizeでSFEN文字列による局面検索を追加

### DIFF
--- a/docs/commands/visualize.md
+++ b/docs/commands/visualize.md
@@ -113,6 +113,10 @@ maou visualize --input-path data.feather --array-type stage1 --share
 ### 検索機能
 
 - **ID検索**: レコードIDで直接検索
+- **SFEN検索**: SFEN文字列で局面を指定して検索．データIDから該当局面を探すのが困難な場合に使用する
+  - `preprocessing`/`stage2`: idカラムが局面のZobristハッシュのため高速に検索する
+  - `hcpe`: 各ファイルのHCPデータを一括ハッシュ計算してスキャンする
+  - `stage1`: 手番正規化済みの盤面配列を直接比較して検索する（idは局面と無関係な合成値のため）
 - **評価値範囲検索**: HCPEデータのみ対応
 
 ### 検索結果タブ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.51.0"
+version = "0.52.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.52.0"
+version = "0.52.1"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/app/visualization/data_retrieval.py
+++ b/src/maou/app/visualization/data_retrieval.py
@@ -156,9 +156,7 @@ class DataRetriever:
             logger.exception(f"Failed to load record: {e}")
             return None
 
-    def get_by_sfen(
-        self, sfen: str
-    ) -> dict[str, Any] | None:
+    def get_by_sfen(self, sfen: str) -> dict[str, Any] | None:
         """SFEN文字列でレコードを検索．
 
         array_typeに応じて検索方法を切り替える:

--- a/src/maou/app/visualization/data_retrieval.py
+++ b/src/maou/app/visualization/data_retrieval.py
@@ -156,6 +156,131 @@ class DataRetriever:
             logger.exception(f"Failed to load record: {e}")
             return None
 
+    def get_by_sfen(
+        self, sfen: str
+    ) -> dict[str, Any] | None:
+        """SFEN文字列でレコードを検索．
+
+        array_typeに応じて検索方法を切り替える:
+        - preprocessing/stage2: idカラムがZobristハッシュのため，
+          Board.hash()を計算してget_by_id経由でO(1)検索する．
+        - hcpe: idが局面と無関係な文字列のため，各ファイルのhcp列を
+          Rustの一括ハッシュ計算(hcp_hashes)でスキャンする．
+        - stage1: idが合成値(局面ハッシュではない)のため，
+          正規化済み盤面配列を直接比較して線形探索する．
+
+        Args:
+            sfen: 検索するSFEN文字列
+
+        Returns:
+            レコードデータの辞書，見つからない場合はNone
+
+        Raises:
+            ValueError: 不正なSFEN文字列の場合
+        """
+        from maou.domain.board.shogi import Board
+
+        board = Board()
+        board.set_sfen(sfen)
+
+        if self.array_type in ("preprocessing", "stage2"):
+            return self.get_by_id(str(board.hash()))
+
+        if self.search_index.use_mock_data:
+            logger.debug(
+                f"⚠️  MOCK: SFEN search is not supported in mock mode: {sfen}"
+            )
+            return None
+
+        if self.array_type == "hcpe":
+            return self._search_hcpe_by_hash(board.hash())
+
+        if self.array_type == "stage1":
+            return self._search_by_normalized_board(
+                board.get_normalized_board_id_positions().tolist(),
+                board.get_normalized_pieces_in_hand().tolist(),
+            )
+
+        return None
+
+    def _search_hcpe_by_hash(
+        self, target_hash: int
+    ) -> dict[str, Any] | None:
+        """全HCPEファイルをZobristハッシュで一括検索する．
+
+        Rustの一括ハッシュ計算(hcp_hashes)でファイル単位にベクトル化して
+        一致行を探す(1行ずつPythonでHCPをデコードするより高速)．
+
+        Args:
+            target_hash: 検索対象局面のZobristハッシュ値
+
+        Returns:
+            一致したレコードの辞書，見つからない場合はNone
+        """
+        import numpy as np
+
+        from maou._rust.maou_search import hcp_hashes
+
+        for file_index in range(len(self.file_paths)):
+            df = self._load_df_cached(file_index)
+            if "hcp" not in df.columns or df.height == 0:
+                continue
+
+            hcp_bytes_list = df["hcp"].to_list()
+            hcps = np.frombuffer(
+                b"".join(hcp_bytes_list), dtype=np.uint8
+            ).reshape(-1, 32)
+            hashes = hcp_hashes(hcps)
+
+            matches = np.nonzero(hashes == target_hash)[0]
+            if len(matches) > 0:
+                row_number = int(matches[0])
+                return self._extract_record_from_df(
+                    df, row_number
+                )
+
+        return None
+
+    def _search_by_normalized_board(
+        self,
+        target_board: list[list[int]],
+        target_hand: list[int],
+    ) -> dict[str, Any] | None:
+        """手番正規化済みの盤面配列でレコードを線形探索する(Stage1用)．
+
+        Stage1のidは局面ハッシュではなく合成値のため，ハッシュベースの
+        高速パスが使えず，盤面配列を直接比較する．
+
+        Args:
+            target_board: 手番正規化済み9x9駒ID配列
+            target_hand: 手番正規化済み持ち駒配列(14要素)
+
+        Returns:
+            一致したレコードの辞書，見つからない場合はNone
+        """
+        for file_index in range(len(self.file_paths)):
+            df = self._load_df_cached(file_index)
+            if (
+                "boardIdPositions" not in df.columns
+                or "piecesInHand" not in df.columns
+            ):
+                continue
+
+            board_col = df["boardIdPositions"].to_list()
+            hand_col = df["piecesInHand"].to_list()
+            for row_number, (board_val, hand_val) in enumerate(
+                zip(board_col, hand_col)
+            ):
+                if (
+                    board_val == target_board
+                    and hand_val == target_hand
+                ):
+                    return self._extract_record_from_df(
+                        df, row_number
+                    )
+
+        return None
+
     def get_by_eval_range(
         self,
         min_eval: int | None,

--- a/src/maou/infra/visualization/gradio_server.py
+++ b/src/maou/infra/visualization/gradio_server.py
@@ -1593,6 +1593,25 @@ class GradioVisualizationServer:
                             elem_id="id-search-btn",
                         )
 
+                    # SFEN検索
+                    with gr.Group():
+                        gr.Markdown("### SFEN検索")
+
+                        sfen_input = gr.Textbox(
+                            label="🔍 SFEN",
+                            placeholder=(
+                                "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/"
+                                "PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+                            ),
+                            info="局面をSFEN文字列で指定して検索します",
+                            elem_id="sfen-search-input",
+                        )
+                        sfen_search_btn = gr.Button(
+                            "SFEN検索",
+                            variant="primary",
+                            elem_id="sfen-search-btn",
+                        )
+
                     # 評価値範囲検索（HCPEデータのみ）
                     if self.supports_eval_search:
                         with gr.Group():
@@ -1838,6 +1857,19 @@ class GradioVisualizationServer:
             id_search_btn.click(
                 fn=self._search_by_id,
                 inputs=[id_input],
+                outputs=[
+                    board_display,
+                    record_details,
+                    selected_record_id,
+                    record_indicator,
+                    prev_record_btn,
+                    next_record_btn,
+                ],
+            )
+
+            sfen_search_btn.click(
+                fn=self._search_by_sfen,
+                inputs=[sfen_input],
                 outputs=[
                     board_display,
                     record_details,
@@ -3052,6 +3084,84 @@ class GradioVisualizationServer:
                 gr.Button(interactive=False),
                 gr.Button(interactive=False),
             )
+
+    def _search_by_sfen(
+        self, sfen: str
+    ) -> tuple[
+        str, dict[str, Any], str, str, gr.Button, gr.Button
+    ]:
+        """SFEN検索のラッパー関数（viz_interfaceがNoneの場合をハンドリング）．
+
+        Args:
+            sfen: 検索するSFEN文字列
+
+        Returns:
+            (board_svg, record_details, selected_record_id,
+             record_indicator, prev_record_btn, next_record_btn)のタプル．
+            検索失敗時はboard_svg, record_details以外はgr.skip()を返す．
+        """
+        # Thread-safe access to viz_interface
+        with self._index_lock:
+            if not self.has_data or self.viz_interface is None:
+                board_svg, details = self._search_by_sfen_mock(
+                    sfen
+                )
+                return (
+                    board_svg,
+                    details,
+                    gr.skip(),
+                    gr.skip(),
+                    gr.skip(),
+                    gr.skip(),
+                )
+
+            board_svg, details = (
+                self.viz_interface.search_by_sfen(sfen)
+            )
+
+            # 検索失敗時（"error"キーの存在で判定）は状態を変更しない
+            if "error" in details:
+                return (
+                    board_svg,
+                    details,
+                    gr.skip(),
+                    gr.skip(),
+                    gr.skip(),
+                    gr.skip(),
+                )
+
+            # 検索成功: 該当レコードのIDを選択状態にし，ボタン無効化
+            record_id = str(details.get("id", sfen))
+            return (
+                board_svg,
+                details,
+                record_id,
+                "SFEN検索: 1/1",
+                gr.Button(interactive=False),
+                gr.Button(interactive=False),
+            )
+
+    def _search_by_sfen_mock(
+        self, sfen: str
+    ) -> tuple[str, dict[str, Any]]:
+        """SFEN検索のモック実装．
+
+        Args:
+            sfen: 検索するSFEN文字列
+
+        Returns:
+            (board_svg, record_details)のタプル
+        """
+        logger.info("Mock SFEN search: %s", sfen)
+
+        board_svg = self._get_default_board_svg()
+        record_details = {
+            "message": "SFEN検索機能は実装中です",
+            "searched_sfen": sfen,
+            "status": "mock",
+        }
+
+        return (board_svg, record_details)
 
     def _get_default_board_svg(self) -> str:
         """デフォルトの盤面SVGを生成（平手初期配置）．"""

--- a/src/maou/interface/visualization.py
+++ b/src/maou/interface/visualization.py
@@ -131,6 +131,63 @@ class VisualizationInterface:
 
         return (board_svg, record_details)
 
+    def search_by_sfen(
+        self, sfen: str
+    ) -> tuple[str, dict[str, Any]]:
+        """SFENでレコードを検索し，ボードを描画．
+
+        Args:
+            sfen: 検索するSFEN文字列
+
+        Returns:
+            (board_svg, record_details)のタプル
+        """
+        if not sfen or not sfen.strip():
+            return (
+                self._render_empty_message(
+                    "SFENを入力してください"
+                ),
+                {},
+            )
+
+        try:
+            record = self.data_retriever.get_by_sfen(
+                sfen.strip()
+            )
+        except ValueError as e:
+            return (
+                self._render_empty_message(
+                    f"不正なSFEN文字列です: {e}"
+                ),
+                {
+                    "error": "Invalid SFEN",
+                    "searched_sfen": sfen,
+                },
+            )
+
+        if record is None:
+            return (
+                self._render_empty_message(
+                    f"SFEN '{sfen}' に一致するレコードが見つかりません"
+                ),
+                {
+                    "error": "Record not found",
+                    "searched_sfen": sfen,
+                },
+            )
+
+        # Rendererに委譲してボード描画と詳細抽出
+        board_svg = self.renderer.render_board(record)
+        record_details = self.renderer.extract_display_fields(
+            record
+        )
+
+        logger.info(
+            f"Successfully retrieved and rendered record by SFEN: {sfen}"
+        )
+
+        return (board_svg, record_details)
+
     def search_by_eval_range(
         self,
         min_eval: int | None,

--- a/tests/maou/app/visualization/test_data_retrieval.py
+++ b/tests/maou/app/visualization/test_data_retrieval.py
@@ -390,6 +390,25 @@ class TestDataRetriever:
 class TestGetBySfen:
     """DataRetriever.get_by_sfenのテスト．"""
 
+    @pytest.fixture
+    def data_retriever(self, tmp_path: Path) -> DataRetriever:
+        """テスト用DataRetriever(hcpe/モックモード)を作成．"""
+        dummy_file = tmp_path / "test.feather"
+        dummy_file.touch()
+
+        search_index = SearchIndex.build(
+            file_paths=[dummy_file],
+            array_type="hcpe",
+            num_mock_records=100,
+            use_mock_data=True,
+        )
+        return DataRetriever(
+            search_index=search_index,
+            file_paths=[dummy_file],
+            array_type="hcpe",
+            load_df=lambda path: pl.read_ipc(path),
+        )
+
     def test_invalid_sfen_raises(
         self, data_retriever: DataRetriever
     ) -> None:
@@ -404,9 +423,7 @@ class TestGetBySfen:
         record = data_retriever.get_by_sfen(INITIAL_SFEN)
         assert record is None
 
-    def test_hcpe_real_data_hit(
-        self, tmp_path: Path
-    ) -> None:
+    def test_hcpe_real_data_hit(self, tmp_path: Path) -> None:
         """HCPE実データでSFENに一致するレコードを取得できる．"""
         target_board = Board()
         target_board.set_sfen(INITIAL_SFEN)
@@ -508,9 +525,7 @@ class TestGetBySfen:
                 "gameResult": pl.Series(
                     "gameResult", [1], dtype=pl.Int8
                 ),
-                "id": pl.Series(
-                    "id", ["pos_0"], dtype=pl.Utf8
-                ),
+                "id": pl.Series("id", ["pos_0"], dtype=pl.Utf8),
                 "partitioningKey": pl.Series(
                     "partitioningKey", [None], dtype=pl.Date
                 ),
@@ -696,9 +711,7 @@ class TestGetBySfen:
         record = retriever.get_by_sfen(INITIAL_SFEN)
         assert record is None
 
-    def test_stage2_real_data_hit(
-        self, tmp_path: Path
-    ) -> None:
+    def test_stage2_real_data_hit(self, tmp_path: Path) -> None:
         """Stage2データでSFENに一致するレコードをid経由で取得できる．"""
         board = Board()
         board.set_sfen(INITIAL_SFEN)
@@ -755,9 +768,7 @@ class TestGetBySfen:
         assert record is not None
         assert record["id"] == str(position_hash)
 
-    def test_stage1_real_data_hit(
-        self, tmp_path: Path
-    ) -> None:
+    def test_stage1_real_data_hit(self, tmp_path: Path) -> None:
         """Stage1データは合成idのため盤面配列の一致で検索する．"""
         board = Board()
         board.set_sfen(INITIAL_SFEN)
@@ -772,9 +783,7 @@ class TestGetBySfen:
         schema = get_stage1_polars_schema()
         df = pl.DataFrame(
             {
-                "id": pl.Series(
-                    "id", [12345], dtype=pl.UInt64
-                ),
+                "id": pl.Series("id", [12345], dtype=pl.UInt64),
                 "boardIdPositions": pl.Series(
                     "boardIdPositions",
                     [board_positions],
@@ -828,9 +837,7 @@ class TestGetBySfen:
         schema = get_stage1_polars_schema()
         df = pl.DataFrame(
             {
-                "id": pl.Series(
-                    "id", [99999], dtype=pl.UInt64
-                ),
+                "id": pl.Series("id", [99999], dtype=pl.UInt64),
                 "boardIdPositions": pl.Series(
                     "boardIdPositions",
                     [

--- a/tests/maou/app/visualization/test_data_retrieval.py
+++ b/tests/maou/app/visualization/test_data_retrieval.py
@@ -11,7 +11,30 @@ from maou.domain.board.shogi import (
     Board,
     PieceId,
 )
+from maou.domain.data.rust_io import (
+    save_hcpe_df,
+    save_preprocessing_df,
+    save_stage1_df,
+    save_stage2_df,
+)
+from maou.domain.data.schema import (
+    get_hcpe_polars_schema,
+    get_preprocessing_polars_schema,
+    get_stage1_polars_schema,
+    get_stage2_polars_schema,
+)
 from maou.infra.visualization.search_index import SearchIndex
+from maou.interface.data_io import (
+    load_hcpe_df,
+    load_preprocessing_df,
+    load_stage1_df,
+    load_stage2_df,
+)
+
+INITIAL_SFEN = (
+    "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/"
+    "PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+)
 
 
 class TestDataRetriever:
@@ -362,6 +385,492 @@ class TestDataRetriever:
                     f"White piece at (0, {col}) has ID {piece_id} "
                     f"< DOMAIN_WHITE_MIN ({DOMAIN_WHITE_MIN})"
                 )
+
+
+class TestGetBySfen:
+    """DataRetriever.get_by_sfenのテスト．"""
+
+    def test_invalid_sfen_raises(
+        self, data_retriever: DataRetriever
+    ) -> None:
+        """不正なSFEN文字列でValueErrorが発生する．"""
+        with pytest.raises(ValueError):
+            data_retriever.get_by_sfen("not a valid sfen")
+
+    def test_mock_mode_returns_none(
+        self, data_retriever: DataRetriever
+    ) -> None:
+        """モックモードのhcpeではSFEN検索は常にNoneを返す．"""
+        record = data_retriever.get_by_sfen(INITIAL_SFEN)
+        assert record is None
+
+    def test_hcpe_real_data_hit(
+        self, tmp_path: Path
+    ) -> None:
+        """HCPE実データでSFENに一致するレコードを取得できる．"""
+        target_board = Board()
+        target_board.set_sfen(INITIAL_SFEN)
+        target_hcp = target_board.to_hcp()
+
+        # 別局面(初期局面から1手進めた局面)も混ぜて識別性を確認する
+        other_board = Board()
+        other_board.set_sfen(INITIAL_SFEN)
+        other_board.push_move(
+            next(iter(other_board.get_legal_moves()))
+        )
+        other_hcp = other_board.to_hcp()
+
+        schema = get_hcpe_polars_schema()
+        df = pl.DataFrame(
+            {
+                "hcp": pl.Series(
+                    "hcp",
+                    [other_hcp, target_hcp],
+                    dtype=pl.Binary,
+                ),
+                "eval": pl.Series(
+                    "eval", [0, 0], dtype=pl.Int16
+                ),
+                "bestMove16": pl.Series(
+                    "bestMove16", [0, 0], dtype=pl.Int16
+                ),
+                "gameResult": pl.Series(
+                    "gameResult", [1, 1], dtype=pl.Int8
+                ),
+                "id": pl.Series(
+                    "id",
+                    ["pos_other", "pos_target"],
+                    dtype=pl.Utf8,
+                ),
+                "partitioningKey": pl.Series(
+                    "partitioningKey",
+                    [None, None],
+                    dtype=pl.Date,
+                ),
+                "ratings": pl.Series(
+                    "ratings",
+                    [None, None],
+                    dtype=pl.List(pl.UInt16),
+                ),
+                "endgameStatus": pl.Series(
+                    "endgameStatus",
+                    [None, None],
+                    dtype=pl.Utf8,
+                ),
+                "moves": pl.Series(
+                    "moves", [0, 1], dtype=pl.Int16
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "hcpe_real.feather"
+        save_hcpe_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="hcpe",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="hcpe",
+            load_df=load_hcpe_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+
+        assert record is not None
+        assert record["id"] == "pos_target"
+
+    def test_hcpe_real_data_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """HCPE実データに一致局面がない場合はNoneを返す．"""
+        stored_board = Board()
+        stored_board.set_sfen(INITIAL_SFEN)
+        stored_board.push_move(
+            next(iter(stored_board.get_legal_moves()))
+        )
+        stored_hcp = stored_board.to_hcp()
+
+        schema = get_hcpe_polars_schema()
+        df = pl.DataFrame(
+            {
+                "hcp": pl.Series(
+                    "hcp", [stored_hcp], dtype=pl.Binary
+                ),
+                "eval": pl.Series("eval", [0], dtype=pl.Int16),
+                "bestMove16": pl.Series(
+                    "bestMove16", [0], dtype=pl.Int16
+                ),
+                "gameResult": pl.Series(
+                    "gameResult", [1], dtype=pl.Int8
+                ),
+                "id": pl.Series(
+                    "id", ["pos_0"], dtype=pl.Utf8
+                ),
+                "partitioningKey": pl.Series(
+                    "partitioningKey", [None], dtype=pl.Date
+                ),
+                "ratings": pl.Series(
+                    "ratings",
+                    [None],
+                    dtype=pl.List(pl.UInt16),
+                ),
+                "endgameStatus": pl.Series(
+                    "endgameStatus", [None], dtype=pl.Utf8
+                ),
+                "moves": pl.Series(
+                    "moves", [0], dtype=pl.Int16
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "hcpe_real.feather"
+        save_hcpe_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="hcpe",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="hcpe",
+            load_df=load_hcpe_df,
+        )
+
+        # 初期局面は保存していないので見つからないはず
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+        assert record is None
+
+    def test_preprocessing_real_data_hit(
+        self, tmp_path: Path
+    ) -> None:
+        """PreprocessingデータでSFENに一致するレコードをid経由で取得できる．"""
+        board = Board()
+        board.set_sfen(INITIAL_SFEN)
+        position_hash = board.hash()
+
+        board_positions = (
+            board.get_normalized_board_id_positions().tolist()
+        )
+        pieces_in_hand = (
+            board.get_normalized_pieces_in_hand().tolist()
+        )
+
+        from maou.domain.move.label import MOVE_LABELS_NUM
+
+        schema = get_preprocessing_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [position_hash], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [board_positions],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [pieces_in_hand],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "moveLabel": pl.Series(
+                    "moveLabel",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "moveWinRate": pl.Series(
+                    "moveWinRate",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "bestMoveWinRate": pl.Series(
+                    "bestMoveWinRate",
+                    [0.5],
+                    dtype=pl.Float32,
+                ),
+                "resultValue": pl.Series(
+                    "resultValue", [0.0], dtype=pl.Float32
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "preprocessing_real.feather"
+        save_preprocessing_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="preprocessing",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="preprocessing",
+            load_df=load_preprocessing_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+
+        assert record is not None
+        assert record["id"] == str(position_hash)
+
+    def test_preprocessing_real_data_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """Preprocessingデータに一致局面がない場合はNoneを返す．"""
+        stored_board = Board()
+        stored_board.set_sfen(INITIAL_SFEN)
+        stored_board.push_move(
+            next(iter(stored_board.get_legal_moves()))
+        )
+        stored_hash = stored_board.hash()
+
+        from maou.domain.move.label import MOVE_LABELS_NUM
+
+        schema = get_preprocessing_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [stored_hash], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [
+                        stored_board.get_normalized_board_id_positions().tolist()
+                    ],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [
+                        stored_board.get_normalized_pieces_in_hand().tolist()
+                    ],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "moveLabel": pl.Series(
+                    "moveLabel",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "moveWinRate": pl.Series(
+                    "moveWinRate",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "bestMoveWinRate": pl.Series(
+                    "bestMoveWinRate",
+                    [0.5],
+                    dtype=pl.Float32,
+                ),
+                "resultValue": pl.Series(
+                    "resultValue", [0.0], dtype=pl.Float32
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "preprocessing_real.feather"
+        save_preprocessing_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="preprocessing",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="preprocessing",
+            load_df=load_preprocessing_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+        assert record is None
+
+    def test_stage2_real_data_hit(
+        self, tmp_path: Path
+    ) -> None:
+        """Stage2データでSFENに一致するレコードをid経由で取得できる．"""
+        board = Board()
+        board.set_sfen(INITIAL_SFEN)
+        position_hash = board.hash()
+
+        from maou.domain.move.label import MOVE_LABELS_NUM
+
+        schema = get_stage2_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [position_hash], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [
+                        board.get_normalized_board_id_positions().tolist()
+                    ],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [
+                        board.get_normalized_pieces_in_hand().tolist()
+                    ],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "legalMovesLabel": pl.Series(
+                    "legalMovesLabel",
+                    [[0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.UInt8),
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "stage2_real.feather"
+        save_stage2_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="stage2",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="stage2",
+            load_df=load_stage2_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+
+        assert record is not None
+        assert record["id"] == str(position_hash)
+
+    def test_stage1_real_data_hit(
+        self, tmp_path: Path
+    ) -> None:
+        """Stage1データは合成idのため盤面配列の一致で検索する．"""
+        board = Board()
+        board.set_sfen(INITIAL_SFEN)
+        board_positions = (
+            board.get_normalized_board_id_positions().tolist()
+        )
+        pieces_in_hand = (
+            board.get_normalized_pieces_in_hand().tolist()
+        )
+        empty_reachable = [[0] * 9 for _ in range(9)]
+
+        schema = get_stage1_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [12345], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [board_positions],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [pieces_in_hand],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "reachableSquares": pl.Series(
+                    "reachableSquares",
+                    [empty_reachable],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "stage1_real.feather"
+        save_stage1_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="stage1",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="stage1",
+            load_df=load_stage1_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+
+        assert record is not None
+        assert record["id"] == "12345"
+
+    def test_stage1_real_data_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """Stage1データに一致局面がない場合はNoneを返す．"""
+        stored_board = Board()
+        stored_board.set_sfen(INITIAL_SFEN)
+        stored_board.push_move(
+            next(iter(stored_board.get_legal_moves()))
+        )
+        empty_reachable = [[0] * 9 for _ in range(9)]
+
+        schema = get_stage1_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [99999], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [
+                        stored_board.get_normalized_board_id_positions().tolist()
+                    ],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [
+                        stored_board.get_normalized_pieces_in_hand().tolist()
+                    ],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "reachableSquares": pl.Series(
+                    "reachableSquares",
+                    [empty_reachable],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "stage1_real.feather"
+        save_stage1_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="stage1",
+            use_mock_data=False,
+        )
+        retriever = DataRetriever(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="stage1",
+            load_df=load_stage1_df,
+        )
+
+        record = retriever.get_by_sfen(INITIAL_SFEN)
+        assert record is None
 
 
 class TestPreprocessingMockData:

--- a/tests/maou/interface/test_visualization.py
+++ b/tests/maou/interface/test_visualization.py
@@ -2,10 +2,22 @@
 
 from pathlib import Path
 
+import polars as pl
 import pytest
 
+from maou.domain.board.shogi import Board
+from maou.domain.data.rust_io import save_preprocessing_df
+from maou.domain.data.schema import (
+    get_preprocessing_polars_schema,
+)
+from maou.domain.move.label import MOVE_LABELS_NUM
 from maou.infra.visualization.search_index import SearchIndex
 from maou.interface.visualization import VisualizationInterface
+
+INITIAL_SFEN = (
+    "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/"
+    "PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+)
 
 
 class TestVisualizationInterface:
@@ -85,6 +97,121 @@ class TestVisualizationInterface:
 
         assert "IDを入力してください" in board_svg
         assert record_details == {}
+
+    def test_search_by_sfen_empty_string(
+        self, viz_interface: VisualizationInterface
+    ) -> None:
+        """空文字列でエラーメッセージが返る．"""
+        board_svg, record_details = (
+            viz_interface.search_by_sfen("")
+        )
+
+        assert "SFENを入力してください" in board_svg
+        assert record_details == {}
+
+    def test_search_by_sfen_whitespace(
+        self, viz_interface: VisualizationInterface
+    ) -> None:
+        """空白のみのSFENで検索エラーが返る．"""
+        board_svg, record_details = (
+            viz_interface.search_by_sfen("   ")
+        )
+
+        assert "SFENを入力してください" in board_svg
+        assert record_details == {}
+
+    def test_search_by_sfen_invalid(
+        self, viz_interface: VisualizationInterface
+    ) -> None:
+        """不正なSFEN文字列でエラーメッセージが返る．"""
+        board_svg, record_details = (
+            viz_interface.search_by_sfen("not a valid sfen")
+        )
+
+        assert "不正なSFEN文字列です" in board_svg
+        assert record_details["error"] == "Invalid SFEN"
+
+    def test_search_by_sfen_not_found_mock_mode(
+        self, viz_interface: VisualizationInterface
+    ) -> None:
+        """モックモードのhcpeでは一致局面が存在せず未検出になる．"""
+        board_svg, record_details = (
+            viz_interface.search_by_sfen(INITIAL_SFEN)
+        )
+
+        assert "見つかりません" in board_svg
+        assert record_details["error"] == "Record not found"
+
+    def test_search_by_sfen_hit_real_preprocessing_data(
+        self, tmp_path: Path
+    ) -> None:
+        """Preprocessing実データでSFEN検索が一致レコードを描画する．"""
+        board = Board()
+        board.set_sfen(INITIAL_SFEN)
+        position_hash = board.hash()
+
+        schema = get_preprocessing_polars_schema()
+        df = pl.DataFrame(
+            {
+                "id": pl.Series(
+                    "id", [position_hash], dtype=pl.UInt64
+                ),
+                "boardIdPositions": pl.Series(
+                    "boardIdPositions",
+                    [
+                        board.get_normalized_board_id_positions().tolist()
+                    ],
+                    dtype=pl.List(pl.List(pl.UInt8)),
+                ),
+                "piecesInHand": pl.Series(
+                    "piecesInHand",
+                    [
+                        board.get_normalized_pieces_in_hand().tolist()
+                    ],
+                    dtype=pl.List(pl.UInt8),
+                ),
+                "moveLabel": pl.Series(
+                    "moveLabel",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "moveWinRate": pl.Series(
+                    "moveWinRate",
+                    [[0.0] * MOVE_LABELS_NUM],
+                    dtype=pl.List(pl.Float32),
+                ),
+                "bestMoveWinRate": pl.Series(
+                    "bestMoveWinRate",
+                    [0.5],
+                    dtype=pl.Float32,
+                ),
+                "resultValue": pl.Series(
+                    "resultValue", [0.0], dtype=pl.Float32
+                ),
+            },
+            schema=schema,
+        )
+
+        file_path = tmp_path / "preprocessing_real.feather"
+        save_preprocessing_df(df, file_path)
+
+        search_index = SearchIndex.build(
+            file_paths=[file_path],
+            array_type="preprocessing",
+            use_mock_data=False,
+        )
+        viz_interface = VisualizationInterface(
+            search_index=search_index,
+            file_paths=[file_path],
+            array_type="preprocessing",
+        )
+
+        board_svg, record_details = (
+            viz_interface.search_by_sfen(INITIAL_SFEN)
+        )
+
+        assert "<svg" in board_svg
+        assert record_details["id"] == str(position_hash)
 
     def test_search_by_eval_range_valid(
         self, viz_interface: VisualizationInterface


### PR DESCRIPTION
データIDから該当局面を探すのが困難だったため，SFEN文字列を指定して
レコードを検索できるようにした．

- preprocessing/stage2: idカラムが局面のZobristハッシュのため，
  Board.hash()経由でO(1)検索する高速パスを追加
- hcpe: idが局面と無関係な文字列のため，Rustの一括ハッシュ計算
  (hcp_hashes)で各ファイルのHCP列をスキャンして検索する
- stage1: idが合成値のため，手番正規化済みの盤面配列を直接比較して
  線形探索する
- Gradio UIにID検索と並ぶ「SFEN検索」ボックスを追加

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HEEnZWNrREExJ7QNs4nqtv