### PR TITLE
feat(selfplay): A/B ハーネスと持ち時間モードを CLI へ露出 (GPU 検証を wheel だけで完結させる)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/selfplay.md
+++ b/docs/commands/selfplay.md
@@ -29,6 +29,16 @@
   the first N plies uniformly at random among legal moves (deterministic
   per `--seed`, mixed with the game index). `--opening-script` applies a
   forced opening to both agents instead.
+- **A/B matches** (`--ab-mode`): player A plays the lever on, player B off,
+  everything else identical. Colors swap every game and the pair
+  (2n, 2n+1) shares one opening sequence, so the paired comparison cancels
+  opening variance. Used to settle the design's open questions
+  ([design §12](../design/usi-engine/index.md); GPU procedure:
+  [verification.md](../design/usi-engine/verification.md)).
+- **Real-clock mode** (`--clock-ms`): instead of a fixed per-move budget,
+  a real clock runs and the time strategy decides each move's budget. Time
+  spent is measured on the wall clock, so it requires `--parallel 1` and is
+  mutually exclusive with `--playouts` / `--movetime-ms`.
 - HCPE (training data) generation from self-play records is a later
   campaign; this command produces the driver + records + smoke layer only.
 
@@ -54,6 +64,15 @@
 | `--resign-value INT` | default `0` | Resign when the root win rate stays below this permille for `--resign-consecutive` moves (`0` = never). |
 | `--resign-consecutive INT` | default `3` | Consecutive below-threshold moves required to resign. |
 | `--opening-script "MOVES"` | | Forced opening move sequence in USI notation, applied to both agents (only when `--sfen` is a move-1 position — see [`usi.md`](usi.md)). |
+| `--clock-ms INT` | default `0` | Real-clock mode: initial time per side in milliseconds (`0` = off). Mutually exclusive with `--playouts` / `--movetime-ms`, and requires `--parallel 1`. |
+| `--byoyomi-ms INT` | default `0` | Byoyomi in milliseconds (real-clock mode only). |
+| `--inc-ms INT` | default `0` | Fischer increment per move in milliseconds (real-clock mode only). |
+| `--min-think-ms INT` | | Minimum thinking time per move (engine default `100`); only meaningful in real-clock mode. |
+| `--ab-mode MODE` | | A/B match instead of plain self-play: `subtree` (subtree reuse), `maxmoves` (in-search draw terminal), `budget` (same config, smaller budget for B — harness sanity check), `horizon` (time-strategy horizon; requires `--clock-ms`). |
+| `--playouts-b INT` | | Player B playout budget (`--ab-mode budget`; defaults to one eighth of `--playouts`). |
+| `--horizon INT` | | Assumed remaining moves for player A (`--ab-mode horizon`; defaults to the engine value). |
+| `--horizon-b INT` | | Assumed remaining moves for player B (`--ab-mode horizon`; default `25`). |
+| `--alternate-colors/--no-alternate-colors` | default: on with `--ab-mode` | Swap colors every game and pair the openings (2n, 2n+1). |
 | `--root-dfpn/--no-root-dfpn` | **default on** | Root-parallel dfpn mate search. |
 | `--root-dfpn-nodes INT` | default `2000000` | Node budget for the root dfpn mate search. |
 | `--root-dfpn-depth INT` | default `2047` | Depth limit for the root dfpn mate search. |
@@ -72,16 +91,26 @@
   "black"|"white"|null, "reason": "checkmate"|"resign"|"declaration"|
   "repetition"|"perpetual_check"|"max_moves"|"illegal_move",
   "black_player": "a"|"b", "plies": N, "playouts": N, "reused_moves": N,
-  "carried_visits": N, "elapsed_ms": N}`.
+  "carried_visits": N, "elapsed_ms": N, "remaining_ms": [N, N]|null}`.
   (`reused_moves` / `carried_visits` measure how often subtree reuse
   warm-started a search and how many visits it carried over — the
   effective budget the retained tree added.)
-  (`black_player` records color alternation in A/B matches driven via the
-  Rust harness `cargo run -p maou_usi --example selfplay_ab`; plain CLI
-  self-play always reports `"a"`.)
+  (`black_player` records color alternation in A/B matches; plain
+  self-play always reports `"a"`. `remaining_ms` is `[black, white]` time
+  left at the end and is only filled in real-clock mode.)
 - stdout prints a summary: game count, black/white/draw results, a reason
-  histogram, totals for plies / playouts / summed game time, and how much
-  subtree reuse contributed.
+  histogram, totals for plies / playouts / summed game time, wall-clock
+  `throughput:` in playouts per second (the denominator is the whole run,
+  so `--parallel` sweeps are comparable), and how much subtree reuse
+  contributed.
+- With `--ab-mode` the summary additionally reports, from player A's point
+  of view: `W/D/L`, the score with a Wilson 95% interval, the Elo
+  conversion with its interval, the paired statistics (pairs, mean, SE,
+  t value, pairs where A came out ahead) and — in real-clock mode — the
+  average time left at the end for each side. Read the engagement numbers
+  (carried visits, time left) before concluding "no effect": at n = 40 the
+  interval only resolves differences of roughly 150 Elo, so a win rate
+  alone cannot separate "no effect" from "the lever never fired".
 
 ## Example
 
@@ -94,4 +123,19 @@ maou selfplay --games 2 --playouts 16 --max-moves 64 \
 maou selfplay --model-path model.onnx --games 20 --parallel 4 \
   --playouts 800 --opening-random-plies 6 --seed 1 \
   --output selfplay.jsonl
+
+# A/B: subtree reuse on (A) vs off (B), paired openings with color swap
+maou selfplay --model-path model.onnx --games 40 --ab-mode subtree \
+  --playouts 800 --opening-random-plies 8 --seed 1 --max-moves 256
+
+# A/B on the time strategy: real clock, horizon 40 (A) vs 20 (B)
+maou selfplay --model-path model.onnx --games 40 --ab-mode horizon \
+  --clock-ms 32000 --inc-ms 500 --horizon 40 --horizon-b 20 \
+  --resign-value 0 --opening-random-plies 8 --seed 1 --max-moves 256
 ```
+
+The same harness is available without building the Python extension as
+`cargo run --release -p maou_usi --example selfplay_ab` (a thin wrapper
+around the same `maou_usi::ab` implementation, so the numbers agree).
+GPU procedure for the open questions:
+[verification.md](../design/usi-engine/verification.md).

--- a/docs/design/usi-engine/index.md
+++ b/docs/design/usi-engine/index.md
@@ -4,9 +4,9 @@
 > 2026-07-17，未決事項 1-6 すべて提案どおり)．
 > 各節に「実装済み」「設計方針 (未実装)」「未決」のいずれかを明記する．
 > 本ドキュメント起草時点では全節が設計方針 (マイルストーン M1-M4 で実装)．
-> 2026-07-26: M1-M4 実装完了 (M1=#393/#394, M2=#395, M3=#397, M4=feat/usi-m4)．
-> 未決事項 4 (in-search) は実装済み・未決 5 (バッチ aggregator) は計測待ち，
-> 未決 1-3 は未決のまま (reviews/2026-07-26-usi-m4-selfplay-docs.md)．
+> 2026-07-26: M1-M4 実装完了 (M1=#393/#394, M2=#395, M3=#397, M4=#401)．
+> 未決事項は 3/4/6 が決着，1/5 が GPU 実測待ち，2 が GUI 実機待ち
+> (現状は §12 の表，検証手順は [verification.md](verification.md))．
 
 ## 1. 目的とスコープ
 
@@ -283,11 +283,16 @@ minor (M1 で 0.47.0)．
 
 ### 未決事項
 
-| # | 未決 | 決め方 |
-|---|---|---|
-| 1 | TimeStrategy の定数 (想定残り手数カーブ・margin 既定値) | 実装時に自己対局で調整，worklog 記録 |
-| 2 | keep-alive 空行の default | 将棋所実機で挙動確認後 |
-| 3 | USI_Hash → NodeCapacity 換算係数 | NodePool のノード実サイズから実装時決定 |
-| 4 | MaxMovesToDraw の in-search 対応 | M4 で効果計測後 |
-| 5 | バッチ aggregator (自己対局並列時) | M4 で計測後 |
-| 6 | subtree 再利用の採否 | M3 で効果計測後 |
+| # | 未決 | 決め方 | 現状 (2026-07-26) |
+|---|---|---|---|
+| 1 | TimeStrategy の定数 (想定残り手数カーブ・margin 既定値) | 実装時に自己対局で調整，worklog 記録 | **GPU 実測待ち** — CPU (約 23 playouts/秒) では「時計が効くが枯渇しない」regime を作れず測定不能．基盤 (持ち時間モード + `--ab-mode horizon`) は実装済み．手順: [verification.md §4](verification.md) |
+| 2 | keep-alive 空行の default | 将棋所実機で挙動確認後 | **GUI 実機待ち (将来課題)** — 実装済み・既定 off．手元に GUI 環境がなく未実施．確認項目: [verification.md §8](verification.md) |
+| 3 | USI_Hash → NodeCapacity 換算係数 | NodePool のノード実サイズから実装時決定 | **決着** — 実測レイアウト由来の 808 B/node (Node 48B + 分岐 62 × Edge 12B + 諸経費)．旧 512B は 1.6 倍の過小評価 |
+| 4 | MaxMovesToDraw の in-search 対応 | M4 で効果計測後 | **決着 (on)** — 発火は上限直前の探索深さ分のみで 60 局の勝敗は不変．採否の根拠は棋力ではなく「最大手数時の詰みも引き分け」という電竜戦ルールへの適合．既定 0 では bit-identical |
+| 5 | バッチ aggregator (自己対局並列時) | M4 で計測後 | **GPU 実測待ち** — CPU では評価器の `Mutex<Session>` が上限で `parallel 1/2/4` が 64/65/65 playouts/秒 と完全に頭打ち．GPU でのバッチ効果で採否確定．手順: [verification.md §5](verification.md) |
+| 6 | subtree 再利用の採否 | M3 で効果計測後 | **決着 (on 継続)** — 探索手の 90% で reroot 成功，引き継ぎは playout の 18-20% (予算 64/256/800 で一定)．勝率 40 局は +44 Elo (CI が 0 を含む) で，予算較正の予測と整合．GPU 実挙動の確認: [verification.md §6](verification.md) |
+
+GPU (Colab) / GUI 実機での検証手順は [verification.md](verification.md) に
+分離した．A/B ハーネスは `maou selfplay --ab-mode`
+([docs/commands/selfplay.md](../../commands/selfplay.md)) として配布 wheel に
+入っており，Rust example `selfplay_ab` は同じ `maou_usi::ab` を呼ぶ．

--- a/docs/design/usi-engine/verification.md
+++ b/docs/design/usi-engine/verification.md
@@ -1,0 +1,283 @@
+# USI エンジンの検証手順 (GPU / GUI)
+
+[設計本体](index.md) の未決事項のうち，**DevContainer (CPU) では原理的に
+閉じられないもの**の手順書．CPU で閉じた項目の根拠は index.md §12 を見ること．
+
+| 残件 | 必要な環境 | 手順 |
+|---|---|---|
+| 未決 1 TimeStrategy の定数 | GPU (探索速度が要る) | [§4](#4-未決-1-timestrategy-の想定残り手数) |
+| 未決 5 バッチ aggregator | GPU | [§5](#5-未決-5-バッチ-aggregator-の採否) |
+| 未決 2 keep-alive の既定値 | GUI 実機 | [§8](#8-gui-実機検証-将来課題-未実施) — **将来課題** |
+
+**GPU 環境は Colab (L4) のみ**という前提で，検証は **Release `latest` の
+事前ビルド wheel** で行う (Rust ツールチェイン不要)．A/B ハーネスは
+`maou selfplay --ab-mode` として wheel に入っている (Rust example
+`selfplay_ab` は同じ `maou_usi::ab` を呼ぶ薄いラッパーで，数値の定義は同一)．
+
+---
+
+## 1. 環境構築 (Colab / 事前ビルド wheel)
+
+wheel の取得と provider の解決 (`ldconfig`) は
+[docs/design/position-search/benchmarking.md §4](../position-search/benchmarking.md)
+の手順をそのまま使う (セル 0-2)．`maou search` ではなく `maou selfplay` /
+`maou-usi` を叩く点だけが違う．
+
+検証モデルは学習済みの
+**`model_20260725_044443_vit-19.8m_32_fp16.onnx`** (ViT 19.8M / fp16 / IR 9)
+を `/content/model_fp16.onnx` へ置く．棋力に依存する判定 (§3・§4・§6) は
+mock 評価器や極小モデルでは意味を持たない．
+
+GPU 実行の共通フラグ:
+
+```bash
+--model-path /content/model_fp16.onnx \
+--tensorrt --cuda --threads 2 --batch-size 256 \
+--trt-cache-dir /content/trt_cache
+```
+
+- TensorRT の初回エンジンビルドは **バッチ shape ごとに数十秒〜数分**．
+  `--trt-cache-dir` を必ず指定し，同じセッション内で使い回す．
+- **計測の前にキャッシュを温める** (§2 の smoke を先に 1 回通す)．初回
+  ビルドが計測区間に入ると playouts/秒 が過小に出る．
+
+## 2. 事前確認 — 探索速度の実測 (以降の設定はこの値から決める)
+
+```python
+# 1 局面探索の NPS (warmup はエンジンビルドを計測区間から外す)
+!maou search --sfen "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1" \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 2 --batch-size 256 --time-ms 30000 --root-dfpn \
+    --trt-cache-dir /content/trt_cache
+```
+
+```python
+# 自己対局 1 局の smoke (対局経路が GPU で通ることの確認 + TRT キャッシュ温め)
+!maou selfplay --games 1 --playouts 800 --max-moves 64 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 2 --batch-size 256 --trt-cache-dir /content/trt_cache
+```
+
+得られた **playouts/秒 (以下 `NPS`)** を控える．CPU (DevContainer) の実測は
+ViT 19.8M / 1 スレッド / batch 8 で **約 23 playouts/秒**で，これが未決 1 を
+CPU で閉じられない理由だった．
+
+## 3. ハーネスの再較正 (`--ab-mode budget`)
+
+**レバーの A/B より先に通す健全性確認**．予算の多い側が勝たなければ，この
+driver で棋力差を測ること自体が成立していない．同時に **GPU の予算域での
+1 doubling あたり Elo** を測り直す (CPU で得た「1 doubling ≈ 208 Elo」は
+16→64 playouts の極低予算域の値で，高予算域へは外挿できない)．
+
+```python
+!maou selfplay --games 24 --ab-mode budget --playouts 800 --playouts-b 200 \
+    --opening-random-plies 8 --seed 1 --max-moves 256 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 2 --batch-size 256 --trt-cache-dir /content/trt_cache \
+    --output /content/ab_budget.jsonl
+```
+
+判定:
+
+- **A が有意に勝つこと** (`paired` の t 値が明確に正，`A ahead in` が過半)．
+  勝たない場合は以降の A/B を回しても意味がないので，先に原因を調べる．
+- `A Elo` を 2 doubling (800 vs 200) で割った値が，その予算域での
+  1 doubling あたり Elo．§4・§6 の期待値計算に使う．
+
+## 4. 未決 1: TimeStrategy の想定残り手数
+
+`--ab-mode horizon` は **持ち時間モード** (実時計を回して TimeStrategy に
+1 手の予算を決めさせる) で A/B する．A = `--horizon`，B = `--horizon-b` で，
+それ以外は同一設定．壁時計で消費を測るため **`--parallel 1` 限定**．
+
+### 4.1 regime ゲート (先に通すこと)
+
+CPU での 3 回の失敗はすべて **regime を外したこと**が原因で，レバーの効果
+以前の問題だった (worklog 2026-07-26)．次の 3 条件を満たす時計設定でのみ
+結果を採用する:
+
+1. **早期終了しない** — `reasons` が `resign` / `checkmate` に支配されて
+   いない (`--resign-value 0` で投了を切る)．
+2. **`min_think` に張り付かない** — `総 playouts ÷ 総手数` が
+   `NPS × min_think` を十分上回る (張り付くと両者とも同じ最小予算になり，
+   horizon の違いが消える)．
+3. **時計が実際に効く** — `time left at end` が初期持ち時間の大半を残して
+   いない (残しているなら「多く使う側が単純に得」なだけでトレードオフが
+   発生していない)．
+
+初期持ち時間の目安:
+
+```
+初期持ち時間 [秒] ≈ horizon × (目標 playouts/手 ÷ NPS)
+```
+
+例: `NPS = 2000`，目標 1600 playouts/手，horizon 40 → 32 秒 + 加算 0.5 秒．
+
+### 4.2 実行
+
+```python
+!maou selfplay --games 40 --ab-mode horizon \
+    --clock-ms 32000 --inc-ms 500 --horizon 40 --horizon-b 20 \
+    --resign-value 0 --max-moves 256 --opening-random-plies 8 --seed 1 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 2 --batch-size 256 --trt-cache-dir /content/trt_cache \
+    --output /content/ab_horizon.jsonl
+```
+
+### 4.3 判定
+
+- **機構の発火**: `time left at end (avg)` が A/B で明確に違うこと．同じなら
+  horizon の違いが時間配分に出ていない = レバーが効いていないので，勝率を
+  読んではいけない (設計 §12 の A/B tripwire)．
+- **効果**: `paired` の平均と t 値を第一に見る (Wilson CI は n=40 では
+  ±15% あり，~150 Elo 級しか検出できない)．§3 で得た 1 doubling あたり
+  Elo から期待値を出し，符号と桁が整合するかを見る．
+- **決着の書き方**: 有意差なしなら「この regime では差が出ない → 既定
+  (horizon 40) を据え置く」で閉じてよい．**据え置きも決着**であり，根拠
+  (regime ゲートを通した上での測定) を worklog に残すことが要件．
+- 既定値を変える場合は `TimeStrategyConfig::horizon_moves` (rust/maou_usi)
+  と [docs/commands/usi.md](../../commands/usi.md) を同時に更新する．
+
+## 5. 未決 5: バッチ aggregator の採否
+
+同時対局数を振って **wall clock ベースの playouts/秒** (`throughput:` 行) を
+比較する．CPU では評価器の `Mutex<Session>` が上限で `parallel 1/2/4` が
+`64/65/65 playouts/秒` (完全に頭打ち) だった．
+
+```python
+for p in (1, 2, 4, 8):
+    !maou selfplay --games 8 --parallel {p} --playouts 800 --max-moves 120 \
+        --model-path /content/model_fp16.onnx --tensorrt --cuda \
+        --threads 2 --batch-size 256 --trt-cache-dir /content/trt_cache --quiet
+```
+
+判定規則:
+
+- **スケールする** (parallel 4 で 3 倍以上) → GPU では Mutex 直列化が上限に
+  ならない ⇒ **aggregator は不要** (未決 5 を「見送り」で確定)．
+- **頭打ち** (parallel 4 で 1.5 倍未満) → GPU が遊んでいる ⇒ **採用検討**．
+  併せて `nvidia-smi dmon` などで GPU 利用率を見て「直列化で遊んでいる」
+  ことを確認してから，次 campaign の課題として起票する．
+- 中間 (1.5〜3 倍) は `--batch-size` を振って上限がバッチ側か直列化側かを
+  切り分ける (バッチを上げて改善するなら aggregator の余地がある)．
+
+## 6. subtree 再利用の GPU 実挙動 (`--ab-mode subtree`)
+
+CPU では「探索手の 90% で reroot 成功・引き継ぎは playout の 18-20%」が
+実測済み (`--parallel 1` / 実モデル)．GPU (TRT) でも同じ発火量になるかを
+確認する — mock 評価器では 1.2% しか出ず，mock だけ見ると無効と誤判定する．
+
+```python
+!maou selfplay --games 24 --ab-mode subtree --playouts 800 \
+    --opening-random-plies 8 --seed 1 --max-moves 256 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 2 --batch-size 256 --trt-cache-dir /content/trt_cache
+```
+
+`subtree reuse:` 行の引き継ぎ率が CPU と同水準 (18-20%) なら，CPU で出した
+「on 継続」の結論が GPU でも通る．大きく外れたら worklog に記録して原因
+(TRT 経路のバッチ待ちで再利用が効かない等) を追う．
+
+## 7. USI プロトコルの headless smoke (GUI なし)
+
+GUI を使わずに確認できる範囲 (`go mate` / ponder / keep-alive / TRT 初回
+ビルド中の `readyok` 待ち) はここで潰す．**一括 pipe は使わない** —
+`quit` が先に届いて `stop` が立ち，探索が 0 playout で終わる (既知の罠)．
+必ず応答を待ってから次を送る:
+
+```python
+%%writefile /content/usi_smoke.py
+import subprocess, time
+
+def send(p, line):
+    p.stdin.write(line + "\n"); p.stdin.flush(); print(">", line)
+
+def wait(p, token, timeout=600.0):
+    """token で始まる行が来るまで読み，途中の行 (空行含む) も表示する."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = p.stdout.readline()
+        if line == "":
+            raise RuntimeError("engine exited")
+        print("<", repr(line.rstrip("\n")))
+        if line.startswith(token):
+            return line.rstrip("\n")
+    raise TimeoutError(token)
+
+p = subprocess.Popen(["maou-usi"], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     text=True, bufsize=1)
+send(p, "usi"); wait(p, "usiok")
+for opt in [
+    "setoption name ModelPath value /content/model_fp16.onnx",
+    "setoption name UseTensorRT value true",
+    "setoption name UseCuda value true",
+    "setoption name TrtCacheDir value /content/trt_cache",
+    "setoption name KeepAlive value 5000",   # 未決 2: 空行の生存通知
+    "setoption name USI_Ponder value true",
+]:
+    send(p, opt)
+t0 = time.monotonic(); send(p, "isready"); wait(p, "readyok")
+print(f"isready took {time.monotonic() - t0:.1f}s")   # TRT 初回ビルド込み
+
+send(p, "position startpos")
+send(p, "go btime 30000 wtime 30000 binc 500 winc 500")
+best = wait(p, "bestmove")            # "bestmove <手> [ponder <予想手>]"
+tokens = best.split()
+assert len(tokens) >= 4, f"ponder 予想手が付かない: {best}"
+# GUI と同じ手順: 自分の手 + 予想した相手の手を進めてから go ponder
+send(p, f"position startpos moves {tokens[1]} {tokens[3]}")
+send(p, "go ponder btime 30000 wtime 30000 binc 500 winc 500")
+time.sleep(2.0); send(p, "ponderhit"); wait(p, "bestmove")
+
+# go mate: 先手 5三歩 + 持駒金 / 後手 5一玉 = G*5b の 1 手詰め
+send(p, "position sfen 4k4/9/4P4/9/9/9/9/9/9 b G 1")
+send(p, "go mate 10000"); wait(p, "checkmate")
+
+send(p, "quit"); p.wait(timeout=30)
+print("smoke ok")
+```
+
+```python
+!python /content/usi_smoke.py
+```
+
+確認項目:
+
+- `isready` の所要 (TRT 初回ビルド) と，その間に **空行が流れているか**
+  (`KeepAlive` の実動作．GUI が無害に無視するかは実機でしか判らない = 未決 2)．
+- `bestmove ... ponder ...` が付くこと，`ponderhit` 後に `bestmove` が返ること．
+- `go mate` が `checkmate <手順>` を返すこと．
+
+## 8. GUI 実機検証 (将来課題 — 未実施)
+
+**現時点で GUI を動かせる環境がないため未実施**．Colab では GUI (将棋所 /
+ShogiGUI / ShogiHome) を動かせないので，§7 の headless smoke で代替できない
+項目だけがここに残る．
+
+環境要件: GUI を動かせるデスクトップ環境 (Windows / Linux)．GPU は必須では
+ないが，TRT 初回ビルドの待ち時間を実機で見るには GPU 機が望ましい．
+
+チェックリスト:
+
+- [ ] エンジン登録 (`maou-usi` を引数なしで起動．[usi.md](../../commands/usi.md)
+      の登録手順) と `usi` → `usiok` → option 一覧の表示．
+- [ ] **`KeepAlive` の空行を GUI が無害に無視するか** — 無視するなら既定を
+      on にできる (**未決 2 の判断はこれだけが根拠になる**)．壊れる GUI が
+      あるなら既定 off のまま，該当 GUI 名を docs に残す．
+- [ ] **TRT 初回エンジンビルド中に `readyok` を待てるか** (GUI 側の
+      タイムアウトに引っかからないか)．`TrtCacheDir` 指定で 2 回目が短縮
+      されることも確認．
+- [ ] **`OpeningScript` が実サーバ/GUI 経由で正しく消化されるか** (電竜戦
+      HWT の玉往復ハンデ)．指定局面方式で手数付きの局面を渡された場合に
+      再発火しないこと (手数 1 ガード) も確認．
+- [ ] ponder の実挙動 (GUI が `go ponder` を送るか，`ponderhit` /
+      `stop` 後の応答が速いか)．
+- [ ] 1 局を最後まで完走 (投了・入玉宣言・千日手の表示が GUI と食い違わない)．
+
+## 9. 結果の記録先
+
+- 数値と失敗した試行は `worklog/YYYY-MM-DD-HHMMSS.md` (JST，追記不可)．
+- 「再導出しない結論」は `scratchpad/compass.md` の Invariants へ．
+- 既定値やドキュメントを変える場合のみ `reviews/*.md` を起票する
+  (`CLAUDE.md` / `docs/` を変更するときの必須手順)．
+- 未決事項の状態は [index.md §12](index.md) の表を更新する．

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.56.0"
+version = "0.57.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-07-26-gpu-verification-procedure.md
+++ b/reviews/2026-07-26-gpu-verification-procedure.md
@@ -1,7 +1,8 @@
 ---
 title: GPU (Colab L4) 検証手順の文書化と A/B ハーネスの CLI 露出に伴う docs 更新
 date: 2026-07-26
-status: pending
+status: applied
+applied_in: 27dacbc
 target:
   - docs/design/usi-engine/verification.md (新設)
   - docs/design/usi-engine/index.md

--- a/reviews/2026-07-26-gpu-verification-procedure.md
+++ b/reviews/2026-07-26-gpu-verification-procedure.md
@@ -1,0 +1,96 @@
+---
+title: GPU (Colab L4) 検証手順の文書化と A/B ハーネスの CLI 露出に伴う docs 更新
+date: 2026-07-26
+status: pending
+target:
+  - docs/design/usi-engine/verification.md (新設)
+  - docs/design/usi-engine/index.md
+  - docs/commands/selfplay.md
+risk: low
+reversibility: easy
+---
+
+# 提案: GPU 検証手順 (Colab L4 / 事前ビルド wheel) の文書化
+
+## 背景
+
+USI campaign の残件は 3 件で，いずれも DevContainer (CPU) では閉じられない:
+
+| 残件 | 閉じられない理由 (worklog 2026-07-26) |
+|---|---|
+| 未決 1 TimeStrategy 定数 | CPU 23 playouts/秒では「時計が効くが枯渇しない」regime を作れない |
+| 未決 5 バッチ aggregator | CPU では `Mutex<Session>` が上限で並列スケール 0．GPU でのバッチ効果は未測定 |
+| GUI 実機検証 | GUI (将棋所/ShogiGUI/ShogiHome) を動かせる環境が手元にない |
+
+user 決定 (2026-07-26):
+
+- **GPU を使えるのは Colab (L4) のみ**．GPU 検証は **Release `latest` の
+  事前ビルド wheel** を使う (Rust ビルド不要)．検証モデルは
+  `model_20260725_044443_vit-19.8m_32_fp16.onnx` (ViT 19.8M / fp16 / IR 9)．
+- **GUI 実機検証は将来の課題としてドキュメント化するにとどめる**．
+
+問題は，A/B ハーネス (`--mode horizon` 等) が **Rust example
+(`cargo run -p maou_usi --example selfplay_ab`) にしかなく wheel に含まれない**
+ことだった．そこで A/B と持ち時間モードを `maou selfplay` に露出する
+(`src/`/`rust/` 側は本レビュー対象外 — 同 PR に含む)．
+
+## ドキュメント変更内容 (本レビューの承認対象)
+
+### `docs/design/usi-engine/verification.md` (新設)
+
+USI エンジンの検証手順を 1 枚にまとめる:
+
+1. **GPU 検証 (Colab L4，事前ビルド wheel)** — インストールは
+   `docs/design/position-search/benchmarking.md` §4 を参照 (重複記述を避け
+   差分のみ書く: モデル配置と `--tensorrt --cuda --batch-size` 既定)．
+2. **未決 1 (TimeStrategy horizon) の手順と判定基準** — `maou selfplay
+   --ab-mode horizon` の実行セル，**regime ゲート** (投了/proven で早期終了
+   しない・min_think に張り付かない・終局時残り時間が初期値の大半を残さない)
+   を先に確認し，外れていたら時計設定を変えてやり直す，という運用を明記．
+   判定は Wilson CI + ペア t 値 + 残り時間で行う．
+3. **未決 5 (バッチ aggregator) の手順と判定基準** — `--parallel 1/2/4/8` の
+   playouts/秒 (wall clock) を比較し，スケールすれば aggregator 不要，
+   頭打ちなら採用検討，という決定規則を明記．
+4. **TRT/GPU の健全性確認** — subtree 再利用 (`--ab-mode subtree`) と
+   `go mate` / ponder / keep-alive の headless smoke (一括 pipe ではなく
+   「応答待ち→quit」の Python driver 断片を載せる — compass invariant)．
+5. **GUI 実機検証 (将来課題)** — 環境要件 (GUI + できれば GPU) と確認項目
+   チェックリスト (keep-alive 空行の扱い = 未決 2 の既定値判断 / TRT 初回
+   ビルド中に readyok を待てるか / OpeningScript が実サーバ経由で消化される
+   か / ponder の実挙動)．**未実施であることを明示**する．
+
+### `docs/design/usi-engine/index.md` (更新)
+
+- §12 未決事項の表に「現状」列を足し，1-6 の決着状況 (決着 / GPU 実測待ち /
+  実機待ち) と根拠 (PR・手順書) を書く．§12 から verification.md へリンク．
+
+### `docs/commands/selfplay.md` (更新)
+
+- 新オプション (`--ab-mode` / `--playouts-b` / `--horizon` / `--horizon-b` /
+  `--clock-ms` / `--byoyomi-ms` / `--inc-ms` / `--min-think-ms` /
+  `--alternate-colors`) を CLI options 表に追加．
+- Output 節に A/B サマリ (W/D/L・Wilson CI・Elo・ペア t 値・引き継ぎ訪問数・
+  残り持ち時間) と throughput 行 (wall clock playouts/秒) を追記．
+- 「A/B は Rust example 経由」という記述を CLI 経由に差し替える (example は
+  同じ `maou_usi::ab` を使う薄いラッパーとして残る)．
+
+## 追記 (2026-07-26，同承認範囲)
+
+- index.md 冒頭の到達状態メモ (7c221d3 で入れた 3 行) が §12 の現状列と
+  食い違うため，「3/4/6 決着・1/5 GPU 待ち・2 GUI 待ち」へ更新した．
+  実装状況の説明の正確性維持であり，新しい設計判断は含まない．
+- user 指示 (2026-07-26) により，Colab 手順には棋力測定ハーネスの再較正
+  (`--ab-mode budget` を GPU 予算域で回し 1 doubling あたり Elo を測り直す)
+  も含めた — CPU で得た「1 doubling ≈ 208 Elo」は 16→64 playouts の極低
+  予算域の値で，GPU の高予算域へ外挿できないため．
+
+## リスクと理由
+
+- **risk: low** — ドキュメントのみ．手順は既存 (benchmarking.md §4) の
+  Colab 手順の再利用で，新しい設計判断は「GUI 実機検証を将来課題として
+  据え置く」という user 決定の記録のみ．
+- **reversibility: easy** — 新設ファイルの削除と 2 ファイルの巻き戻し．
+
+## ロールバック
+
+verification.md の削除，index.md §12 と selfplay.md の該当行の巻き戻し．

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_usi.rs
+++ b/rust/maou_rust/src/maou_usi.rs
@@ -3,7 +3,8 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-use maou_usi::selfplay::{GameOutcome, SelfplayConfig};
+use maou_usi::ab::{build_ab, summarize, AbMode, AbOptions, RunSummary, SummaryOptions};
+use maou_usi::selfplay::{ClockSetting, GameOutcome, SelfplayConfig};
 use maou_usi::{EngineConfig, TimeStrategyConfig};
 
 /// 評価器・探索・戦略の共通引数を [`EngineConfig`] へ反映する
@@ -201,6 +202,54 @@ fn outcome_to_dict<'py>(py: Python<'py>, o: &GameOutcome) -> PyResult<Bound<'py,
     d.set_item("reused_moves", o.reused_moves)?;
     d.set_item("carried_visits", o.carried_visits)?;
     d.set_item("elapsed_ms", o.elapsed_ms)?;
+    // 終局時の残り持ち時間 [先手, 後手]．持ち時間モード以外は None
+    d.set_item("remaining_ms", o.remaining_ms.map(|r| r.to_vec()))?;
+    Ok(d)
+}
+
+/// [`RunSummary`] → Python dict (`ab` は A/B 対戦時のみ dict，他は None)．
+fn summary_to_dict<'py>(py: Python<'py>, s: &RunSummary) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("games", s.games)?;
+    d.set_item("black_wins", s.black_wins)?;
+    d.set_item("white_wins", s.white_wins)?;
+    d.set_item("draws", s.draws)?;
+    let reasons = PyDict::new(py);
+    for (name, count) in &s.reasons {
+        reasons.set_item(name, count)?;
+    }
+    d.set_item("reasons", reasons)?;
+    d.set_item("total_plies", s.total_plies)?;
+    d.set_item("total_playouts", s.total_playouts)?;
+    d.set_item("total_game_ms", s.total_game_ms)?;
+    d.set_item("reused_moves", s.reused_moves)?;
+    d.set_item("carried_visits", s.carried_visits)?;
+    match &s.ab {
+        None => d.set_item("ab", py.None())?,
+        Some(ab) => {
+            let a = PyDict::new(py);
+            a.set_item("wins", ab.wins)?;
+            a.set_item("draws", ab.draws)?;
+            a.set_item("losses", ab.losses)?;
+            a.set_item("score", ab.score)?;
+            a.set_item("score_rate", ab.score_rate)?;
+            a.set_item("ci_lo", ab.ci_lo)?;
+            a.set_item("ci_hi", ab.ci_hi)?;
+            a.set_item("elo", ab.elo)?;
+            a.set_item("elo_lo", ab.elo_lo)?;
+            a.set_item("elo_hi", ab.elo_hi)?;
+            a.set_item("pairs", ab.pairs)?;
+            a.set_item("pairs_a_ahead", ab.pairs_a_ahead)?;
+            a.set_item("pairs_tied", ab.pairs_tied)?;
+            a.set_item("pairs_b_ahead", ab.pairs_b_ahead)?;
+            a.set_item("paired_mean", ab.paired_mean)?;
+            a.set_item("paired_se", ab.paired_se)?;
+            a.set_item("paired_t", ab.paired_t)?;
+            a.set_item("time_left_a_ms", ab.time_left_a_ms)?;
+            a.set_item("time_left_b_ms", ab.time_left_b_ms)?;
+            d.set_item("ab", a)?
+        }
+    }
     Ok(d)
 }
 
@@ -225,19 +274,37 @@ fn outcome_to_dict<'py>(py: Python<'py>, o: &GameOutcome) -> PyResult<Bound<'py,
 ///   デフォルト 0)．`seed` (int, optional): 乱数シード (デフォルト 0)．
 /// - `verbose` (bool, optional): 対局ごとの進捗を stderr へ出す (デフォルト
 ///   true)．
+/// - `min_think_ms` (int, optional): 最低思考時間 (持ち時間モードの下限)．
 /// - 残りは `run_usi` と同名の評価器・探索・戦略引数
 ///   (`opening_script` は両側エージェントに適用される)．
 ///
+/// # A/B 対戦 (レバーの効果計測．設計 §12)
+///
+/// - `ab_mode` (str, optional): `"subtree"` / `"maxmoves"` / `"budget"` /
+///   `"horizon"`．指定するとプレイヤー B (レバー off 側) が作られ，A 視点の
+///   勝率統計が summary に載る．レバー以外の設定は A と同一になる．
+/// - `playouts_b` (int, optional): `"budget"` の B 側予算 (未指定 = A の 1/8)．
+/// - `horizon_moves` / `horizon_moves_b` (int, optional): `"horizon"` の
+///   A/B 想定残り手数 (未指定 = 40 / 25)．
+/// - `alternate_colors` (bool, optional): 対局ごとに先後を入れ替え，ペア
+///   (2n, 2n+1) で同じ開局系列を共有する (`ab_mode` 指定時のデフォルト true)．
+/// - `clock_ms` / `byoyomi_ms` / `inc_ms` (int, optional): 持ち時間モード
+///   (`clock_ms` > 0 で有効)．`playouts`/`movetime_ms` と排他，`parallel=1`
+///   限定 (壁時計で消費を測るため)．`"horizon"` では必須．
+///
 /// # 返り値
 ///
-/// 対局 index 順の dict リスト: `{game_index, sfen, moves, winner
-/// ("black"/"white"/None), reason, plies, playouts, elapsed_ms}`．
+/// `{"records": [...], "summary": {...}}`．`records` は対局 index 順の dict
+/// `{game_index, sfen, moves, winner ("black"/"white"/None), reason,
+/// black_player, plies, playouts, reused_moves, carried_visits, elapsed_ms,
+/// remaining_ms}`，`summary` は集計 (`ab` キーは A/B 対戦時のみ dict)．
 ///
 /// # エラー
 ///
-/// 設定不正・モデルロード失敗・対局中の内部エラーは `RuntimeError`．
+/// 設定不正・モデルロード失敗・対局中の内部エラーは `RuntimeError`，
+/// 未知の `ab_mode` は `ValueError`．
 #[pyfunction]
-#[pyo3(signature = (*, model_path=None, games=None, parallel=None, playouts=None, movetime_ms=None, max_moves=None, sfen=None, opening_random_plies=None, seed=None, verbose=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, draw_value_black=None, draw_value_white=None, resign_value=None, resign_consecutive=None, opening_script=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None))]
+#[pyo3(signature = (*, model_path=None, games=None, parallel=None, playouts=None, movetime_ms=None, max_moves=None, sfen=None, opening_random_plies=None, seed=None, verbose=None, threads=None, batch_size=None, node_capacity=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, draw_value_black=None, draw_value_white=None, resign_value=None, resign_consecutive=None, opening_script=None, root_dfpn=None, root_dfpn_nodes=None, root_dfpn_depth=None, leaf_mate=None, leaf_mate_nodes=None, leaf_mate_threads=None, min_think_ms=None, ab_mode=None, playouts_b=None, horizon_moves=None, horizon_moves_b=None, alternate_colors=None, clock_ms=None, byoyomi_ms=None, inc_ms=None))]
 #[allow(clippy::too_many_arguments)]
 fn run_selfplay(
     py: Python<'_>,
@@ -268,7 +335,16 @@ fn run_selfplay(
     leaf_mate: Option<bool>,
     leaf_mate_nodes: Option<u64>,
     leaf_mate_threads: Option<usize>,
-) -> PyResult<Py<PyList>> {
+    min_think_ms: Option<u64>,
+    ab_mode: Option<String>,
+    playouts_b: Option<u64>,
+    horizon_moves: Option<u64>,
+    horizon_moves_b: Option<u64>,
+    alternate_colors: Option<bool>,
+    clock_ms: Option<u64>,
+    byoyomi_ms: Option<u64>,
+    inc_ms: Option<u64>,
+) -> PyResult<Py<PyDict>> {
     let mut engine = EngineConfig::default();
     apply_common_engine_args(
         &mut engine,
@@ -293,29 +369,72 @@ fn run_selfplay(
     );
     // 自己対局に伝送遅延はない (movetime をそのまま思考時間にする)
     engine.time.network_delay_ms = 0;
+    if let Some(v) = min_think_ms {
+        engine.time.min_think_ms = v;
+    }
+
+    // 持ち時間モード (clock_ms > 0)．playouts/movetime との排他は
+    // maou_usi::selfplay::run_selfplay が検証する
+    let clock = match clock_ms {
+        Some(v) if v > 0 => Some(ClockSetting {
+            initial_ms: v,
+            byoyomi_ms: byoyomi_ms.unwrap_or(0),
+            inc_ms: inc_ms.unwrap_or(0),
+        }),
+        _ => None,
+    };
+    let max_moves = max_moves.unwrap_or(512);
+
+    // A/B 対戦: レバーの on/off を A/B へ割る (maou_usi::ab が単一実装)
+    let mode = match &ab_mode {
+        None => None,
+        Some(name) => Some(AbMode::parse(name).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "未知の ab_mode: {name} (subtree | maxmoves | budget | horizon)"
+            ))
+        })?),
+    };
+    if let Some(m) = mode {
+        if m.needs_clock() && clock.is_none() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "ab_mode=horizon は持ち時間モード (clock_ms > 0) が必要",
+            ));
+        }
+    }
+    let alternate_colors = alternate_colors.unwrap_or(mode.is_some());
+    let setup = mode.map(|mode| {
+        build_ab(
+            &engine,
+            &AbOptions {
+                mode,
+                playouts_b,
+                max_moves,
+                horizon_a: horizon_moves.unwrap_or(engine.time.horizon_moves),
+                horizon_b: horizon_moves_b.unwrap_or(25),
+            },
+            playouts,
+        )
+    });
 
     let config = SelfplayConfig {
-        engine,
-        // A/B 対戦 (engine_b / 色交代 / 同期解除) は Rust example
-        // (selfplay_ab) 経由 — CLI には露出しない
-        engine_b: None,
-        alternate_colors: false,
-        sync_max_moves_to_draw: true,
+        engine: setup.as_ref().map_or(engine, |s| s.engine_a.clone()),
+        engine_b: setup.as_ref().map(|s| s.engine_b.clone()),
+        alternate_colors,
+        sync_max_moves_to_draw: setup.as_ref().is_none_or(|s| s.sync_max_moves_to_draw),
         sfen,
         games: games.unwrap_or(1),
         parallel: parallel.unwrap_or(1),
-        // playouts/movetime_ms 両方未指定なら playout 予算のデフォルトを使う
-        // 予算の per-side 指定 (A/B 検証用) と持ち時間モード (TimeStrategy
-        // 調整用) は Rust example 経由 — CLI は共通予算のみ
-        playouts_b: None,
+        playouts_b: setup.as_ref().and_then(|s| s.playouts_b),
         movetime_ms_b: None,
-        clock: None,
-        playouts: match (playouts, movetime_ms) {
-            (None, None) => SelfplayConfig::default().playouts,
+        clock,
+        // playouts/movetime_ms/clock がどれも未指定なら playout 予算の
+        // デフォルトを使う (持ち時間モードでは時計から算出させる)
+        playouts: match (playouts, movetime_ms, clock) {
+            (None, None, None) => SelfplayConfig::default().playouts,
             _ => playouts,
         },
         movetime_ms,
-        max_moves: max_moves.unwrap_or(512),
+        max_moves,
         opening_random_plies: opening_random_plies.unwrap_or(0),
         seed: seed.unwrap_or(0),
     };
@@ -343,6 +462,7 @@ fn run_selfplay(
         }
     };
 
+    let ab = mode.is_some();
     let outcomes = py
         .detach(move || maou_usi::selfplay::run_selfplay(&config, Some(&progress)))
         .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
@@ -351,7 +471,17 @@ fn run_selfplay(
     for o in &outcomes {
         list.append(outcome_to_dict(py, o)?)?;
     }
-    Ok(list.unbind())
+    let summary = summarize(
+        &outcomes,
+        SummaryOptions {
+            ab,
+            paired: ab && alternate_colors,
+        },
+    );
+    let result = PyDict::new(py);
+    result.set_item("records", list)?;
+    result.set_item("summary", summary_to_dict(py, &summary)?)?;
+    Ok(result.unbind())
 }
 
 /// Create maou_usi submodule

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/examples/selfplay_ab.rs
+++ b/rust/maou_usi/examples/selfplay_ab.rs
@@ -1,7 +1,8 @@
-//! 自己対局 A/B ハーネス — 設定レバーの棋力効果を対戦で測る (設計 §12 未決 4/6)．
+//! 自己対局 A/B ハーネス (Rust 単体版) — 設定レバーの棋力効果を対戦で測る．
 //!
-//! プレイヤー A (レバー on) vs B (レバー off) を色交代 + ペア開局で対戦させ，
-//! A の勝率と Wilson 95% 信頼区間を報告する．
+//! **配布 wheel を使う環境 (Colab など) では `maou selfplay --ab-mode ...` を
+//! 使う** (同じ [`maou_usi::ab`] を呼ぶので数値の定義は一致する)．この example
+//! は Python 拡張をビルドせずに Rust だけで回したいときの入口．
 //!
 //! ```bash
 //! cargo run --release -p maou_usi --example selfplay_ab --features onnx -- \
@@ -11,15 +12,14 @@
 //!
 //! - `--mode subtree`: A = subtree 再利用 on / B = off
 //! - `--mode maxmoves`: A = MaxMovesToDraw の in-search 終端化 on / B = off
-//!   (両者とも driver の最大手数で引き分けになる点は同一．知識の有無だけが違う)
 //! - `--mode budget`: A = `--playouts` / B = `--playouts-b` (既定 A の 1/8)．
-//!   **ハーネスの健全性確認** — 予算の多い側が勝たなければ，この driver で
-//!   棋力差を測ること自体が成立していない (レバーの A/B より前に通すべき検証)
+//!   **ハーネスの健全性確認**
 //! - `--mode horizon`: 持ち時間モードで TimeStrategy の想定残り手数を A/B
-//!   (`--horizon` vs `--horizon-b`)．設計 §12 未決 1 の調整用．時計は
-//!   `--clock-ms` / `--byoyomi-ms` / `--inc-ms`．壁時計を測るので parallel=1
+//!   (`--horizon` vs `--horizon-b`)．時計は `--clock-ms` / `--byoyomi-ms` /
+//!   `--inc-ms`．壁時計を測るので parallel=1
 
-use maou_usi::selfplay::{run_selfplay, GameOutcome, SelfplayConfig};
+use maou_usi::ab::{build_ab, summarize, AbMode, AbOptions, SummaryOptions};
+use maou_usi::selfplay::{run_selfplay, ClockSetting, GameOutcome, SelfplayConfig};
 use maou_usi::EngineConfig;
 
 fn arg_value<T: std::str::FromStr>(args: &[String], key: &str) -> Option<T> {
@@ -29,22 +29,13 @@ fn arg_value<T: std::str::FromStr>(args: &[String], key: &str) -> Option<T> {
         .and_then(|v| v.parse().ok())
 }
 
-/// Wilson score interval (95%) — 少数対局でも壊れない勝率の区間推定．
-fn wilson_95(score: f64, n: f64) -> (f64, f64) {
-    if n <= 0.0 {
-        return (0.0, 1.0);
-    }
-    let z = 1.96_f64;
-    let p = score / n;
-    let denom = 1.0 + z * z / n;
-    let center = (p + z * z / (2.0 * n)) / denom;
-    let half = (z / denom) * (p * (1.0 - p) / n + z * z / (4.0 * n * n)).sqrt();
-    ((center - half).max(0.0), (center + half).min(1.0))
-}
-
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let mode: String = arg_value(&args, "--mode").unwrap_or_else(|| "subtree".to_string());
+    let mode_name: String = arg_value(&args, "--mode").unwrap_or_else(|| "subtree".to_string());
+    let Some(mode) = AbMode::parse(&mode_name) else {
+        eprintln!("unknown --mode {mode_name} (subtree | maxmoves | budget | horizon)");
+        std::process::exit(2);
+    };
     let model: Option<String> = arg_value(&args, "--model");
     let games: u32 = arg_value(&args, "--games").unwrap_or(20);
     let parallel: usize = arg_value(&args, "--parallel").unwrap_or(1);
@@ -81,63 +72,35 @@ fn main() {
     // 自己対局に伝送遅延はない (持ち時間モードで margin を引かない)
     base.time.network_delay_ms = 0;
 
-    // 予算差モードのみ B の playout を変える (既定は A の 1/8)
-    let playouts_b_opt: Option<u64> = if mode == "budget" {
-        Some(arg_value(&args, "--playouts-b").unwrap_or((playouts / 8).max(1)))
-    } else {
-        None
-    };
-
-    let (engine_a, engine_b, sync) = match mode.as_str() {
-        // A = subtree 再利用 on (現行 default) / B = off
-        "subtree" => {
-            let a = base.clone();
-            let mut b = base.clone();
-            b.subtree_reuse = false;
-            (a, b, true)
-        }
-        // A = in-search 終端化 on / B = off (max_moves_to_draw を per-side 管理
-        // するため sync は切る．driver の終局判定は両者共通で max_moves)
-        "maxmoves" => {
-            let mut a = base.clone();
-            a.max_moves_to_draw = max_moves;
-            let mut b = base.clone();
-            b.max_moves_to_draw = 0;
-            (a, b, false)
-        }
-        // A/B の設定は同一で探索予算だけを変える (ハーネスの健全性確認)
-        "budget" => (base.clone(), base.clone(), true),
-        // 持ち時間モードで TimeStrategy の想定残り手数だけを変える (未決 1)
-        "horizon" => {
-            let mut a = base.clone();
-            a.time.horizon_moves = horizon_a;
-            let mut b = base.clone();
-            b.time.horizon_moves = horizon_b;
-            (a, b, true)
-        }
-        other => {
-            eprintln!("unknown --mode {other} (subtree | maxmoves | budget | horizon)");
-            std::process::exit(2);
-        }
-    };
-    let clock = (mode == "horizon").then_some(maou_usi::selfplay::ClockSetting {
+    let setup = build_ab(
+        &base,
+        &AbOptions {
+            mode,
+            playouts_b: arg_value(&args, "--playouts-b"),
+            max_moves,
+            horizon_a,
+            horizon_b,
+        },
+        Some(playouts),
+    );
+    let clock = mode.needs_clock().then_some(ClockSetting {
         initial_ms: clock_ms,
         byoyomi_ms,
         inc_ms,
     });
 
     let config = SelfplayConfig {
-        engine: engine_a,
-        engine_b: Some(engine_b),
+        engine: setup.engine_a,
+        engine_b: Some(setup.engine_b),
         alternate_colors: true,
-        sync_max_moves_to_draw: sync,
+        sync_max_moves_to_draw: setup.sync_max_moves_to_draw,
         sfen: None,
         games,
         parallel,
         // 持ち時間モードでは playout 予算を渡さない (時計から算出させる)
         playouts: clock.is_none().then_some(playouts),
         movetime_ms: None,
-        playouts_b: playouts_b_opt,
+        playouts_b: setup.playouts_b,
         movetime_ms_b: None,
         clock,
         max_moves,
@@ -172,39 +135,6 @@ fn main() {
         }
     };
 
-    // 集計: A 視点の W/D/L (勝ち 1 点，引き分け 0.5 点)
-    let mut wins = 0u32;
-    let mut draws = 0u32;
-    let mut losses = 0u32;
-    let mut reasons: std::collections::BTreeMap<&'static str, u32> = Default::default();
-    let mut total_plies = 0usize;
-    let mut total_ms = 0u64;
-    let mut total_playouts = 0u64;
-    let mut reused_moves = 0u32;
-    let mut carried_visits = 0u64;
-    for o in &outcomes {
-        use maou_shogi::types::Color;
-        let a_is_winner = match (o.winner, o.black_is_a) {
-            (None, _) => None,
-            (Some(Color::Black), black_a) => Some(black_a),
-            (Some(Color::White), black_a) => Some(!black_a),
-        };
-        match a_is_winner {
-            Some(true) => wins += 1,
-            Some(false) => losses += 1,
-            None => draws += 1,
-        }
-        *reasons.entry(o.reason.as_str()).or_default() += 1;
-        total_plies += o.moves.len();
-        total_ms += o.elapsed_ms;
-        total_playouts += o.playouts;
-        reused_moves += o.reused_moves;
-        carried_visits += o.carried_visits;
-    }
-    let n = outcomes.len() as f64;
-    let score = f64::from(wins) + 0.5 * f64::from(draws);
-    let (lo, hi) = wilson_95(score, n);
-
     if let Some(path) = out {
         use std::io::Write;
         let mut f = std::fs::File::create(&path).expect("JSONL 出力先を作成できる");
@@ -232,7 +162,7 @@ fn main() {
         eprintln!("[ab] wrote {} records to {path}", outcomes.len());
     }
 
-    println!("mode: {mode} (A = lever on, B = off)");
+    println!("mode: {mode_name} (A = lever on, B = off)");
     match clock {
         Some(c) => println!(
             "games: {games}, clock: {}ms + {}ms/move (byoyomi {}ms), horizon: A {horizon_a} / B {horizon_b}, random plies: {random_plies}, max moves: {max_moves}, seed: {seed}",
@@ -240,67 +170,18 @@ fn main() {
         ),
         None => println!(
             "games: {games}, playouts/move: A {playouts} / B {}, random plies: {random_plies}, max moves: {max_moves}, seed: {seed}",
-            playouts_b_opt.unwrap_or(playouts),
+            setup.playouts_b.unwrap_or(playouts),
         ),
     }
-    println!("A result: {wins}W {draws}D {losses}L");
-    println!(
-        "A score: {:.1}/{} = {:.1}% (Wilson 95% CI [{:.1}%, {:.1}%])",
-        score,
-        n,
-        100.0 * score / n,
-        100.0 * lo,
-        100.0 * hi,
-    );
-    println!(
-        "reasons: {}",
-        reasons
-            .iter()
-            .map(|(k, v)| format!("{k} {v}"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-    println!(
-        "plies: {} total, wall: {:.1}s summed",
-        total_plies,
-        total_ms as f64 / 1000.0,
-    );
-    // 時間配分の診断 (持ち時間モード): 終局時の残り時間 = 使い残し．
-    // 勝率より少ないサンプルで「配分が保守的すぎないか」が分かる
-    if let Some(c) = clock {
-        let mut left = [0u64; 2]; // [A, B]
-        let mut n = 0u32;
-        for o in &outcomes {
-            if let Some(rem) = o.remaining_ms {
-                // rem は [先手, 後手]．A/B 視点へ写す
-                let (a, b) = if o.black_is_a {
-                    (rem[0], rem[1])
-                } else {
-                    (rem[1], rem[0])
-                };
-                left[0] += a;
-                left[1] += b;
-                n += 1;
+    // 勝率・ペア差分・機構の発火量をまとめて出す (集計は maou_usi::ab)
+    print!(
+        "{}",
+        summarize(
+            &outcomes,
+            SummaryOptions {
+                ab: true,
+                paired: config.alternate_colors,
             }
-        }
-        if n > 0 {
-            let avg = |v: u64| v as f64 / f64::from(n);
-            println!(
-                "time left at end (avg): A {:.1}s / B {:.1}s (initial {:.1}s + {}ms/move)",
-                avg(left[0]) / 1000.0,
-                avg(left[1]) / 1000.0,
-                c.initial_ms as f64 / 1000.0,
-                c.inc_ms,
-            );
-        }
-    }
-    // 機構レベルの計測: 勝率が有意でなくても「レバーが実対局で発火したか」
-    // は決着する (subtree 再利用は A 側のみ on なので carry は全て A の分)
-    println!(
-        "subtree reuse engagement: {} moves carried {} visits ({:.1}% of {} total playouts)",
-        reused_moves,
-        carried_visits,
-        100.0 * carried_visits as f64 / total_playouts.max(1) as f64,
-        total_playouts,
+        )
     );
 }

--- a/rust/maou_usi/src/ab.rs
+++ b/rust/maou_usi/src/ab.rs
@@ -1,0 +1,678 @@
+//! 自己対局 A/B 計測 — 設定レバーの効果を対戦で測る (設計 §12 の未決事項)．
+//!
+//! 2 つの責務だけを持つ:
+//!
+//! - [`build_ab`]: レバーの on/off を プレイヤー A/B の [`EngineConfig`] へ割る
+//! - [`summarize`]: 対局結果 ([`GameOutcome`]) を A 視点の統計へ集計する
+//!
+//! `maou selfplay --ab-mode` (PyO3 経由) と Rust example `selfplay_ab` が
+//! 同じ実装を使うため，どちらから回しても数値の定義は一致する．
+//!
+//! 集計が勝率だけでなく **機構の発火量** (subtree 再利用の引き継ぎ訪問数) と
+//! **ペア比較の t 値** を必ず出すのは，n=40 級の勝率だけでは「効果なし」と
+//! 「機構が動いていない」を区別できないため (worklog 2026-07-26: 40 局の
+//! Wilson CI は ±15% 程度あり，予算 +18% 相当 = 約 +50 Elo は原理的に埋もれる)．
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::selfplay::GameOutcome;
+use crate::EngineConfig;
+
+/// A/B で比較するレバー．
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AbMode {
+    /// A = subtree 再利用 on (現行の既定) / B = off (設計 §12 未決 6)．
+    Subtree,
+    /// A = `MaxMovesToDraw` の in-search 終端化 on / B = off (未決 4)．
+    /// 両者とも driver の最大手数で引き分けになる点は同一で，探索が
+    /// リミットを知っているかどうかだけが違う．
+    MaxMoves,
+    /// A/B 同一設定で探索予算だけを変える (ハーネスの健全性確認)．
+    /// 予算の多い側が勝たなければ，この driver で棋力差を測ること自体が
+    /// 成立していない — レバーの A/B より前に通すべき検証．
+    Budget,
+    /// 持ち時間モードで `TimeStrategy` の想定残り手数を A/B (未決 1)．
+    Horizon,
+}
+
+impl AbMode {
+    /// CLI 文字列 → モード (未知の文字列は `None`)．
+    pub fn parse(s: &str) -> Option<AbMode> {
+        match s {
+            "subtree" => Some(AbMode::Subtree),
+            "maxmoves" => Some(AbMode::MaxMoves),
+            "budget" => Some(AbMode::Budget),
+            "horizon" => Some(AbMode::Horizon),
+            _ => None,
+        }
+    }
+
+    /// CLI 文字列表現．
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AbMode::Subtree => "subtree",
+            AbMode::MaxMoves => "maxmoves",
+            AbMode::Budget => "budget",
+            AbMode::Horizon => "horizon",
+        }
+    }
+
+    /// 持ち時間モード (実時計) を必要とするか．
+    pub fn needs_clock(&self) -> bool {
+        matches!(self, AbMode::Horizon)
+    }
+}
+
+/// A/B のパラメータ ([`build_ab`] の入力)．
+#[derive(Clone, Copy, Debug)]
+pub struct AbOptions {
+    /// 比較するレバー．
+    pub mode: AbMode,
+    /// [`AbMode::Budget`] で B に渡す playout 予算 (`None` = A の 1/8)．
+    pub playouts_b: Option<u64>,
+    /// [`AbMode::MaxMoves`] で A 側が探索へ渡すリミット (driver の最大手数)．
+    pub max_moves: u32,
+    /// [`AbMode::Horizon`] の A 側 想定残り手数．
+    pub horizon_a: u64,
+    /// [`AbMode::Horizon`] の B 側 想定残り手数．
+    pub horizon_b: u64,
+}
+
+/// [`build_ab`] の出力 ([`crate::selfplay::SelfplayConfig`] へそのまま載せる)．
+#[derive(Clone, Debug)]
+pub struct AbSetup {
+    /// プレイヤー A (レバー on 側) のエンジン設定．
+    pub engine_a: EngineConfig,
+    /// プレイヤー B (レバー off 側) のエンジン設定．
+    pub engine_b: EngineConfig,
+    /// driver がエージェントの `max_moves_to_draw` を同期してよいか
+    /// ([`AbMode::MaxMoves`] のときだけ false = 呼び出し側が管理する)．
+    pub sync_max_moves_to_draw: bool,
+    /// B の playout 予算 (`None` = A と同じ)．
+    pub playouts_b: Option<u64>,
+}
+
+/// レバーの on/off を A/B の [`EngineConfig`] へ割る．
+///
+/// `base` は共通条件 (モデル・スレッド数・詰み探索など呼び出し側の設定) で，
+/// 差分はモードが決めるフィールドだけに限る — A/B の差が 1 つであることを
+/// この関数が保証する．`playouts` は [`AbMode::Budget`] の既定 (A の 1/8)
+/// 算出にだけ使う．
+pub fn build_ab(base: &EngineConfig, opts: &AbOptions, playouts: Option<u64>) -> AbSetup {
+    let mut engine_a = base.clone();
+    let mut engine_b = base.clone();
+    let mut sync_max_moves_to_draw = true;
+    let mut playouts_b = None;
+    match opts.mode {
+        AbMode::Subtree => {
+            engine_b.subtree_reuse = false;
+        }
+        AbMode::MaxMoves => {
+            // per-side に管理するので driver の同期は切る (終局判定自体は
+            // driver 側の max_moves で両者共通)
+            engine_a.max_moves_to_draw = opts.max_moves;
+            engine_b.max_moves_to_draw = 0;
+            sync_max_moves_to_draw = false;
+        }
+        AbMode::Budget => {
+            playouts_b = Some(
+                opts.playouts_b
+                    .unwrap_or_else(|| (playouts.unwrap_or(0) / 8).max(1)),
+            );
+        }
+        AbMode::Horizon => {
+            engine_a.time.horizon_moves = opts.horizon_a;
+            engine_b.time.horizon_moves = opts.horizon_b;
+        }
+    }
+    AbSetup {
+        engine_a,
+        engine_b,
+        sync_max_moves_to_draw,
+        playouts_b,
+    }
+}
+
+/// 集計のモード指定．
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SummaryOptions {
+    /// A/B 対戦 (`engine_b` あり) — A 視点の勝率統計を出す．
+    pub ab: bool,
+    /// ペア開局 + 色交代 — 対局 (2n, 2n+1) を対にした差分統計を出す．
+    pub paired: bool,
+}
+
+/// A 視点の勝率統計 (A/B 対戦のときだけ作られる)．
+#[derive(Clone, Debug, PartialEq)]
+pub struct AbSummary {
+    /// A から見た勝ち数．
+    pub wins: u32,
+    /// 引き分け数．
+    pub draws: u32,
+    /// A から見た負け数．
+    pub losses: u32,
+    /// A のスコア (勝ち 1 点 + 引き分け 0.5 点)．
+    pub score: f64,
+    /// スコア率 (`score / games`)．
+    pub score_rate: f64,
+    /// Wilson 95% 信頼区間の下限 (スコア率)．
+    pub ci_lo: f64,
+    /// Wilson 95% 信頼区間の上限 (スコア率)．
+    pub ci_hi: f64,
+    /// スコア率の Elo 換算 (0% / 100% では `None`)．
+    pub elo: Option<f64>,
+    /// Elo 換算の下限 (`ci_lo` 由来)．
+    pub elo_lo: Option<f64>,
+    /// Elo 換算の上限 (`ci_hi` 由来)．
+    pub elo_hi: Option<f64>,
+    /// ペア数 (色交代 + ペア開局のときのみ > 0)．
+    pub pairs: u32,
+    /// A が優位だったペア数 (ペア合計スコア > 1.0)．
+    pub pairs_a_ahead: u32,
+    /// 同着ペア数．
+    pub pairs_tied: u32,
+    /// B が優位だったペア数．
+    pub pairs_b_ahead: u32,
+    /// ペア差分の平均 (ペア合計スコア − 1.0．範囲 [-1, +1])．
+    pub paired_mean: f64,
+    /// ペア差分の標準誤差．
+    pub paired_se: f64,
+    /// ペア差分の t 値 (`paired_mean / paired_se`)．
+    pub paired_t: f64,
+    /// 終局時の A 側平均残り持ち時間 (ミリ秒．持ち時間モードのみ)．
+    pub time_left_a_ms: Option<f64>,
+    /// 終局時の B 側平均残り持ち時間 (ミリ秒．持ち時間モードのみ)．
+    pub time_left_b_ms: Option<f64>,
+}
+
+/// 自己対局 1 回分の集計．
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunSummary {
+    /// 対局数．
+    pub games: u32,
+    /// 先手勝ち数．
+    pub black_wins: u32,
+    /// 後手勝ち数．
+    pub white_wins: u32,
+    /// 引き分け数．
+    pub draws: u32,
+    /// 終局理由のヒストグラム (理由名の昇順)．
+    pub reasons: Vec<(&'static str, u32)>,
+    /// 総手数．
+    pub total_plies: u64,
+    /// 総 playout 数 (両側合計)．
+    pub total_playouts: u64,
+    /// 対局の壁時計時間の総和 (ミリ秒．並列時は wall clock と一致しない)．
+    pub total_game_ms: u64,
+    /// subtree 再利用が発火した手数．
+    pub reused_moves: u32,
+    /// 引き継いだ訪問数の合計．
+    pub carried_visits: u64,
+    /// A 視点の勝率統計 (A/B 対戦のときのみ)．
+    pub ab: Option<AbSummary>,
+}
+
+/// 対局結果を集計する．
+///
+/// `opts.ab` が true のときだけ A 視点の統計を作る (純粋自己対局では
+/// 「A の勝ち」に意味がないため)．`opts.paired` が true ならペア (2n, 2n+1)
+/// の差分統計も作る — 開局サンプリング分散を相殺した比較になる．
+pub fn summarize(outcomes: &[GameOutcome], opts: SummaryOptions) -> RunSummary {
+    use maou_shogi::types::Color;
+
+    let mut black_wins = 0;
+    let mut white_wins = 0;
+    let mut draws = 0;
+    let mut reasons: BTreeMap<&'static str, u32> = BTreeMap::new();
+    let mut total_plies = 0u64;
+    let mut total_playouts = 0u64;
+    let mut total_game_ms = 0u64;
+    let mut reused_moves = 0u32;
+    let mut carried_visits = 0u64;
+    for o in outcomes {
+        match o.winner {
+            Some(Color::Black) => black_wins += 1,
+            Some(Color::White) => white_wins += 1,
+            None => draws += 1,
+        }
+        *reasons.entry(o.reason.as_str()).or_default() += 1;
+        total_plies += o.moves.len() as u64;
+        total_playouts += o.playouts;
+        total_game_ms += o.elapsed_ms;
+        reused_moves += o.reused_moves;
+        carried_visits += o.carried_visits;
+    }
+
+    RunSummary {
+        games: outcomes.len() as u32,
+        black_wins,
+        white_wins,
+        draws,
+        reasons: reasons.into_iter().collect(),
+        total_plies,
+        total_playouts,
+        total_game_ms,
+        reused_moves,
+        carried_visits,
+        ab: opts.ab.then(|| summarize_ab(outcomes, opts.paired)),
+    }
+}
+
+/// A 視点の 1 局のスコア (勝ち 1.0 / 引き分け 0.5 / 負け 0.0)．
+fn a_score(o: &GameOutcome) -> f64 {
+    use maou_shogi::types::Color;
+    match o.winner {
+        None => 0.5,
+        Some(Color::Black) => f64::from(u8::from(o.black_is_a)),
+        Some(Color::White) => f64::from(u8::from(!o.black_is_a)),
+    }
+}
+
+/// A 視点の勝率統計を作る．
+fn summarize_ab(outcomes: &[GameOutcome], paired: bool) -> AbSummary {
+    let mut wins = 0u32;
+    let mut draws = 0u32;
+    let mut losses = 0u32;
+    let mut time_left = [0f64; 2];
+    let mut clocked = 0u32;
+    for o in outcomes {
+        let s = a_score(o);
+        if s > 0.75 {
+            wins += 1;
+        } else if s < 0.25 {
+            losses += 1;
+        } else {
+            draws += 1;
+        }
+        if let Some(rem) = o.remaining_ms {
+            // rem は [先手, 後手]．A/B 視点へ写す
+            let (a, b) = if o.black_is_a {
+                (rem[0], rem[1])
+            } else {
+                (rem[1], rem[0])
+            };
+            time_left[0] += a as f64;
+            time_left[1] += b as f64;
+            clocked += 1;
+        }
+    }
+    let n = outcomes.len() as f64;
+    let score = f64::from(wins) + 0.5 * f64::from(draws);
+    let score_rate = if n > 0.0 { score / n } else { 0.0 };
+    let (ci_lo, ci_hi) = wilson_95(score, n);
+
+    // ペア差分: 対局 (2n, 2n+1) の A スコア合計 − 1.0 (= 引き分け均衡)．
+    // 端数の 1 局は捨てる (対にならないため)
+    let mut diffs: Vec<f64> = Vec::new();
+    let mut pairs_a_ahead = 0u32;
+    let mut pairs_tied = 0u32;
+    let mut pairs_b_ahead = 0u32;
+    if paired {
+        for chunk in outcomes.chunks_exact(2) {
+            let d = a_score(&chunk[0]) + a_score(&chunk[1]) - 1.0;
+            if d > 0.0 {
+                pairs_a_ahead += 1;
+            } else if d < 0.0 {
+                pairs_b_ahead += 1;
+            } else {
+                pairs_tied += 1;
+            }
+            diffs.push(d);
+        }
+    }
+    let (paired_mean, paired_se, paired_t) = paired_stats(&diffs);
+
+    AbSummary {
+        wins,
+        draws,
+        losses,
+        score,
+        score_rate,
+        ci_lo,
+        ci_hi,
+        elo: elo(score_rate),
+        elo_lo: elo(ci_lo),
+        elo_hi: elo(ci_hi),
+        pairs: diffs.len() as u32,
+        pairs_a_ahead,
+        pairs_tied,
+        pairs_b_ahead,
+        paired_mean,
+        paired_se,
+        paired_t,
+        time_left_a_ms: (clocked > 0).then(|| time_left[0] / f64::from(clocked)),
+        time_left_b_ms: (clocked > 0).then(|| time_left[1] / f64::from(clocked)),
+    }
+}
+
+/// Wilson score interval (95%) — 少数対局でも壊れない勝率の区間推定．
+pub fn wilson_95(score: f64, n: f64) -> (f64, f64) {
+    if n <= 0.0 {
+        return (0.0, 1.0);
+    }
+    let z = 1.96_f64;
+    let p = score / n;
+    let denom = 1.0 + z * z / n;
+    let center = (p + z * z / (2.0 * n)) / denom;
+    let half = (z / denom) * (p * (1.0 - p) / n + z * z / (4.0 * n * n)).sqrt();
+    ((center - half).max(0.0), (center + half).min(1.0))
+}
+
+/// スコア率 → Elo 差 (0% / 100% は発散するため `None`)．
+pub fn elo(score_rate: f64) -> Option<f64> {
+    if score_rate <= 0.0 || score_rate >= 1.0 {
+        return None;
+    }
+    // + 0.0 は 50% ちょうどで -0.0 になるのを避けるため (表示が "-0" になる)
+    Some(-400.0 * (1.0 / score_rate - 1.0).log10() + 0.0)
+}
+
+/// ペア差分の (平均, 標準誤差, t 値)．標本 0/1 個では SE と t を 0 にする．
+fn paired_stats(diffs: &[f64]) -> (f64, f64, f64) {
+    let n = diffs.len();
+    if n == 0 {
+        return (0.0, 0.0, 0.0);
+    }
+    let mean = diffs.iter().sum::<f64>() / n as f64;
+    if n < 2 {
+        return (mean, 0.0, 0.0);
+    }
+    // 不偏分散 → 標準誤差
+    let var = diffs.iter().map(|d| (d - mean).powi(2)).sum::<f64>() / (n as f64 - 1.0);
+    let se = (var / n as f64).sqrt();
+    let t = if se > 0.0 { mean / se } else { 0.0 };
+    (mean, se, t)
+}
+
+/// 人が読むサマリ (Rust example 用．CLI は Python 側で整形する)．
+impl fmt::Display for RunSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "games: {}", self.games)?;
+        writeln!(
+            f,
+            "results: black {} / white {} / draw {}",
+            self.black_wins, self.white_wins, self.draws
+        )?;
+        writeln!(
+            f,
+            "reasons: {}",
+            self.reasons
+                .iter()
+                .map(|(k, v)| format!("{k} {v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )?;
+        writeln!(
+            f,
+            "plies: {} total, playouts: {} total, game time: {:.1}s summed",
+            self.total_plies,
+            self.total_playouts,
+            self.total_game_ms as f64 / 1000.0,
+        )?;
+        writeln!(
+            f,
+            "subtree reuse: {} move(s) warm-started, {} visits carried over ({:.1}% of playouts)",
+            self.reused_moves,
+            self.carried_visits,
+            100.0 * self.carried_visits as f64 / self.total_playouts.max(1) as f64,
+        )?;
+        if let Some(ab) = &self.ab {
+            let elo = |v: Option<f64>| match v {
+                Some(e) => format!("{e:+.0}"),
+                None => "n/a".to_string(),
+            };
+            writeln!(f, "A result: {}W {}D {}L", ab.wins, ab.draws, ab.losses)?;
+            writeln!(
+                f,
+                "A score: {:.1}/{} = {:.1}% (Wilson 95% CI [{:.1}%, {:.1}%])",
+                ab.score,
+                self.games,
+                100.0 * ab.score_rate,
+                100.0 * ab.ci_lo,
+                100.0 * ab.ci_hi,
+            )?;
+            writeln!(
+                f,
+                "A Elo: {} [{}, {}]",
+                elo(ab.elo),
+                elo(ab.elo_lo),
+                elo(ab.elo_hi)
+            )?;
+            if ab.pairs > 0 {
+                writeln!(
+                    f,
+                    "paired: {} pairs, mean {:+.3} (SE {:.3}), t = {:+.2}, A ahead in {}/{} (tied {})",
+                    ab.pairs,
+                    ab.paired_mean,
+                    ab.paired_se,
+                    ab.paired_t,
+                    ab.pairs_a_ahead,
+                    ab.pairs,
+                    ab.pairs_tied,
+                )?;
+            }
+            if let (Some(a), Some(b)) = (ab.time_left_a_ms, ab.time_left_b_ms) {
+                writeln!(
+                    f,
+                    "time left at end (avg): A {:.1}s / B {:.1}s",
+                    a / 1000.0,
+                    b / 1000.0
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selfplay::GameEndReason;
+    use maou_shogi::types::Color;
+
+    fn outcome(game_index: u32, black_is_a: bool, winner: Option<Color>) -> GameOutcome {
+        GameOutcome {
+            game_index,
+            sfen: "startpos".to_string(),
+            moves: vec!["7g7f".to_string()],
+            black_is_a,
+            winner,
+            reason: GameEndReason::MaxMoves,
+            playouts: 100,
+            reused_moves: 1,
+            carried_visits: 20,
+            elapsed_ms: 1000,
+            remaining_ms: None,
+        }
+    }
+
+    #[test]
+    fn test_ab_mode_parse_roundtrip() {
+        for name in ["subtree", "maxmoves", "budget", "horizon"] {
+            let mode = AbMode::parse(name).expect("既知のモード");
+            assert_eq!(mode.as_str(), name);
+        }
+        assert!(AbMode::parse("unknown").is_none());
+        assert!(AbMode::Horizon.needs_clock());
+        assert!(!AbMode::Subtree.needs_clock());
+    }
+
+    #[test]
+    fn test_build_ab_differs_in_exactly_one_lever() {
+        let base = EngineConfig::default();
+        let opts = AbOptions {
+            mode: AbMode::Subtree,
+            playouts_b: None,
+            max_moves: 512,
+            horizon_a: 40,
+            horizon_b: 25,
+        };
+        let setup = build_ab(&base, &opts, Some(64));
+        assert!(setup.engine_a.subtree_reuse, "A は既定 (on) のまま");
+        assert!(!setup.engine_b.subtree_reuse);
+        assert!(setup.sync_max_moves_to_draw);
+        assert_eq!(setup.playouts_b, None, "予算は共通");
+        // 差はレバー 1 つだけ (他フィールドは base のまま)
+        let mut b_as_a = setup.engine_b.clone();
+        b_as_a.subtree_reuse = setup.engine_a.subtree_reuse;
+        assert_eq!(format!("{b_as_a:?}"), format!("{:?}", setup.engine_a));
+    }
+
+    #[test]
+    fn test_build_ab_maxmoves_unsyncs_driver() {
+        let opts = AbOptions {
+            mode: AbMode::MaxMoves,
+            playouts_b: None,
+            max_moves: 120,
+            horizon_a: 40,
+            horizon_b: 25,
+        };
+        let setup = build_ab(&EngineConfig::default(), &opts, Some(64));
+        assert_eq!(setup.engine_a.max_moves_to_draw, 120);
+        assert_eq!(setup.engine_b.max_moves_to_draw, 0);
+        assert!(
+            !setup.sync_max_moves_to_draw,
+            "driver に上書きさせるとレバーが消える"
+        );
+    }
+
+    #[test]
+    fn test_build_ab_budget_defaults_to_one_eighth() {
+        let opts = AbOptions {
+            mode: AbMode::Budget,
+            playouts_b: None,
+            max_moves: 512,
+            horizon_a: 40,
+            horizon_b: 25,
+        };
+        let setup = build_ab(&EngineConfig::default(), &opts, Some(64));
+        assert_eq!(setup.playouts_b, Some(8));
+        // 明示指定が優先される
+        let setup = build_ab(
+            &EngineConfig::default(),
+            &AbOptions {
+                playouts_b: Some(3),
+                ..opts
+            },
+            Some(64),
+        );
+        assert_eq!(setup.playouts_b, Some(3));
+    }
+
+    #[test]
+    fn test_build_ab_horizon_sets_time_strategy() {
+        let opts = AbOptions {
+            mode: AbMode::Horizon,
+            playouts_b: None,
+            max_moves: 512,
+            horizon_a: 40,
+            horizon_b: 20,
+        };
+        let setup = build_ab(&EngineConfig::default(), &opts, None);
+        assert_eq!(setup.engine_a.time.horizon_moves, 40);
+        assert_eq!(setup.engine_b.time.horizon_moves, 20);
+    }
+
+    #[test]
+    fn test_summarize_a_view_follows_color_alternation() {
+        // A が先手で勝ち / A が後手で勝ち / A が先手で負け / 引き分け
+        let outcomes = vec![
+            outcome(0, true, Some(Color::Black)),
+            outcome(1, false, Some(Color::White)),
+            outcome(2, true, Some(Color::White)),
+            outcome(3, false, None),
+        ];
+        let s = summarize(
+            &outcomes,
+            SummaryOptions {
+                ab: true,
+                paired: false,
+            },
+        );
+        assert_eq!(s.games, 4);
+        assert_eq!((s.black_wins, s.white_wins, s.draws), (1, 2, 1));
+        let ab = s.ab.expect("A/B 集計あり");
+        assert_eq!((ab.wins, ab.draws, ab.losses), (2, 1, 1));
+        assert!((ab.score - 2.5).abs() < 1e-9);
+        assert!((ab.score_rate - 0.625).abs() < 1e-9);
+        assert_eq!(ab.pairs, 0, "paired=false ではペア統計を作らない");
+    }
+
+    #[test]
+    fn test_summarize_paired_statistics() {
+        // ペア 0: A が両局勝ち (+1.0) / ペア 1: 1 勝 1 敗 (0.0)
+        let outcomes = vec![
+            outcome(0, true, Some(Color::Black)),
+            outcome(1, false, Some(Color::White)),
+            outcome(2, true, Some(Color::Black)),
+            outcome(3, false, Some(Color::Black)),
+        ];
+        let s = summarize(
+            &outcomes,
+            SummaryOptions {
+                ab: true,
+                paired: true,
+            },
+        );
+        let ab = s.ab.expect("A/B 集計あり");
+        assert_eq!(ab.pairs, 2);
+        assert_eq!(
+            (ab.pairs_a_ahead, ab.pairs_tied, ab.pairs_b_ahead),
+            (1, 1, 0)
+        );
+        assert!((ab.paired_mean - 0.5).abs() < 1e-9);
+        // 差分 [1.0, 0.0] の不偏分散 = 0.5 → SE = sqrt(0.5/2) = 0.5
+        assert!((ab.paired_se - 0.5).abs() < 1e-9);
+        assert!((ab.paired_t - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_summarize_aggregates_mechanism_counters() {
+        let outcomes = vec![outcome(0, true, None), outcome(1, true, None)];
+        let s = summarize(&outcomes, SummaryOptions::default());
+        assert!(s.ab.is_none(), "純粋自己対局では A 視点を作らない");
+        assert_eq!(s.total_playouts, 200);
+        assert_eq!(s.reused_moves, 2);
+        assert_eq!(s.carried_visits, 40);
+        assert_eq!(s.total_plies, 2);
+        assert_eq!(s.reasons, vec![("max_moves", 2)]);
+    }
+
+    #[test]
+    fn test_wilson_and_elo() {
+        // 全勝は上限 1.0 に張り付き，下限は 1.0 未満
+        let (lo, hi) = wilson_95(10.0, 10.0);
+        assert!(lo > 0.6 && lo < 1.0, "lo = {lo}");
+        assert!((hi - 1.0).abs() < 1e-9);
+        // 五分は 0.5 を挟む
+        let (lo, hi) = wilson_95(20.0, 40.0);
+        assert!(lo < 0.5 && hi > 0.5);
+        // n=0 は区間が全域
+        assert_eq!(wilson_95(0.0, 0.0), (0.0, 1.0));
+
+        assert_eq!(elo(0.5), Some(0.0));
+        assert!((elo(0.75).expect("有限") - 190.8).abs() < 0.1);
+        assert_eq!(elo(1.0), None);
+        assert_eq!(elo(0.0), None);
+    }
+
+    #[test]
+    fn test_time_left_maps_to_ab_sides() {
+        let mut a_black = outcome(0, true, None);
+        a_black.remaining_ms = Some([10_000, 4_000]);
+        let mut a_white = outcome(1, false, None);
+        a_white.remaining_ms = Some([6_000, 20_000]);
+        let s = summarize(
+            &[a_black, a_white],
+            SummaryOptions {
+                ab: true,
+                paired: false,
+            },
+        );
+        let ab = s.ab.expect("A/B 集計あり");
+        // A = 10s と 20s / B = 4s と 6s
+        assert!((ab.time_left_a_ms.expect("時計あり") - 15_000.0).abs() < 1e-9);
+        assert!((ab.time_left_b_ms.expect("時計あり") - 5_000.0).abs() < 1e-9);
+    }
+}

--- a/rust/maou_usi/src/lib.rs
+++ b/rust/maou_usi/src/lib.rs
@@ -7,11 +7,13 @@
 //! - [`backend`]: [`agent::SearchBackend`] の実装 (maou_search)
 //! - [`time`][]: 時間管理 (持ち時間 → 1 手予算の変換レイヤー)
 //! - [`stdio`]: 標準入出力 transport (reader スレッド + dispatcher)
+//! - [`ab`]: 自己対局 A/B 計測 (レバー割り当て + 結果集計．pure)
 //!
 //! プロトコル層とエージェントを分離しているのは，自己対局 driver (M4) が
 //! agent を stdio なしで直接駆動するためと，将来の CSA transport を agent
 //! 無変更で追加するため．
 
+pub mod ab;
 pub mod agent;
 pub mod backend;
 pub mod protocol;
@@ -19,6 +21,7 @@ pub mod selfplay;
 pub mod stdio;
 pub mod time;
 
+pub use ab::{build_ab, summarize, AbMode, AbOptions, AbSetup, AbSummary, RunSummary};
 pub use agent::{Agent, EngineConfig, SearchBackend, SearchBudget, SearchOutcome};
 pub use backend::MaouSearchBackend;
 pub use selfplay::{run_selfplay, GameEndReason, GameOutcome, SelfplayConfig};

--- a/src/maou/app/usi/selfplay.py
+++ b/src/maou/app/usi/selfplay.py
@@ -1,6 +1,7 @@
 """自己対局ユースケース (Rust maou_usi::selfplay の薄いラッパー)."""
 
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,14 @@ from maou._rust.maou_usi import (
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+AB_MODES: tuple[str, ...] = (
+    "subtree",
+    "maxmoves",
+    "budget",
+    "horizon",
+)
+"""A/B 対戦で比較できるレバー (Rust maou_usi::ab::AbMode と対応)."""
 
 
 class SelfplayRunner:
@@ -56,6 +65,21 @@ class SelfplayRunner:
             cuda: CUDA Execution Provider を使うか．
             tensorrt: TensorRT Execution Provider を使うか．
             trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+            min_think_ms: 最低思考時間ミリ秒 (None = エンジン既定 100)．
+                持ち時間モードで 1 手の下限を変えるときだけ指定する．
+            ab_mode: A/B 対戦で比較するレバー ([`AB_MODES`]．None = 純粋
+                自己対局)．指定するとレバー off 側の相手 B が作られ，
+                レバー以外の設定は A と同一になる．
+            playouts_b: ``ab_mode="budget"`` の B 側予算 (None = A の 1/8)．
+            horizon_moves: ``ab_mode="horizon"`` の A 側想定残り手数
+                (None = エンジン既定)．
+            horizon_moves_b: 同 B 側想定残り手数 (None = 25)．
+            alternate_colors: 対局ごとに先後を入れ替え，ペア (2n, 2n+1) で
+                同じ開局系列を共有するか (None = ab_mode 指定時 True)．
+            clock_ms: 持ち時間モードの初期持ち時間ミリ秒 (0/None = 無効)．
+                playouts/movetime_ms と排他で parallel=1 限定．
+            byoyomi_ms: 秒読みミリ秒 (持ち時間モードのみ)．
+            inc_ms: 1 手加算ミリ秒 (持ち時間モードのみ)．
         """
 
         model_path: Path | None = None
@@ -85,31 +109,58 @@ class SelfplayRunner:
         cuda: bool = False
         tensorrt: bool = False
         trt_engine_cache_dir: Path | None = None
+        min_think_ms: int | None = None
+        ab_mode: str | None = None
+        playouts_b: int | None = None
+        horizon_moves: int | None = None
+        horizon_moves_b: int | None = None
+        alternate_colors: bool | None = None
+        clock_ms: int | None = None
+        byoyomi_ms: int | None = None
+        inc_ms: int | None = None
 
-    def run(
-        self, option: SelfplayOption
-    ) -> list[dict[str, Any]]:
-        """自己対局を実行し対局結果のリストを返す (対局 index 順)．
+    @dataclass(kw_only=True, frozen=True)
+    class SelfplayResult:
+        """自己対局の実行結果．
+
+        Attributes:
+            records: 対局ごとの dict (対局 index 順)．
+            summary: 集計 (Rust maou_usi::ab::summarize)．``ab`` キーは
+                A/B 対戦時のみ dict で，それ以外は None．
+            wall_ms: 実行全体の壁時計時間ミリ秒 (並列時のスループット算出
+                に使う — 対局ごとの elapsed_ms の総和とは一致しない)．
+        """
+
+        records: list[dict[str, Any]]
+        summary: dict[str, Any]
+        wall_ms: int
+
+    def run(self, option: SelfplayOption) -> SelfplayResult:
+        """自己対局を実行し対局結果と集計を返す．
 
         Args:
             option: 自己対局オプション．
 
         Returns:
-            対局ごとの dict: ``{game_index, sfen, moves, winner
-            ("black"/"white"/None), reason, black_player ("a"/"b" — A/B
-            対戦時の色交代記録．CLI の純粋自己対局では常に "a"), plies,
-            playouts, elapsed_ms}``．
+            [`SelfplayResult`]．``records`` の 1 件は ``{game_index, sfen,
+            moves, winner ("black"/"white"/None), reason, black_player
+            ("a"/"b" — A/B 対戦時の色交代記録．純粋自己対局では常に "a"),
+            plies, playouts, reused_moves, carried_visits, elapsed_ms,
+            remaining_ms}``．
 
         Raises:
             RuntimeError: 設定不正・モデルロード失敗・対局中の内部エラー
                 (Rust 側から伝播する)．
+            ValueError: 未知の ``ab_mode``，または持ち時間なしの
+                ``ab_mode="horizon"`` (Rust 側から伝播する)．
         """
         logger.info(
             "Starting selfplay: %d game(s), parallel=%d",
             option.games,
             option.parallel,
         )
-        records: list[dict[str, Any]] = _rust_run_selfplay(
+        started = time.monotonic()
+        result: dict[str, Any] = _rust_run_selfplay(
             model_path=(
                 str(option.model_path)
                 if option.model_path is not None
@@ -145,8 +196,23 @@ class SelfplayRunner:
             leaf_mate=option.leaf_mate,
             leaf_mate_nodes=option.leaf_mate_nodes,
             leaf_mate_threads=option.leaf_mate_threads,
+            min_think_ms=option.min_think_ms,
+            ab_mode=option.ab_mode,
+            playouts_b=option.playouts_b,
+            horizon_moves=option.horizon_moves,
+            horizon_moves_b=option.horizon_moves_b,
+            alternate_colors=option.alternate_colors,
+            clock_ms=option.clock_ms,
+            byoyomi_ms=option.byoyomi_ms,
+            inc_ms=option.inc_ms,
         )
+        wall_ms = int((time.monotonic() - started) * 1000)
+        records: list[dict[str, Any]] = result["records"]
         logger.info(
             "Selfplay finished: %d game(s)", len(records)
         )
-        return records
+        return SelfplayRunner.SelfplayResult(
+            records=records,
+            summary=result["summary"],
+            wall_ms=wall_ms,
+        )

--- a/src/maou/infra/console/selfplay.py
+++ b/src/maou/infra/console/selfplay.py
@@ -1,7 +1,7 @@
 import json
 import logging
-from collections import Counter
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -166,6 +166,89 @@ logger: logging.Logger = logging.getLogger(__name__)
     required=False,
 )
 @click.option(
+    "--clock-ms",
+    help="Real-clock mode: initial time per side in milliseconds "
+    "(0 = off). Mutually exclusive with --playouts/--movetime-ms and "
+    "requires --parallel 1, because time spent is measured on the wall "
+    "clock. This is the mode that exercises the time strategy.",
+    type=int,
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--byoyomi-ms",
+    help="Byoyomi in milliseconds (real-clock mode only).",
+    type=int,
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--inc-ms",
+    help="Fischer increment per move in milliseconds (real-clock mode "
+    "only).",
+    type=int,
+    default=0,
+    show_default=True,
+    required=False,
+)
+@click.option(
+    "--min-think-ms",
+    help="Minimum thinking time per move in milliseconds (engine "
+    "default 100). Only meaningful in real-clock mode.",
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--ab-mode",
+    help="Play an A/B match instead of plain self-play: player A runs "
+    "the lever on, player B off, everything else identical. "
+    "'subtree' = subtree reuse, 'maxmoves' = in-search draw terminal, "
+    "'budget' = same config with a smaller budget for B (harness sanity "
+    "check), 'horizon' = time-strategy horizon (needs --clock-ms).",
+    type=click.Choice(
+        ["subtree", "maxmoves", "budget", "horizon"]
+    ),
+    default=None,
+    required=False,
+)
+@click.option(
+    "--playouts-b",
+    help="Per-move playout budget for player B (--ab-mode budget; "
+    "defaults to one eighth of --playouts).",
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--horizon",
+    help="Assumed remaining moves used to split the clock, player A "
+    "(--ab-mode horizon; defaults to the engine value).",
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--horizon-b",
+    help="Assumed remaining moves for player B (--ab-mode horizon; "
+    "default 25).",
+    type=int,
+    default=None,
+    required=False,
+)
+@click.option(
+    "--alternate-colors/--no-alternate-colors",
+    type=bool,
+    is_flag=True,
+    help="Swap colors every game and let the pair (2n, 2n+1) share one "
+    "opening sequence, so the pair comparison cancels opening variance "
+    "(default: on when --ab-mode is given).",
+    default=None,
+    required=False,
+)
+@click.option(
     "--root-dfpn/--no-root-dfpn",
     type=bool,
     is_flag=True,
@@ -266,6 +349,15 @@ def selfplay(
     resign_value: int,
     resign_consecutive: int,
     opening_script: str | None,
+    clock_ms: int,
+    byoyomi_ms: int,
+    inc_ms: int,
+    min_think_ms: int | None,
+    ab_mode: str | None,
+    playouts_b: int | None,
+    horizon: int | None,
+    horizon_b: int | None,
+    alternate_colors: bool | None,
     root_dfpn: bool,
     root_dfpn_nodes: int,
     root_dfpn_depth: int,
@@ -285,6 +377,13 @@ def selfplay(
     the model is loaded and warmed up exactly once. Game termination
     (nyugyoku declaration, sennichite incl. perpetual check, max moves,
     resignation) uses the same implementation as the USI engine.
+
+    With ``--ab-mode`` the run becomes an A/B match: player A plays the
+    lever on, player B off, and everything else stays identical. The
+    summary then reports A's score with a Wilson 95% interval, the Elo
+    conversion, the paired (color-swapped) statistics and how much the
+    mechanism actually engaged — a win rate alone cannot separate "no
+    effect" from "the mechanism never fired".
 
     Args:
         model_path: Path to the ONNX model file (mock evaluator if
@@ -306,6 +405,15 @@ def selfplay(
         resign_value: Resign win-rate threshold in permille (0 = never).
         resign_consecutive: Consecutive below-threshold moves to resign.
         opening_script: Forced opening moves in USI notation.
+        clock_ms: Real-clock mode initial time per side (0 = off).
+        byoyomi_ms: Byoyomi in milliseconds (real-clock mode).
+        inc_ms: Fischer increment per move (real-clock mode).
+        min_think_ms: Minimum thinking time per move.
+        ab_mode: Lever compared in an A/B match (None = plain self-play).
+        playouts_b: Player B playout budget (``--ab-mode budget``).
+        horizon: Player A assumed remaining moves (``--ab-mode horizon``).
+        horizon_b: Player B assumed remaining moves.
+        alternate_colors: Swap colors per game and pair the openings.
         root_dfpn: Run dfpn mate search on the root position in parallel.
         root_dfpn_nodes: Node budget for the root dfpn mate search.
         root_dfpn_depth: Search depth limit for the root dfpn mate search.
@@ -317,7 +425,7 @@ def selfplay(
         trt_cache_dir: TensorRT engine cache directory.
         quiet: Suppress per-game progress lines.
     """
-    records = selfplay_interface.selfplay(
+    result = selfplay_interface.selfplay(
         model_path=model_path,
         games=games,
         parallel=parallel,
@@ -345,51 +453,125 @@ def selfplay(
         cuda=cuda,
         tensorrt=tensorrt,
         trt_engine_cache_dir=trt_cache_dir,
+        min_think_ms=min_think_ms,
+        ab_mode=ab_mode,
+        playouts_b=playouts_b,
+        horizon_moves=horizon,
+        horizon_moves_b=horizon_b,
+        alternate_colors=alternate_colors,
+        clock_ms=clock_ms,
+        byoyomi_ms=byoyomi_ms,
+        inc_ms=inc_ms,
     )
 
     if output is not None:
         with output.open("w", encoding="utf-8") as f:
-            for record in records:
+            for record in result.records:
                 f.write(
                     json.dumps(record, ensure_ascii=False)
                     + "\n"
                 )
         logger.info(
             "Wrote %d game record(s) to %s",
-            len(records),
+            len(result.records),
             output,
         )
 
-    winners = Counter(str(r["winner"]) for r in records)
-    reasons = Counter(str(r["reason"]) for r in records)
-    total_plies = sum(int(r["plies"]) for r in records)
-    total_playouts = sum(int(r["playouts"]) for r in records)
-    total_ms = sum(int(r["elapsed_ms"]) for r in records)
-    click.echo(f"games: {len(records)}")
+    _echo_summary(
+        result.summary,
+        wall_ms=result.wall_ms,
+        parallel=parallel,
+        ab_mode=ab_mode,
+    )
+
+
+def _elo(value: float | None) -> str:
+    """Elo 値の表示文字列 (0% / 100% は発散するため None = "n/a")."""
+    return f"{value:+.0f}" if value is not None else "n/a"
+
+
+def _echo_summary(
+    summary: dict[str, Any],
+    *,
+    wall_ms: int,
+    parallel: int,
+    ab_mode: str | None,
+) -> None:
+    """Print the run summary produced by the Rust aggregator.
+
+    Args:
+        summary: Aggregated result (``maou_usi::ab::summarize``).
+        wall_ms: Wall-clock duration of the whole run in milliseconds.
+        parallel: Number of games played concurrently.
+        ab_mode: Lever compared in the A/B match, if any.
+    """
+    total_playouts = int(summary["total_playouts"])
+    click.echo(f"games: {summary['games']}")
     click.echo(
         "results: "
-        f"black {winners.get('black', 0)} / "
-        f"white {winners.get('white', 0)} / "
-        f"draw {winners.get('None', 0)}"
+        f"black {summary['black_wins']} / "
+        f"white {summary['white_wins']} / "
+        f"draw {summary['draws']}"
     )
     click.echo(
         "reasons: "
         + ", ".join(
-            f"{k} {v}" for k, v in sorted(reasons.items())
+            f"{k} {v}"
+            for k, v in sorted(summary["reasons"].items())
         )
     )
     click.echo(
-        f"plies: {total_plies} total, playouts: {total_playouts} total, "
-        f"game time: {total_ms / 1000.0:.1f}s summed"
+        f"plies: {summary['total_plies']} total, "
+        f"playouts: {total_playouts} total, "
+        f"game time: {int(summary['total_game_ms']) / 1000.0:.1f}s summed"
     )
-    reused = sum(int(r["reused_moves"]) for r in records)
-    carried = sum(int(r["carried_visits"]) for r in records)
+    # 並列スループット: 分母は wall clock (対局ごとの合計ではない)．
+    # --parallel を振ってこの値が伸びるかがバッチ aggregator 採否の材料
+    wall_s = wall_ms / 1000.0
+    click.echo(
+        f"throughput: {total_playouts / wall_s if wall_s else 0.0:.1f} "
+        f"playouts/s over {wall_s:.1f}s wall clock (parallel={parallel})"
+    )
+    carried = int(summary["carried_visits"])
     pct = (
         100.0 * carried / total_playouts
         if total_playouts
         else 0.0
     )
     click.echo(
-        f"subtree reuse: {reused} move(s) warm-started, "
+        f"subtree reuse: {summary['reused_moves']} move(s) warm-started, "
         f"{carried} visits carried over ({pct:.1f}% of playouts)"
     )
+
+    ab = summary.get("ab")
+    if ab is None:
+        return
+    click.echo(f"A/B mode: {ab_mode} (A = lever on, B = off)")
+    click.echo(
+        f"A result: {ab['wins']}W {ab['draws']}D {ab['losses']}L"
+    )
+    click.echo(
+        f"A score: {ab['score']:.1f}/{summary['games']} = "
+        f"{100.0 * ab['score_rate']:.1f}% "
+        f"(Wilson 95% CI [{100.0 * ab['ci_lo']:.1f}%, "
+        f"{100.0 * ab['ci_hi']:.1f}%])"
+    )
+    click.echo(
+        f"A Elo: {_elo(ab['elo'])} "
+        f"[{_elo(ab['elo_lo'])}, {_elo(ab['elo_hi'])}]"
+    )
+    if ab["pairs"]:
+        click.echo(
+            f"paired: {ab['pairs']} pairs, "
+            f"mean {ab['paired_mean']:+.3f} "
+            f"(SE {ab['paired_se']:.3f}), "
+            f"t = {ab['paired_t']:+.2f}, "
+            f"A ahead in {ab['pairs_a_ahead']}/{ab['pairs']} "
+            f"(tied {ab['pairs_tied']})"
+        )
+    if ab["time_left_a_ms"] is not None:
+        click.echo(
+            "time left at end (avg): "
+            f"A {ab['time_left_a_ms'] / 1000.0:.1f}s / "
+            f"B {ab['time_left_b_ms'] / 1000.0:.1f}s"
+        )

--- a/src/maou/interface/selfplay.py
+++ b/src/maou/interface/selfplay.py
@@ -2,9 +2,8 @@
 
 import logging
 from pathlib import Path
-from typing import Any
 
-from maou.app.usi.selfplay import SelfplayRunner
+from maou.app.usi.selfplay import AB_MODES, SelfplayRunner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -38,7 +37,16 @@ def selfplay(
     cuda: bool = False,
     tensorrt: bool = False,
     trt_engine_cache_dir: Path | None = None,
-) -> list[dict[str, Any]]:
+    min_think_ms: int | None = None,
+    ab_mode: str | None = None,
+    playouts_b: int | None = None,
+    horizon_moves: int | None = None,
+    horizon_moves_b: int | None = None,
+    alternate_colors: bool | None = None,
+    clock_ms: int | None = None,
+    byoyomi_ms: int | None = None,
+    inc_ms: int | None = None,
+) -> SelfplayRunner.SelfplayResult:
     """in-process 自己対局を実行して対局結果のリストを返す．
 
     Args:
@@ -69,16 +77,51 @@ def selfplay(
         cuda: CUDA Execution Provider を使うか．
         tensorrt: TensorRT Execution Provider を使うか．
         trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
+        min_think_ms: 最低思考時間ミリ秒 (None = エンジン既定)．
+        ab_mode: A/B 対戦のレバー (subtree/maxmoves/budget/horizon．
+            None = 純粋自己対局)．
+        playouts_b: ab_mode="budget" の B 側予算 (None = A の 1/8)．
+        horizon_moves: ab_mode="horizon" の A 側想定残り手数．
+        horizon_moves_b: 同 B 側想定残り手数．
+        alternate_colors: 先後交代 + ペア開局 (None = ab_mode 指定時 True)．
+        clock_ms: 持ち時間モードの初期持ち時間ミリ秒 (0/None = 無効)．
+        byoyomi_ms: 秒読みミリ秒．
+        inc_ms: 1 手加算ミリ秒．
 
     Returns:
-        対局 index 順の対局結果 dict のリスト．
+        対局結果 (records) + 集計 (summary) + 壁時計時間 (wall_ms)．
 
     Raises:
-        ValueError: playouts と movetime_ms を同時指定した場合．
+        ValueError: 探索予算の指定が排他条件を満たさない場合，未知の
+            ab_mode，持ち時間モードと parallel > 1 の併用．
     """
-    if playouts is not None and movetime_ms is not None:
+    budgets = [
+        name
+        for name, value in (
+            ("playouts", playouts),
+            ("movetime_ms", movetime_ms),
+            ("clock_ms", clock_ms or None),
+        )
+        if value is not None
+    ]
+    if len(budgets) > 1:
         raise ValueError(
-            "playouts と movetime_ms は同時に指定できない"
+            "探索予算は playouts / movetime_ms / clock_ms の"
+            f"いずれか 1 つだけ指定できる (指定: {', '.join(budgets)})"
+        )
+    if ab_mode is not None and ab_mode not in AB_MODES:
+        raise ValueError(
+            f"未知の ab_mode: {ab_mode} "
+            f"({' | '.join(AB_MODES)})"
+        )
+    if ab_mode == "horizon" and not clock_ms:
+        raise ValueError(
+            "ab_mode=horizon は持ち時間モード (clock_ms > 0) が必要"
+        )
+    if clock_ms and parallel > 1:
+        # 消費時間を壁時計で測るため，同時対局の CPU 競合で歪む
+        raise ValueError(
+            "持ち時間モード (clock_ms) は parallel=1 でのみ使える"
         )
     option = SelfplayRunner.SelfplayOption(
         model_path=model_path,
@@ -108,5 +151,14 @@ def selfplay(
         cuda=cuda,
         tensorrt=tensorrt,
         trt_engine_cache_dir=trt_engine_cache_dir,
+        min_think_ms=min_think_ms,
+        ab_mode=ab_mode,
+        playouts_b=playouts_b,
+        horizon_moves=horizon_moves,
+        horizon_moves_b=horizon_moves_b,
+        alternate_colors=alternate_colors,
+        clock_ms=clock_ms,
+        byoyomi_ms=byoyomi_ms,
+        inc_ms=inc_ms,
     )
     return SelfplayRunner().run(option)

--- a/tests/maou/infra/console/test_selfplay_cli.py
+++ b/tests/maou/infra/console/test_selfplay_cli.py
@@ -97,3 +97,109 @@ def test_selfplay_rejects_conflicting_budgets() -> None:
         ["--playouts", "16", "--movetime-ms", "100"],
     )
     assert result.exit_code != 0
+
+
+def test_selfplay_reports_throughput() -> None:
+    """壁時計ベースの playouts/秒 が出る (並列スケール計測の材料)．"""
+    result = CliRunner().invoke(
+        selfplay, ["--games", "1", *_FAST]
+    )
+    assert result.exit_code == 0, result.output
+    assert "throughput:" in result.output
+    assert "playouts/s" in result.output
+    assert "parallel=1" in result.output
+
+
+def test_selfplay_ab_mode_reports_a_view_statistics(
+    tmp_path: Path,
+) -> None:
+    """--ab-mode で A 視点の勝率統計とペア比較が出る．"""
+    out = tmp_path / "ab.jsonl"
+    result = CliRunner().invoke(
+        selfplay,
+        [
+            "--games",
+            "2",
+            "--ab-mode",
+            "subtree",
+            "--opening-random-plies",
+            "2",
+            "--seed",
+            "5",
+            "--output",
+            str(out),
+            *_FAST,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "A/B mode: subtree" in result.output
+    assert "Wilson 95% CI" in result.output
+    assert "A Elo:" in result.output
+    assert "paired: 1 pairs" in result.output
+
+    # 色交代は ab-mode の既定 on (ペア 2 局で先後が入れ替わる)
+    records = [
+        json.loads(line)
+        for line in out.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [r["black_player"] for r in records] == ["a", "b"]
+
+
+def test_selfplay_clock_mode_tracks_remaining_time(
+    tmp_path: Path,
+) -> None:
+    """持ち時間モードで残り時間が記録される (時間配分の診断)．"""
+    out = tmp_path / "clock.jsonl"
+    result = CliRunner().invoke(
+        selfplay,
+        [
+            "--games",
+            "1",
+            "--clock-ms",
+            "2000",
+            "--inc-ms",
+            "50",
+            "--max-moves",
+            "8",
+            "--node-capacity",
+            "4096",
+            "--no-root-dfpn",
+            "--no-leaf-mate",
+            "--quiet",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    record = json.loads(
+        out.read_text(encoding="utf-8").splitlines()[0]
+    )
+    remaining = record["remaining_ms"]
+    assert len(remaining) == 2
+    assert all(0 <= ms <= 2000 + 50 * 8 for ms in remaining)
+
+
+def test_selfplay_rejects_clock_with_playouts() -> None:
+    """持ち時間モードと playout 予算は排他．"""
+    result = CliRunner().invoke(
+        selfplay,
+        ["--playouts", "16", "--clock-ms", "1000"],
+    )
+    assert result.exit_code != 0
+
+
+def test_selfplay_rejects_horizon_without_clock() -> None:
+    """--ab-mode horizon は持ち時間モードが必須．"""
+    result = CliRunner().invoke(
+        selfplay, ["--ab-mode", "horizon", *_FAST]
+    )
+    assert result.exit_code != 0
+
+
+def test_selfplay_rejects_clock_with_parallel() -> None:
+    """持ち時間モードは壁時計依存なので parallel=1 限定．"""
+    result = CliRunner().invoke(
+        selfplay,
+        ["--clock-ms", "1000", "--parallel", "2"],
+    )
+    assert result.exit_code != 0

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.56.0"
+version = "0.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 背景

USI campaign の残件 3 件は DevContainer (CPU) では閉じられない:

| 残件 | 閉じられない理由 |
|---|---|
| 未決 1 TimeStrategy 定数 | CPU 約 23 playouts/秒では「時計が効くが枯渇しない」regime を作れない |
| 未決 5 バッチ aggregator | CPU では `Mutex<Session>` が上限で並列スケール 0 |
| GUI 実機検証 | GUI を動かせる環境が手元にない |

GPU が使えるのは Colab (L4) のみで，そこでは **Release `latest` の事前ビルド
wheel** を使う．ところが A/B ハーネス (`--mode horizon` 等) は Rust example
`selfplay_ab` にしかなく **wheel に含まれていない**ため，未決 1/5 を Colab で
測れない状態だった．本 PR はその穴を塞ぎ，検証手順を文書化する．

## 変更

### Rust — `maou_usi::ab` (新設)

- `build_ab`: レバーの on/off を A/B の `EngineConfig` へ割る (差分がレバー
  1 つだけであることをこの関数が保証する)
- `summarize`: 勝率だけでなく **Wilson 95% CI / Elo / ペア差分の t 値 /
  機構の発火量 (引き継ぎ訪問数・残り持ち時間)** を出す．n=40 の勝率だけでは
  「効果なし」と「機構が動いていない」を区別できないため
- example `selfplay_ab` と PyO3 の双方がこの単一実装を呼ぶ (数値の定義が一致)

### CLI — `maou selfplay`

- `--ab-mode subtree|maxmoves|budget|horizon` / `--playouts-b` /
  `--horizon` / `--horizon-b`
- 持ち時間モード `--clock-ms` / `--byoyomi-ms` / `--inc-ms` /
  `--min-think-ms` (単体でも使える = 低優先だった CLI 露出の消化)
- `--alternate-colors/--no-alternate-colors` (A/B 時は既定 on)
- サマリに **wall clock ベースの `throughput:` (playouts/秒)** を追加 —
  `--parallel` を振って並列スケールを測る材料 (未決 5 の判定に使う)
- JSONL に `remaining_ms` (終局時の残り持ち時間) を追加

### docs (reviews/2026-07-26-gpu-verification-procedure.md — applied)

- `docs/design/usi-engine/verification.md` 新設: Colab L4 手順 / 未決 1 の
  **regime ゲート**と判定基準 / 未決 5 の決定規則 / ハーネス再較正 /
  headless smoke (go mate・ponder・keep-alive) / **GUI 実機検証を将来課題と
  して明記** (環境要件 + チェックリスト)
- `index.md` §12 に「現状」列 (3/4/6 決着・1/5 GPU 待ち・2 GUI 待ち)
- `docs/commands/selfplay.md` に新オプションと A/B サマリの説明

## テスト

- Rust: `maou_usi` 110 passed (ab モジュール 10 件を新設)．clippy / fmt clean
- Python: 1704 passed / 47 skipped．ruff / isort / mypy clean
- CLI smoke: `--ab-mode subtree` / `--ab-mode horizon --clock-ms` を mock で実行
- **verification.md の smoke スクリプトを実際に流して検証**した (初版に
  ponder 予想手の取り出しミスがあり修正済み — `bestmove <手> ponder <予想手>`)

版数: maou 0.57.0 / maou_usi 0.14.0 / maou_rust 0.31.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)