### PR TITLE
docs: 軽量コマンドの起動経路で重い依存を module-level import しない規約を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,11 @@ Maou (魔王) is a Shogi (Japanese chess) AI project implemented in Python follo
 ### Architecture
 - MUST maintain dependency flow: `infra → interface → app → domain`
 - MUST NOT introduce circular dependencies between layers
+- MUST NOT import heavy optional dependencies (torch, cloud SDKs) at module
+  level in `src/maou/infra/console/` or any path a light command reaches —
+  use PEP 562 `__getattr__` lazy resolution
+- MUST NOT leave a module-level assignment for a name resolved lazily by
+  `__getattr__` (the global shadows the hook and leaks the pre-probe value)
 
 ### Code Quality
 - MUST add type hints to all code

--- a/reviews/2026-07-26-infra-lazy-heavy-imports.md
+++ b/reviews/2026-07-26-infra-lazy-heavy-imports.md
@@ -1,0 +1,62 @@
+---
+title: CLAUDE.md に「軽量コマンドの起動経路は重い依存を module-level に import しない」規約を追加
+date: 2026-07-26
+status: applied
+applied_in: 39b1580
+target:
+  - CLAUDE.md
+risk: low
+reversibility: easy
+---
+
+# 提案: 重い依存の module-level import 禁止を CLAUDE.md の規約にする
+
+## Trigger
+
+worklog/2026-07-26-214115.md — USI M4 の計測中に，`maou usi` の起動が
+**6.2 秒**かかっていることが判明した．内訳は
+`maou.infra.console.common` が module-level で BigQuery を試験 import し，
+`maou.infra.bigquery.bq_data_source` → `maou.interface.learn` 経由で
+**torch 2.09s + google-cloud-bigquery 1.93s** を読み込んでいたため
+(`python -X importtime` で実測)．USI エンジンは GUI に登録され**対局の
+たびに起動**されるので，起動時間はそのまま体感になる (spawn→usiok
+5.9〜15.7 秒を実測)．遅延化後は **0.11 秒**．
+
+同種の回帰は過去にもあり，compass には
+「interface.learn の module-level torch import を infra 継承禁止
+(base install 破壊)」という invariant が既にある．つまり **2 回目**である．
+compass は per-machine な scratchpad なので，恒久規約は CLAUDE.md
+(committed) 側に持たせたい．
+
+## 提案する変更 (CLAUDE.md)
+
+`## Critical Rules (MUST)` の `### Architecture` 節に 2 行追加する:
+
+```
+- MUST NOT import heavy optional dependencies (torch, cloud SDKs) at
+  module level in `src/maou/infra/console/` or any path a light command
+  reaches — use PEP 562 `__getattr__` lazy resolution
+- MUST NOT leave a module-level assignment for a name resolved lazily by
+  `__getattr__` (the global shadows the hook and leaks the pre-probe value)
+```
+
+## リスクと理由
+
+- **risk: low** — 既存コードは既にこの形 (`console/common.py` の
+  `_LAZY_IMPORTS` / `_CLOUD_PROBES`) に揃っており，
+  `tests/maou/infra/console/test_console_import_weight.py` が機械的に
+  検査している．規約の明文化のみ．
+- **reversibility: easy** — 2 行の削除で戻る．
+
+## 代替案と却下理由
+
+- **テストだけで担保する (規約化しない)**: テストは `usi`/`selfplay` の
+  2 経路しか見ていないため，新しい軽量コマンドを足したときに検査対象へ
+  加え忘れる．規約があれば追加時に気付ける．
+- **compass の invariant だけで担保する**: compass は gitignore された
+  per-machine ファイルで，かつ ~9KB の cap があり evict 対象になり得る．
+  2 回発生した回帰の恒久的な置き場所としては弱い．
+
+## ロールバック
+
+CLAUDE.md の該当 2 行を削除する．コード側は無変更で動作する．


### PR DESCRIPTION
## 背景

USI M4 の計測中に `maou usi` の起動が **6.2 秒**かかっていることが判明した．
`python -X importtime` の内訳:

- `maou.infra.console.common` が module-level で BigQuery を試験 import
- → `maou.infra.bigquery.bq_data_source` → `maou.interface.learn`
- → **torch 2.09s + google-cloud-bigquery 1.93s**

USI エンジンは GUI に登録され**対局のたびに起動**されるため，起動時間が
そのまま体感になる (spawn→usiok 5.9〜15.7 秒を実測)．遅延化後は **0.11 秒**．

同型の回帰は 2 回目 (compass に「interface.learn の module-level torch import を
infra 継承禁止」の invariant が既にあった)．compass は gitignore された
per-machine ファイルで ~9KB cap により evict され得るため，恒久規約を
committed な CLAUDE.md 側に置く．

## 変更

`Critical Rules (MUST)` → `Architecture` に 2 行追加:

1. 軽量コマンドが通る経路で torch・クラウド SDK を module-level import しない
   (PEP 562 `__getattr__` 遅延解決を使う)
2. `__getattr__` で遅延解決する名前に module-level 代入を残さない
   (global が hook を隠して probe 前の値が漏れる — 実際に import 順依存の
   バグを作りかけた)

コード側は既にこの形に揃っており (`console/common.py` の `_LAZY_IMPORTS` /
`_CLOUD_PROBES`)，`tests/maou/infra/console/test_console_import_weight.py` が
機械的に検査している (PR #401 で実装済み)．本 PR は規約の明文化のみ．

経緯: `reviews/2026-07-26-infra-lazy-heavy-imports.md` (approved → applied 39b1580)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqV7Y5XhFReThEE7uTie8B