### PR TITLE
fix(dfpn): STRICT VERIFY の成功ログを DFPN_STATS gate 下へ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.9.0"
+version = "5.9.1"
 dependencies = [
  "arrayvec",
  "rustc-hash",

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.9.0"
+version = "5.9.1"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/search/mod.rs
+++ b/rust/maou_shogi/src/dfpn/search/mod.rs
@@ -794,14 +794,21 @@ impl DfPnSolver {
                     )
                 }
                 Some(d) => {
-                    eprintln!(
-                        "[dfpn] STRICT VERIFY Some({}) (root mate_len={}, budget_left={}, wall={:.2}s, tier={})",
-                        d,
-                        last.len().len(),
-                        budget,
-                        verify_wall.as_secs_f64(),
-                        tier
-                    );
+                    // 成功時の診断は DFPN_STATS gate 下 (他の統計と同じ扱い)．leaf-mate 統合
+                    // 探索では 1 手あたり数千回 solve が走り，proven のたびに出すと stderr が
+                    // 溢れて自己対局の進捗行や A/B サマリを流し去ってしまう (実測: 24 局で
+                    // 数万行)．偽証明・budget 枯渇の警告 (下の None 分岐) は soundness の
+                    // アラームなので gate しない．
+                    if dfpn_stats_enabled() {
+                        eprintln!(
+                            "[dfpn] STRICT VERIFY Some({}) (root mate_len={}, budget_left={}, wall={:.2}s, tier={})",
+                            d,
+                            last.len().len(),
+                            budget,
+                            verify_wall.as_secs_f64(),
+                            tier
+                        );
+                    }
                     // PV は pv_choice (verify が記録した無駄合い除外後の最適手) を辿って復元済．
                     // 最短確定手順は result 側の moves に入るため best_mate は空．
                     (


### PR DESCRIPTION
## 問題

実モデルでの自己対局 (Colab L4, 24 局) で `[dfpn] STRICT VERIFY Some(N) ...`
が数万行 stderr に出て，**対局進捗行と A/B サマリが流し去られた** (Colab の
出力が末尾 5000 行に切り詰められ per-game の記録が失われた)．

出所は leaf-mate 統合探索: 1 手あたり数千回 dfpn solve が走り，proven の
たびに 1 行出る．他の dfpn 診断 (`[dfpn] root ...` 等) は `DFPN_STATS` env で
gate 済みなのに，この行だけ無 gate だった．

## 変更

- `verify_proof` 成功時の `STRICT VERIFY Some(d)` を `dfpn_stats_enabled()`
  (= `DFPN_STATS` env) 下へ移動．
- **偽証明 (`None`) / budget 枯渇 (`INCONCLUSIVE`) の警告は無 gate のまま** —
  soundness のアラームであり，出続けるべきもの．

## 検証

- canonical RAN (dfpn 接触の TRIPWIRE): `DFPN_STATS=1` で 29te =
  **396,516 nodes / STRICT Some(29) / PV は記録と bit-identical**．
- `DFPN_STATS` なしでは `STRICT VERIFY` が 0 行 (gate 有効)．
- `cargo test -p maou_shogi` 196 passed，pre-commit 全 Passed．

版数: maou_shogi 5.9.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)