### PR TITLE
fix(selfplay): 持ち時間モードに driver 遅延分のマージンを入れる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.57.1"
+version = "0.57.2"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -23,7 +23,7 @@ use crate::agent::{
 use crate::protocol::CheckmateResult;
 
 /// 進捗スナップショットを observer へ渡すポーリング間隔．
-const POLL_INTERVAL: Duration = Duration::from_millis(100);
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// 保持する評価器 (mock または ONNX)．自己対局 driver はこれを `Arc` で全対局
 /// に共有する (モデルロード/warmup をプロセス内 1 回に — 設計 §9)．

--- a/rust/maou_usi/src/selfplay.rs
+++ b/rust/maou_usi/src/selfplay.rs
@@ -184,6 +184,15 @@ pub struct GameOutcome {
     pub remaining_ms: Option<[u64; 2]>,
 }
 
+/// 持ち時間モードで確保する最低マージン (ミリ秒)．
+///
+/// 呼び出し側の設定値と driver のポーリング粒度 ([`crate::backend::POLL_INTERVAL`])
+/// の大きい方を採る — 探索の停止要求はポーリングでしか届かないため，最悪
+/// 1 周期分は予算を超えて走る．
+fn clock_margin_ms(configured_ms: u64) -> u64 {
+    configured_ms.max(crate::backend::POLL_INTERVAL.as_millis() as u64)
+}
+
 /// SplitMix64 (シード決定的な軽量乱数．依存を増やさない)．
 struct SplitMix64(u64);
 
@@ -236,6 +245,14 @@ pub fn run_selfplay(
         e.usi_ponder = false;
         if config.sync_max_moves_to_draw {
             e.max_moves_to_draw = config.max_moves;
+        }
+        if config.clock.is_some() {
+            // 持ち時間モードは実測消費で時計を引くため，**driver 自身の遅れ**を
+            // マージンとして引かないと残り僅少で踏み越えて時間切れ負けになる
+            // (実測: 30s+0.5s の 4 局で 3 局が timeout)．遅れの主因は monitor の
+            // ポーリング粒度で，探索はその分だけ hard を超えて走り得る．
+            // GUI 対局の NetworkDelay と同じ役割をここで最低限確保する．
+            e.time.network_delay_ms = clock_margin_ms(e.time.network_delay_ms);
         }
         e
     };
@@ -614,6 +631,21 @@ mod tests {
         assert!(
             long > short * 3,
             "手数を 5 倍にしたら playout も増えるはず (short={short}, long={long})"
+        );
+    }
+
+    /// 持ち時間モードのマージンは driver のポーリング粒度を下回らない．
+    ///
+    /// 0 のままだと残り僅少の手で予算を踏み越えて時間切れ負けになる
+    /// (GPU 実測: 30s+0.5s の 4 局中 3 局が timeout)．
+    #[test]
+    fn test_clock_margin_covers_poll_interval() {
+        let poll = crate::backend::POLL_INTERVAL.as_millis() as u64;
+        assert_eq!(clock_margin_ms(0), poll, "既定 0 でも最低 1 周期は確保する");
+        assert_eq!(
+            clock_margin_ms(poll + 500),
+            poll + 500,
+            "呼び出し側がより大きなマージンを指定したら尊重する"
         );
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.57.1"
+version = "0.57.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 問題

GPU パイロット (`--clock-ms 30000 --inc-ms 500`, 4 局) で **3 局が
`timeout` (時間切れ負け)** で終わった．`time left at end: A 7.0s / B 0.8s`．

自己対局は「伝送遅延はない」として `network_delay_ms = 0` にしていたが，
**driver 自身が遅れる**: 探索の停止要求は monitor のポーリング (100ms 周期)
でしか届かないため，探索は最悪 1 周期分 hard を超えて走る．残り時間が僅少に
なるとこの超過を吸収できず時計を踏み越える．

GUI 対局では `NetworkDelay` (既定 1000ms) がこの役割を果たしていた．

## 変更

持ち時間モードのときだけ `network_delay_ms` を最低 1 ポーリング周期
(100ms) まで引き上げる (呼び出し側がより大きい値を設定していればそれを尊重)．
純関数 `clock_margin_ms` に切り出して単体テストを付けた．

## 検証

mock・5s + 0.5s/手・40 手 × 2 局:

| | 修正前 | 修正後 |
|---|---|---|
| 終局理由 | timeout 2/2 | **max_moves 2/2** |
| 終局時残り | 0 | 1.2s / 1.5s |

maou_usi 112 passed，clippy・fmt clean．

版数: maou 0.57.2 / maou_usi 0.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)