### PR TITLE
fix(selfplay,search): 時間制の探索が機能しない 2 つの不具合を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.57.0"
+version = "0.57.1"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/search.rs
+++ b/rust/maou_search/src/search.rs
@@ -1075,6 +1075,10 @@ fn select_leaf<E: Evaluator>(shared: &Shared<'_, E>) -> Selection {
     }
 }
 
+/// 終端連続時に期限を確認する間隔 (backprop 回数)．`Instant::now()` の頻度を
+/// 抑えつつ，時間制の停止が終端の連続で無限に遅れるのを防ぐ．
+const DEADLINE_CHECK_INTERVAL: u32 = 64;
+
 /// 探索スレッドのメインループ．
 fn worker<E: Evaluator>(shared: &Shared<'_, E>) {
     let batch_size = shared.opts.batch_size.max(1);
@@ -1095,6 +1099,12 @@ fn worker<E: Evaluator>(shared: &Shared<'_, E>) {
         items.clear();
         let mut had_collision = false;
 
+        // 終端ばかりで葉が集まらない局面 (in-search 引き分け終端が目前など) では
+        // このループが評価に到達せず回り続ける．playout 制なら complete_playouts が
+        // 上限で止めるが，**時間制は上限が無限**なので内側でも期限を見ないと
+        // 停止しない (時間制 go が返らなくなる)．Instant::now() を毎回叩かない
+        // よう間引く
+        let mut terminal_hits = 0u32;
         while items.len() < batch_size && !shared.stopped() {
             match select_leaf(shared) {
                 Selection::Leaf { path, item } => {
@@ -1103,6 +1113,10 @@ fn worker<E: Evaluator>(shared: &Shared<'_, E>) {
                 }
                 Selection::Backpropped => {
                     shared.complete_playouts(1);
+                    terminal_hits += 1;
+                    if terminal_hits.is_multiple_of(DEADLINE_CHECK_INTERVAL) {
+                        shared.check_deadline();
+                    }
                 }
                 Selection::Collision => {
                     shared.collisions.fetch_add(1, Ordering::Relaxed);

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/selfplay.rs
+++ b/rust/maou_usi/src/selfplay.rs
@@ -413,6 +413,12 @@ fn play_game(
                 },
                 _ => go.clone(),
             };
+            // transport 規約: `go` の直前に stop フラグをクリアする (stdio.rs の
+            // reader と同じ役割を driver が担う)．怠ると observer が時間切れで
+            // 立てた stop が次の go まで残り，2 手目以降の探索が即座に打ち切られて
+            // playouts=0 になる (時間制 go = movetime / 持ち時間モードのみ発現．
+            // playout 制では observer が stop を立てないため露見しなかった)．
+            agent.stop_handle().store(false, Ordering::Release);
             let move_started = Instant::now();
             let out = agent
                 .handle(GuiCommand::Go(go))
@@ -574,6 +580,41 @@ mod tests {
         assert_eq!(o.reason, GameEndReason::MaxMoves);
         assert_eq!(o.winner, None);
         assert_eq!(o.moves.len(), 4);
+    }
+
+    /// 時間制 (`movetime`) でも 3 手目以降が探索される (stop フラグ持ち越し回帰)．
+    ///
+    /// driver が `go` の前に stop をクリアしないと，1 手目の観測者が時間切れで
+    /// 立てた stop が残り 2 手目以降が playouts=0 で即返る．手数を伸ばしても
+    /// 総 playout が増えないことで検出する (機械速度に依らない比率判定)．
+    #[test]
+    fn test_selfplay_movetime_searches_every_move() {
+        let timed = |max_moves: u32| -> u64 {
+            let config = SelfplayConfig {
+                // 時間制では playout 数が青天井なので木のプールを広めに取る
+                // (test_engine の 4096 では GC が回り続けて計測にならない)
+                engine: EngineConfig {
+                    node_capacity: Some(1 << 16),
+                    ..test_engine()
+                },
+                games: 1,
+                playouts: None,
+                movetime_ms: Some(20),
+                max_moves,
+                // in-search 引き分け終端は別バグ (時間制 + 終端間近で無限ループ)
+                // を踏むため本テストでは切る．ここで見たいのは stop 規約のみ
+                sync_max_moves_to_draw: false,
+                ..SelfplayConfig::default()
+            };
+            run_selfplay(&config, None).expect("mock 自己対局は成功する")[0].playouts
+        };
+        let short = timed(2);
+        let long = timed(10);
+        assert!(short > 0, "1-2 手目は素の探索なので playout が出る");
+        assert!(
+            long > short * 3,
+            "手数を 5 倍にしたら playout も増えるはず (short={short}, long={long})"
+        );
     }
 
     #[test]

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.57.0"
+version = "0.57.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 発見の経緯

GPU 検証 (①-b: `--movetime-ms 500` で実効 playouts/手 を測る) で **1 手 16
playouts** という異常値が出た．追跡した結果，**時間制の自己対局は 2 手目
以降まったく探索していなかった**ことが判明した．

`③ 未決 1 (TimeStrategy horizon A/B)` はこのモードで測る予定だったので，
このまま回していれば **完全なノイズを計測して「有意差なし」と結論する**
ところだった．

## 不具合 1: driver が stop フラグをクリアしていない

`Agent::stop_handle` の規約は「transport が `go` 行で false，`stop` 行で
true を store する」(stdio.rs はそうしている)．自己対局 driver はこれを
していなかったため，1 手目で observer が時間切れで立てた stop が残り，
2 手目以降の探索が即 return して `playouts=0` になっていた．

playout 制では observer が stop を立てない (時間予算が無い) ため露見せず，
④ の並列計測などはすべて正常だった．

## 不具合 2: 時間制で葉が集まらないと worker が止まらない

1 を直すと `test_selfplay_clock_mode_runs_and_consumes_time` が hang した．
worker の葉収集ループは

```rust
while items.len() < batch_size && !shared.stopped() { select_leaf(...) }
```

で，終端ばかりで葉が集まらない局面 (in-search 引き分け終端が目前など) では
評価に到達せず回り続ける．playout 制は `complete_playouts` が上限で停止
フラグを立てるが，**時間制は上限が無限**なので誰も止めない．終端 backprop
64 回ごとに `check_deadline()` を見るようにした (`Instant::now()` を毎回
叩かないよう間引き)．

**実戦でも踏み得る**: `MaxMovesToDraw` を設定した対局 (電竜戦 512) で手数
上限に近づくと `go` が返らず時間切れになる．既存のテストが通っていたのは，
不具合 1 のせいで探索が即 return していたため (誤った理由での green)．

## 検証

- 修正後: `movetime 300ms × 8 手` = 322,941 playouts (40k/手)．持ち時間
  モードも残り時間が正しく減る (`remaining_ms [1692, 1895]`)
- 回帰テスト追加: 手数を 5 倍にしたら総 playout も増えること (機械速度に
  依らない比率判定)
- **canonical RAN** (search.rs 接触の TRIPWIRE): 29te = 396,516 nodes /
  PV bit-identical，39te = 17,593,615 nodes / STRICT Some(39) — 記録と一致
- maou_usi 111 passed / maou_search 76 + parity 2 passed / clippy・fmt clean

版数: maou 0.57.1 / maou_search 0.22.1 / maou_usi 0.14.1
(Python 版数も上げたのは wheel 名を変えて Colab の pip が確実に入れ替える
ようにするため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)