### PR TITLE
fix(dfpn): 王手手が守備の歩を取ると二歩が解けて偽 1 手詰になる不具合を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,18 @@ cargo test --release -p maou_shogi -- <test_name> --nocapture --ignored
 | `test_counter_check_example` | - | 逆王手詰将棋 mate-7 健全性 |
 | `test_counter_check_diagnostic` | - | 診断用ログ出力 |
 | `test_no_checkmate_counter_check_probe` | 10M nodes | ノード予算プローブ |
+| `test_false_proof_hunt` | 50 nodes/局面 (leaf-mate 相当) | 偽証明 (`STRICT VERIFY None`) ハンター．ランダム対局から局面生成．env `SEED`/`GAMES`/`PLIES`/`NODES`/`MAXHITS` |
+
+dfpn の **偽 1 手詰 (soundness 違反)** を疑うときは `MATE1PLY_VERIFY=1` を付ける．
+1 手詰と申告した手を実 replay で検証し，偽なら
+`[mate1ply] FALSE MATE site=... m=... sfen=...` を出す
+(production が通る fused / near2 / cached full scan の全経路をカバー)．
+`test_false_proof_hunt` と併用すると広域スイープになる:
+
+```bash
+SEED=1 GAMES=200 MATE1PLY_VERIFY=1 cargo test --release -p maou_shogi -- \
+  --test-threads=1 --ignored --nocapture dfpn::tests::test_false_proof_hunt
+```
 
 dfpn テストは各々が大きな置換表 (TT) を alloc するため，**MUST `--test-threads=1`** で実行すること．
 default の並列実行は memory 制約 DevContainer (8GB) で OOM → `signal: 15 SIGTERM` となり，

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.9.1"
+version = "5.9.2"
 dependencies = [
  "arrayvec",
  "rustc-hash",

--- a/reviews/2026-07-27-dfpn-false-proof-test-docs.md
+++ b/reviews/2026-07-27-dfpn-false-proof-test-docs.md
@@ -1,0 +1,67 @@
+---
+title: CLAUDE.md の [SLOW] テスト表に偽証明ハンターを追加し，soundness スイープの回し方を明記
+date: 2026-07-27
+status: pending
+applied_in:
+target:
+  - CLAUDE.md
+risk: low
+reversibility: trivial
+---
+
+# 提案: dfpn 偽証明ハンターと mate1ply soundness スイープを CLAUDE.md へ反映
+
+## Trigger
+
+`fix(dfpn): 王手手が守備の歩を取ると二歩が解けて偽 1 手詰になる不具合を修正`
+(f967499) で以下の 2 つが増えた．どちらも **次に偽証明を追う人が最初に必要とする
+道具**であり，見つけられないと同じ探索を一からやり直すことになる．
+
+1. `rust/maou_shogi/src/dfpn/tests.rs::test_false_proof_hunt` — `**[SLOW]**` /
+   `#[ignore]` の新規テスト．CLAUDE.md の `[SLOW]` 表は「`[SLOW]` フラグが
+   ついているテストは全て `#[ignore]`」と宣言しているため，表に載らないと
+   **宣言と実体が食い違う**．
+2. `MATE1PLY_VERIFY=1` の検証カバレッジ修復 — 従来は production が通る 3 経路
+   (fused look-ahead / near2 / cached full scan) を素通りしており，実際に
+   soundness 違反が起きていたのに検出できなかった．今回全経路に挿したので，
+   **偽 1 手詰の広域スイープが回せるようになった**ことを書き残す価値がある．
+
+## ドキュメント変更内容 (本レビューの承認対象)
+
+### CLAUDE.md §「重いテスト (Rust dfpn) — release ビルド必須」
+
+**(a) `[SLOW]` テスト表に 1 行追加**:
+
+| テスト名 | バジェット | 備考 |
+|---|---|---|
+| `test_false_proof_hunt` | 50 nodes/局面 (leaf-mate 相当) | 偽証明 (`STRICT VERIFY None`) ハンター．ランダム対局から局面生成．env `SEED`/`GAMES`/`PLIES`/`NODES`/`MAXHITS` |
+
+**(b) 表の直後に soundness スイープの回し方を 3 行追記**:
+
+> dfpn の **偽 1 手詰 (soundness 違反)** を疑うときは `MATE1PLY_VERIFY=1` を付ける．
+> 1 手詰と申告した手を実 replay で検証し，偽なら `[mate1ply] FALSE MATE site=... m=... sfen=...`
+> を出す (production が通る fused / near2 / cached full scan の全経路をカバー)．
+> `test_false_proof_hunt` と併用すると広域スイープになる:
+>
+> ```bash
+> SEED=1 GAMES=200 MATE1PLY_VERIFY=1 cargo test --release -p maou_shogi -- \
+>   --test-threads=1 --ignored --nocapture dfpn::tests::test_false_proof_hunt
+> ```
+
+## 代替案と棄却理由
+
+- **docs/design/tsume-solver/ 側に書く**: 診断 env を列挙した節が現状 docs/ に
+  存在せず，新設すると本 PR の範囲を超える．CLAUDE.md の `[SLOW]` 表は既に
+  「テストの回し方」を担っている節なので，そこへ寄せるのが整合的．
+- **何も書かない**: (1) の表は「全て」と宣言しているため，放置すると規約と実体の
+  乖離になる．棄却．
+
+## リスクと理由
+
+- **risk: low** — CLAUDE.md への追記のみ．既存の MUST 規約の変更・削除は無い．
+- **reversibility: trivial** — 追加した表 1 行と直後の 3 行を消すだけ．
+
+## ロールバック
+
+CLAUDE.md の当該表から `test_false_proof_hunt` 行を削除し，直後に追記した
+`MATE1PLY_VERIFY` の節を削除する．

--- a/reviews/2026-07-27-dfpn-false-proof-test-docs.md
+++ b/reviews/2026-07-27-dfpn-false-proof-test-docs.md
@@ -1,8 +1,8 @@
 ---
 title: CLAUDE.md の [SLOW] テスト表に偽証明ハンターを追加し，soundness スイープの回し方を明記
 date: 2026-07-27
-status: pending
-applied_in:
+status: applied
+applied_in: f221561
 target:
   - CLAUDE.md
 risk: low

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.9.1"
+version = "5.9.2"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/board.rs
+++ b/rust/maou_shogi/src/board.rs
@@ -1436,7 +1436,7 @@ impl Board {
                     king_sq,
                     defender,
                     occ_after,
-                    def_occ,
+                    def_occ_after,
                     def_idx,
                     att_idx,
                     &pinned_after,
@@ -1959,6 +1959,16 @@ impl Board {
     ///
     /// between のマスに守備駒を移動または打てるか確認する．
     /// ピンされた駒は合い駒に使えない．
+    ///
+    /// `def_occ_after` は **王手手を指した後**の守備側占有 (王手駒が守備駒を取った場合，
+    /// その駒は除かれている)．守備駒のビットボードは必ずこれでマスクすること — 移動前の
+    /// `piece_bb` をそのまま使うと 2 種の誤りが出る:
+    ///
+    /// - **(a) 完全性**: 取られて盤上に無い駒を移動合駒の要員として数え，詰みを見逃す．
+    /// - **(b) soundness**: 取られた歩を二歩判定に数え，実際には合法な歩の合駒を非合法と
+    ///   誤判定して **偽の 1 手詰**を申告する．王手手自身が守備の歩を取ってその筋の二歩を
+    ///   解消するケースで発火する (例: 香が 1e の歩を取って王手 → 1 筋の二歩が解け，玉と
+    ///   香の間の 1d へ歩を打って受かるのに「詰み」と申告する)．
     #[allow(clippy::too_many_arguments)]
     fn can_interpose_bb(
         &self,
@@ -1966,13 +1976,30 @@ impl Board {
         king_sq: Square,
         defender: Color,
         occ: Bitboard,
-        _def_occ: Bitboard,
+        def_occ_after: Bitboard,
         def_idx: usize,
         _att_idx: usize,
         pinned: &Bitboard,
         _checker_from: Option<Square>,
     ) -> bool {
         let attacker = defender.opponent();
+        // 王手手適用後に盤上に残る守備駒のみを合駒要員/二歩判定に使う (上記 (a)(b))．
+        // between に依存しないためループ外で 1 回だけ求める．
+        let pb = &self.piece_bb[def_idx];
+        let d_pawn = pb[PieceType::Pawn as usize] & def_occ_after;
+        let d_knight = pb[PieceType::Knight as usize] & def_occ_after;
+        let d_silver = pb[PieceType::Silver as usize] & def_occ_after;
+        let d_gold = (pb[PieceType::Gold as usize]
+            | pb[PieceType::ProPawn as usize]
+            | pb[PieceType::ProLance as usize]
+            | pb[PieceType::ProKnight as usize]
+            | pb[PieceType::ProSilver as usize])
+            & def_occ_after;
+        let d_lance = pb[PieceType::Lance as usize] & def_occ_after;
+        let d_horse = pb[PieceType::Horse as usize] & def_occ_after;
+        let d_dragon = pb[PieceType::Dragon as usize] & def_occ_after;
+        let d_bishop = pb[PieceType::Bishop as usize] & def_occ_after;
+        let d_rook = pb[PieceType::Rook as usize] & def_occ_after;
 
         for to in *between {
             // --- 駒打ちによる合い駒 ---
@@ -1994,13 +2021,11 @@ impl Board {
                         (Color::White, PieceType::Knight) if to.row() >= 7 => continue,
                         _ => {}
                     }
-                    // 二歩チェック
-                    if pt == PieceType::Pawn {
-                        let our_pawns = self.piece_bb[defender.index()][PieceType::Pawn as usize];
-                        let file = Bitboard::file_mask(to.col());
-                        if (our_pawns & file).is_not_empty() {
-                            continue;
-                        }
+                    // 二歩チェック (王手手が取った歩は既に盤上に無い → d_pawn で判定する)
+                    if pt == PieceType::Pawn
+                        && (d_pawn & Bitboard::file_mask(to.col())).is_not_empty()
+                    {
+                        continue;
                     }
                     return true; // 合い駒が打てる
                 }
@@ -2009,60 +2034,41 @@ impl Board {
             // --- 駒移動による合い駒 ---
             // 各守備駒が to に移動できるか(ピンされていない駒のみ)
             // 歩
-            if (attack::step_attacks(attacker, PieceType::Pawn, to)
-                & self.piece_bb[def_idx][PieceType::Pawn as usize]
-                & !*pinned)
+            if (attack::step_attacks(attacker, PieceType::Pawn, to) & d_pawn & !*pinned)
                 .is_not_empty()
             {
                 return true;
             }
             // 桂
-            if (attack::step_attacks(attacker, PieceType::Knight, to)
-                & self.piece_bb[def_idx][PieceType::Knight as usize]
-                & !*pinned)
+            if (attack::step_attacks(attacker, PieceType::Knight, to) & d_knight & !*pinned)
                 .is_not_empty()
             {
                 return true;
             }
             // 銀
-            if (attack::step_attacks(attacker, PieceType::Silver, to)
-                & self.piece_bb[def_idx][PieceType::Silver as usize]
-                & !*pinned)
+            if (attack::step_attacks(attacker, PieceType::Silver, to) & d_silver & !*pinned)
                 .is_not_empty()
             {
                 return true;
             }
             // 金 + 成駒
-            let gold_movers = (self.piece_bb[def_idx][PieceType::Gold as usize]
-                | self.piece_bb[def_idx][PieceType::ProPawn as usize]
-                | self.piece_bb[def_idx][PieceType::ProLance as usize]
-                | self.piece_bb[def_idx][PieceType::ProKnight as usize]
-                | self.piece_bb[def_idx][PieceType::ProSilver as usize])
-                & !*pinned;
+            let gold_movers = d_gold & !*pinned;
             if (attack::step_attacks(attacker, PieceType::Gold, to) & gold_movers).is_not_empty() {
                 return true;
             }
             // 馬・龍(ステップ部分) - 玉は除外
-            let step_pieces = (self.piece_bb[def_idx][PieceType::Horse as usize]
-                | self.piece_bb[def_idx][PieceType::Dragon as usize])
-                & !*pinned
-                & !Bitboard::from_square(king_sq);
+            let step_pieces = (d_horse | d_dragon) & !*pinned & !Bitboard::from_square(king_sq);
             let king_step_to = attack::step_attacks(attacker, PieceType::King, to);
             if (king_step_to & step_pieces).is_not_empty() {
                 return true;
             }
             // 香
-            if (attack::lance_attacks(attacker, to, occ)
-                & self.piece_bb[def_idx][PieceType::Lance as usize]
-                & !*pinned)
-                .is_not_empty()
-            {
+            if (attack::lance_attacks(attacker, to, occ) & d_lance & !*pinned).is_not_empty() {
                 return true;
             }
             // 角・馬(スライド)
             if (attack::bishop_attacks(to, occ)
-                & (self.piece_bb[def_idx][PieceType::Bishop as usize]
-                    | self.piece_bb[def_idx][PieceType::Horse as usize])
+                & (d_bishop | d_horse)
                 & !*pinned
                 & !Bitboard::from_square(king_sq))
             .is_not_empty()
@@ -2071,8 +2077,7 @@ impl Board {
             }
             // 飛・龍(スライド)
             if (attack::rook_attacks(to, occ)
-                & (self.piece_bb[def_idx][PieceType::Rook as usize]
-                    | self.piece_bb[def_idx][PieceType::Dragon as usize])
+                & (d_rook | d_dragon)
                 & !*pinned
                 & !Bitboard::from_square(king_sq))
             .is_not_empty()

--- a/rust/maou_shogi/src/dfpn/movegen/mate1ply.rs
+++ b/rust/maou_shogi/src/dfpn/movegen/mate1ply.rs
@@ -48,7 +48,11 @@ impl DfPnSolver {
             if mate_cand_enabled() {
                 record_mate_cand(board, cached, mm, turn);
             }
-            return (mm, !cached.is_empty());
+            let has_checks = !cached.is_empty();
+            if mate1ply_verify() {
+                self.verify_mate1ply_sound(board, mm, "cached_checks");
+            }
+            return (mm, has_checks);
         }
         mate_cand_bump_cache(true, false);
         let moves = self.generate_check_moves(board);
@@ -56,6 +60,9 @@ impl DfPnSolver {
         let mm = board.mate_move_in_1ply(moves.as_slice(), turn);
         if mate_cand_enabled() {
             record_mate_cand(board, moves.as_slice(), mm, turn);
+        }
+        if mate1ply_verify() {
+            self.verify_mate1ply_sound(board, mm, "cached_checks");
         }
         (mm, !moves.is_empty())
     }
@@ -71,11 +78,19 @@ impl DfPnSolver {
         let hash = board.hash;
         let turn = board.turn;
         if let Some(cached) = self.check_cache.get_slice(hash) {
-            return board.mate_move_in_1ply_maxdist(cached, turn, 2);
+            let mm = board.mate_move_in_1ply_maxdist(cached, turn, 2);
+            if mate1ply_verify() {
+                self.verify_mate1ply_sound(board, mm, "near2");
+            }
+            return mm;
         }
         let moves = self.generate_check_moves(board);
         self.check_cache.insert(hash, &moves);
-        board.mate_move_in_1ply_maxdist(moves.as_slice(), turn, 2)
+        let mm = board.mate_move_in_1ply_maxdist(moves.as_slice(), turn, 2);
+        if mate1ply_verify() {
+            self.verify_mate1ply_sound(board, mm, "near2");
+        }
+        mm
     }
 
     /// 敵玉隣接 geometry から候補を構成する look-ahead 1 手詰判定．
@@ -119,6 +134,9 @@ impl DfPnSolver {
                 board.sfen()
             );
         }
+        if mate1ply_verify() {
+            self.verify_mate1ply_sound(board, fused, "fused");
+        }
         fused
     }
 
@@ -156,6 +174,29 @@ impl DfPnSolver {
             }
         }
         bitboard_mate
+    }
+
+    /// `MATE1PLY_VERIFY` 用の **soundness 専用**チェック: 1 手詰と申告した手は必ず真の 1 手詰
+    /// (do_move 後に王手 かつ 合法手 0) でなければならない．
+    ///
+    /// [`Self::verify_mate1ply`] と違い full scan との一致照合を行わないため，参照実装である
+    /// [`Self::mate1ply_with_cached_checks`] 自身からも**再帰せずに**呼べる．production が実際に
+    /// 通る全経路 (fused look-ahead / near2 / cached full scan) に挿し，偽 1 手詰がどこから出ても
+    /// 捕まるようにする (これらを素通りしていたため二歩起因の偽 1 手詰を検出できなかった)．
+    fn verify_mate1ply_sound(&self, board: &mut Board, m: Option<Move>, site: &str) {
+        let Some(mv) = m else { return };
+        let defender = board.turn.opponent();
+        let cap = board.do_move(mv);
+        let real = board.is_in_check(defender) && !crate::movegen::has_any_legal_move(board);
+        board.undo_move(mv, cap);
+        record_mate1ply_sound(!real);
+        if !real {
+            eprintln!(
+                "[mate1ply] FALSE MATE site={site} m={} sfen={}",
+                mv.to_usi(),
+                board.sfen(),
+            );
+        }
     }
 
     /// `MATE1PLY_VERIFY` 用: 候補列挙の健全性と従来 full scan との一致を照合し統計へ加算する．
@@ -243,8 +284,8 @@ fn m1_fused_verify() -> bool {
 }
 
 thread_local! {
-    /// [calls, mate_found, diffmove, mate_miss, false_pos]．`MATE1PLY_VERIFY` 時のみ加算．
-    static MATE1PLY_STATS: std::cell::Cell<[u64; 5]> = const { std::cell::Cell::new([0; 5]) };
+    /// [calls, mate_found, diffmove, mate_miss, false_pos, sound_checks]．`MATE1PLY_VERIFY` 時のみ加算．
+    static MATE1PLY_STATS: std::cell::Cell<[u64; 6]> = const { std::cell::Cell::new([0; 6]) };
     /// mate_miss dump の出力件数 (最初の数件のみ詳細を出す)．
     static MATE1PLY_MISS_DUMP: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
@@ -269,9 +310,21 @@ fn record_mate1ply(kh: Option<Move>, full: Option<Move>, false_pos: bool) {
     });
 }
 
+/// soundness 専用チェック 1 件分を加算する ([`DfPnSolver::verify_mate1ply_sound`])．
+fn record_mate1ply_sound(false_pos: bool) {
+    MATE1PLY_STATS.with(|s| {
+        let mut v = s.get();
+        v[5] += 1;
+        if false_pos {
+            v[4] += 1;
+        }
+        s.set(v);
+    });
+}
+
 /// kh verify 統計を reset する (solve 開始時)．
 pub(crate) fn reset_mate1ply_stats() {
-    MATE1PLY_STATS.with(|s| s.set([0; 5]));
+    MATE1PLY_STATS.with(|s| s.set([0; 6]));
 }
 
 /// kh verify 統計を report する (solve 終了時; gate off なら no-op)．
@@ -281,12 +334,12 @@ pub(crate) fn report_mate1ply_stats() {
     }
     MATE1PLY_STATS.with(|s| {
         let v = s.get();
-        if v[0] == 0 {
+        if v[0] == 0 && v[5] == 0 {
             return;
         }
         eprintln!(
-            "[mate1ply] calls={} mate_found={} | vs full: diffmove={} mate_miss(full=Some,kh=None)={} | FALSE_MATE(bug)={}",
-            v[0], v[1], v[2], v[3], v[4],
+            "[mate1ply] calls={} mate_found={} | vs full: diffmove={} mate_miss(full=Some,kh=None)={} | sound_checks={} FALSE_MATE(bug)={}",
+            v[0], v[1], v[2], v[3], v[5], v[4],
         );
     });
 }

--- a/rust/maou_shogi/src/dfpn/search/mod.rs
+++ b/rust/maou_shogi/src/dfpn/search/mod.rs
@@ -138,6 +138,15 @@ fn no_dag() -> bool {
     *C.get_or_init(|| std::env::var("NODAG").is_ok())
 }
 
+/// `VDIAG` env: STRICT verify ([`DfPnSolver::verify_proof`]) の判定を局面ごとに dump する
+/// 診断用 (process 内 1 回読み)．偽証明 (`STRICT VERIFY None`) が **どの分岐で** 生じたかを
+/// 局所化する — OR (proven child 無し) / AND (逃れ手あり) / 千日手拒否 / budget 枯渇の区別．
+/// verify は proven 後に 1 回だけ走るため探索 hot path には乗らない．
+pub(super) fn vdiag_enabled() -> bool {
+    static C: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *C.get_or_init(|| std::env::var("VDIAG").is_ok())
+}
+
 /// `DFPN_STATS` env: solve 終了時の統計サマリ (`[dfpn] root ...`) を stderr に出す診断用
 /// (process 内 1 回読み)．default OFF — leaf-mate 統合探索や棋譜解析では solve が
 /// 局面ごと・葉ごとに大量に走るため，常時出力だと stderr が診断行で溢れる．
@@ -644,7 +653,6 @@ impl DfPnSolver {
             );
         }
         super::movegen::mate1ply::report_mate_cand_stats();
-        super::movegen::mate1ply::report_mate1ply_stats();
         if std::env::var("DMBREAK").is_ok() {
             let dm = DM_SITE.with(|c| c.get());
             let lq = super::movegen::legal_quick_dm();
@@ -870,6 +878,10 @@ impl DfPnSolver {
                 Vec::new(),
             )
         };
+        // mate1ply 検証統計は **STRICT verify フェーズを含めた**最後に report する
+        // (verify も `mate1ply_with_cached_checks` を呼ぶため，探索直後に出すと
+        // verify 中に検出した偽 1 手詰が集計から漏れ `FALSE_MATE(bug)=0` と誤表示される)．
+        super::movegen::mate1ply::report_mate1ply_stats();
         // 診断メタデータを 1 回だけ組み立てて返す (per-node コスト無し)．
         let elapsed_ms = self.start_time.elapsed().as_millis() as u64;
         SearchReport {

--- a/rust/maou_shogi/src/dfpn/search/pv.rs
+++ b/rust/maou_shogi/src/dfpn/search/pv.rs
@@ -53,9 +53,13 @@ impl DfPnSolver {
         dep_out: &mut usize,
         fast: bool,
     ) -> Option<u16> {
+        let vdiag = super::vdiag_enabled();
         if *budget == 0 {
             // budget 枯渇 None は経路にも memo 状態にも依存する → 最大汚染として伝播し
             // 祖先にも memo させない (偽 None のキャッシュ化を防ぐ)．
+            if vdiag {
+                eprintln!("[vdiag] L{} budget-exhausted -> None", path.len());
+            }
             *dep_out = 0;
             return None;
         }
@@ -63,6 +67,9 @@ impl DfPnSolver {
         let h = board.hash;
         if let Some(anc) = path.iter().position(|&x| x == h) {
             // 千日手 = 受け方脱出 = 不詰．ただし path[anc] (祖先) に依存する経路依存の結論．
+            if vdiag {
+                eprintln!("[vdiag] L{} repetition(anc={anc}) -> None", path.len());
+            }
             *dep_out = (*dep_out).min(anc);
             return None;
         }
@@ -82,6 +89,22 @@ impl DfPnSolver {
                 let cap = board.do_move(mv);
                 let mated = self.generate_defense_moves_inner(board, false).is_empty()
                     && board.is_in_check(board.turn);
+                if vdiag && !mated {
+                    // mate1ply が 1 手詰と申告したが replay では詰んでいない = 偽 1 手詰．
+                    let defs: Vec<String> = self
+                        .generate_defense_moves_inner(board, false)
+                        .as_slice()
+                        .iter()
+                        .map(|d| d.to_usi())
+                        .collect();
+                    eprintln!(
+                        "[vdiag] L{} FALSE-mate1ply {} in_check={} defenses={:?}",
+                        path.len(),
+                        mv.to_usi(),
+                        board.is_in_check(board.turn),
+                        defs,
+                    );
+                }
                 board.undo_move(mv, cap);
                 if mated {
                     pv_choice.insert(h, mv);
@@ -117,6 +140,19 @@ impl DfPnSolver {
                     }
                 }
                 cands.sort_by_key(|&(_, l)| l);
+                if vdiag {
+                    let cs: Vec<String> = cands
+                        .iter()
+                        .map(|&(m, l)| format!("{}(len{l})", m.to_usi()))
+                        .collect();
+                    eprintln!(
+                        "[vdiag] L{} OR checks={} proven_cands={:?} mate1ply=miss sfen={}",
+                        path.len(),
+                        moves.len(),
+                        cs,
+                        board.sfen(),
+                    );
+                }
                 path.push(h);
                 let mut best: Option<(Move, u16)> = None;
                 for (mv, _) in cands {
@@ -160,6 +196,14 @@ impl DfPnSolver {
                 if board.is_in_check(board.turn) {
                     Some(0) // 受けなし & 王手 = 詰み
                 } else {
+                    // 非王手なのに AND ノード = 攻め方の直前手が王手になっていない．
+                    if vdiag {
+                        eprintln!(
+                            "[vdiag] L{} AND no-defense-but-NOT-in-check -> None sfen={}",
+                            path.len(),
+                            board.sfen(),
+                        );
+                    }
                     None // stalemate 非王手 = 詰みでない
                 }
             } else {
@@ -199,6 +243,15 @@ impl DfPnSolver {
                             infos.push((*m, d, is_drop, recapture_transparent));
                         }
                         None => {
+                            if vdiag {
+                                eprintln!(
+                                    "[vdiag] L{} AND legal={} escape={} -> None sfen={}",
+                                    path.len(),
+                                    legal.len(),
+                                    m.to_usi(),
+                                    board.sfen(),
+                                );
+                            }
                             ok = false;
                             break;
                         }
@@ -241,6 +294,17 @@ impl DfPnSolver {
         // 経路非依存で常に memo 可)．None は祖先の千日手拒否 / budget 枯渇に汚染されている場合
         // (dep < my_level) memo せず，別文脈で再検証させる．dep_out へも None のみ伝播する
         // (Some まで汚染扱いすると循環近傍で巨大 subtree を再検証し verify wall が膨張する)．
+        if vdiag && result.is_none() {
+            eprintln!(
+                "[vdiag] L{my_level} {} -> None (dep={})",
+                if or_node { "OR" } else { "AND" },
+                if dep == usize::MAX {
+                    "-".to_string()
+                } else {
+                    dep.to_string()
+                },
+            );
+        }
         if result.is_some() || dep >= my_level {
             memo.insert(h, result);
         }

--- a/rust/maou_shogi/src/dfpn/tests.rs
+++ b/rust/maou_shogi/src/dfpn/tests.rs
@@ -1785,3 +1785,191 @@ fn test_external_stop_flag_aborts_search() {
     );
     assert_eq!(report.stop_reason, StopReason::Timeout);
 }
+
+/// 回帰: **王手手自身が守備の歩を取って二歩を解消する**場合の偽 1 手詰．
+///
+/// 後手玉 1c / 後手歩 1e / 後手持駒 歩．先手 `1g1e` (香が 1e の歩を取る) は 1 筋の王手だが，
+/// **取ったことで後手の 1 筋の二歩が解消され** `P*1d` の合駒が合法になるため詰みではない．
+/// 修正前は `can_interpose_bb` の二歩判定が **移動前**の歩ビットボード (1e の歩を含む) を見て
+/// 歩合を非合法と誤判定し，1 手詰と申告していた (= soundness 違反)．
+#[test]
+fn test_no_false_mate1ply_when_check_capture_clears_nifu() {
+    const SFEN: &str =
+        "1g1+N+N+B+P1l/9/4Np+P1k/l1p1p1pp1/3PsnP1p/+r4P3/1pPG3PL/p2S1SGbP/SRK6 b GLPp 143";
+    let mut board = Board::new();
+    board.set_sfen(SFEN).expect("正当な SFEN");
+    let m = board.move_from_usi("1g1e").expect("1g1e は合法手");
+    board.do_move(m);
+    assert!(board.is_in_check(board.turn()), "1g1e は王手であるべき");
+    let defenses: Vec<String> = movegen::generate_legal_moves(&mut board)
+        .iter()
+        .map(|d| d.to_usi())
+        .collect();
+    assert!(
+        defenses.iter().any(|d| d == "P*1d"),
+        "1e の歩を取ったことで 1 筋の二歩が解消され P*1d が合法になるはず: {defenses:?}",
+    );
+
+    // mate1ply が返す手は必ず真の 1 手詰でなければならない (偽 1 手詰 = soundness 違反)．
+    let mut b = Board::new();
+    b.set_sfen(SFEN).expect("正当な SFEN");
+    let solver = DfPnSolver::default_solver();
+    if let (Some(mv), _) = solver.mate1ply_with_cached_checks(&mut b) {
+        assert_ne!(mv.to_usi(), "1g1e", "1g1e は偽 1 手詰 (P*1d で受かる)");
+        let cap = b.do_move(mv);
+        let real = b.is_in_check(b.turn()) && movegen::generate_legal_moves(&mut b).is_empty();
+        b.undo_move(mv, cap);
+        assert!(
+            real,
+            "mate1ply が返す手は真の 1 手詰であるべき: {}",
+            mv.to_usi()
+        );
+    }
+}
+
+/// 回帰: 上記の偽 1 手詰が **探索の偽証明** (`[dfpn] STRICT VERIFY None` =
+/// [`StopReason::FalseProof`]) として顕在化した root 局面．
+///
+/// 実際には 3 手詰 (`5b4a 1d1c L*1d`)．修正前は look-ahead が偽 1 手詰 `1g1e` を掴んで
+/// root に pn=0 (mate_len=3) を立て，STRICT verify が実 replay で否定して `Unknown` に
+/// 落としていた (= 詰みを指せない)．修正後は本物の詰み `L*1d` を拾って解ける．
+#[test]
+fn test_no_false_proof_when_check_capture_clears_nifu() {
+    const SFEN: &str =
+        "1g1+N+N1+P1l/4+B4/4Np+P2/l1p1p1ppk/3PsnP1p/+r4P3/1pPG3PL/p2S1SGbP/SRK6 b GLPp 141";
+    let mut board = Board::new();
+    board.set_sfen(SFEN).expect("正当な SFEN");
+    let mut solver = DfPnSolver::with_timeout(31, 1_000_000, 30);
+    let report = solver.solve_report(&mut board);
+    assert_ne!(
+        report.stop_reason,
+        StopReason::FalseProof,
+        "偽証明が再発している: {:?}",
+        report.result,
+    );
+    match report.result {
+        TsumeResult::Checkmate { ref moves, .. } => {
+            let usi: Vec<String> = moves.iter().map(|m| m.to_usi()).collect();
+            assert_eq!(moves.len(), 3, "3 手詰であるべき: {usi:?}");
+            let mut chk = Board::new();
+            chk.set_sfen(SFEN).expect("正当な SFEN");
+            for m in moves {
+                chk.do_move(*m);
+            }
+            assert!(
+                chk.is_in_check(chk.turn()) && movegen::generate_legal_moves(&mut chk).is_empty(),
+                "PV 終局面は真の詰みであるべき: {usi:?}",
+            );
+        }
+        ref other => panic!("3 手詰が返るべき: {other:?}"),
+    }
+}
+
+/// 偽証明ハンター (**[SLOW]**, 診断用)．
+///
+/// 自己対局で観測された `[dfpn] STRICT VERIFY None` (= [`StopReason::FalseProof`]
+/// = 「verify budget が残っているのに `verify_proof` が None を返した」) を，
+/// NN やモデルに依存しない最小構成で再現するための探索ハーネス．
+///
+/// seeded LCG のランダム対局で局面列を作り，**手番側に王手手段がある局面**
+/// (`does_have_mate_possibility` — leaf-mate の enqueue gate と同一) だけを
+/// leaf-mate と同一設定 (`new_leaf_mate(NODES, 1)`: `find_shortest=false` /
+/// 小 TT / 1s) で solve し，`FalseProof` になった局面の SFEN を出力する．
+///
+/// production と同様に **ソルバーは 1 個を使い回す** (`check_cache` が solve を
+/// 跨ぐ唯一の状態)．検出局面は続けて **fresh solver で再 solve** し，再現が
+/// solver の持ち越し状態に依存するか (= check_cache 由来) 局面固有かを切り分ける．
+///
+/// env: `SEED` (既定 1) / `GAMES` (既定 200) / `PLIES` (既定 160) /
+/// `NODES` (既定 50 = leaf-mate の既定予算) / `MAXHITS` (既定 20)．
+#[test]
+#[ignore]
+fn test_false_proof_hunt() {
+    /// 決定的な LCG (外部 rand 依存を避ける)．
+    fn lcg(state: &mut u64) -> u64 {
+        *state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        *state >> 33
+    }
+    fn env_u64(key: &str, default: u64) -> u64 {
+        std::env::var(key)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(default)
+    }
+
+    let seed = env_u64("SEED", 1);
+    let games = env_u64("GAMES", 200);
+    let plies = env_u64("PLIES", 160);
+    let nodes = env_u64("NODES", 50);
+    let max_hits = env_u64("MAXHITS", 20) as usize;
+    const STARTPOS: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+    // production の leaf-mate と同じく 1 ソルバーを使い回す．
+    let mut solver = DfPnSolver::new_leaf_mate(nodes, 1);
+    let mut hits: Vec<String> = Vec::new();
+    let (mut probed, mut mated) = (0u64, 0u64);
+    let t0 = std::time::Instant::now();
+
+    'outer: for g in 0..games {
+        let mut state = seed ^ g.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let mut board = Board::new();
+        board.set_sfen(STARTPOS).expect("startpos は正当な SFEN");
+        for _ in 0..plies {
+            let legal = movegen::generate_legal_moves(&mut board);
+            if legal.is_empty() {
+                break;
+            }
+            if board.does_have_mate_possibility(board.turn()) {
+                let sfen = board.sfen();
+                let mut b = Board::new();
+                b.set_sfen(&sfen).expect("生成局面は正当な SFEN");
+                let rep = solver.solve_report(&mut b);
+                probed += 1;
+                if matches!(
+                    rep.result,
+                    TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. }
+                ) {
+                    mated += 1;
+                }
+                if rep.stop_reason == StopReason::FalseProof {
+                    eprintln!(
+                        "[fp] HIT #{:<3} game={g} root_pn={} root_dn={} mate_len_found={:?} sfen={sfen}",
+                        hits.len() + 1,
+                        rep.root_pn,
+                        rep.root_dn,
+                        rep.mate_len_found,
+                    );
+                    hits.push(sfen);
+                    if hits.len() >= max_hits {
+                        break 'outer;
+                    }
+                }
+            }
+            let m = legal[(lcg(&mut state) as usize) % legal.len()];
+            board.do_move(m);
+        }
+    }
+
+    eprintln!(
+        "[fp] SUMMARY seed={seed} games={games} plies={plies} nodes={nodes} | probed={probed} mated={mated} false_proof={} | {:.1}s",
+        hits.len(),
+        t0.elapsed().as_secs_f64(),
+    );
+
+    // 検出局面を fresh solver で再 solve — 再現が solver 持ち越し状態に依存するか切り分け．
+    for (i, sfen) in hits.iter().enumerate() {
+        let mut b = Board::new();
+        b.set_sfen(sfen).expect("hit 局面は正当な SFEN");
+        let mut fresh = DfPnSolver::new_leaf_mate(nodes, 1);
+        let rep = fresh.solve_report(&mut b);
+        eprintln!(
+            "[fp] REPLAY #{:<3} fresh_solver stop={:<14} nodes={:<6} (isolated={}) sfen={sfen}",
+            i + 1,
+            rep.stop_reason.as_str(),
+            fresh.nodes,
+            rep.stop_reason == StopReason::FalseProof,
+        );
+    }
+}

--- a/rust/maou_shogi/src/dfpn/tests.rs
+++ b/rust/maou_shogi/src/dfpn/tests.rs
@@ -1830,7 +1830,7 @@ fn test_no_false_mate1ply_when_check_capture_clears_nifu() {
 /// 回帰: 上記の偽 1 手詰が **探索の偽証明** (`[dfpn] STRICT VERIFY None` =
 /// [`StopReason::FalseProof`]) として顕在化した root 局面．
 ///
-/// 実際には 3 手詰 (`5b4a 1d1c L*1d`)．修正前は look-ahead が偽 1 手詰 `1g1e` を掴んで
+/// **正解 = 3 手詰 `5b4a 1d1c L*1d`** (user 確認済み oracle)．修正前は look-ahead が偽 1 手詰 `1g1e` を掴んで
 /// root に pn=0 (mate_len=3) を立て，STRICT verify が実 replay で否定して `Unknown` に
 /// 落としていた (= 詰みを指せない)．修正後は本物の詰み `L*1d` を拾って解ける．
 #[test]


### PR DESCRIPTION
## Summary

- 自己対局で多発していた dfpn 偽証明 (`[dfpn] STRICT VERIFY None`) の **根本原因を特定し修正**．`Board::can_interpose_bb` が合駒の二歩判定に **移動前**の歩ビットボードを使っていた
- 王手手自身が守備の歩を取ってその筋の二歩を解消するケースで **偽の 1 手詰**を申告していた (soundness 違反)．同じ staleness で移動合駒の要員も過大に数え，**本物の詰みを取りこぼして**もいた
- 偽 1 手詰を検出すべき `MATE1PLY_VERIFY` が production の通る全経路を素通りしていた穴を塞いだ (だから今まで気付けなかった)
- NN・モデル非依存の **最小再現ハーネス** (`test_false_proof_hunt`) と回帰テスト 2 件を追加．canonical (29te / 39te) は node 数・PV とも bit-identical

## Problem

GPU (Colab L4) での実モデル自己対局で `[dfpn] STRICT VERIFY None (偽証明/不完全) → Unknown (偽詰み回避)` が
40 局あたり 9 件 → 追試で 126 件と看過できない頻度で出ていた．

`STRICT VERIFY None` は「探索が root に pn=0 (詰み証明) を立てたが，STRICT verify が実手 replay で
それを否定した」ことを意味する．STRICT verify が最終権威なので **実害 (偽の詰み手を指す) は出ていない**が，
その分 **本来指せるはずの詰みを `Unknown` に落として捨てている**．また検証側にバグが入れば
偽の詰みを指す経路になるため，soundness 上の潜在リスクだった．

原因候補としては「TT 再利用による GHI (proof-tree の循環)」が疑われていたが，**これは誤りだった**
(TT は solve をまたいで再利用されない．毎 solve 新規確保され，跨ぐ状態は board.hash キーの
純関数キャッシュ `check_cache` のみ)．

## Solution

### 1. 最小再現を作る

NN もモデルも使わず，seeded LCG のランダム対局から局面列を生成し，
**手番側に王手手段がある局面** (`does_have_mate_possibility` — leaf-mate の enqueue gate と同一) を
leaf-mate と同一設定 (`new_leaf_mate(50, 1)`) で解いて `StopReason::FalseProof` を拾うハーネスを書いた．

seed=1 / 約 3.1 万局面中 **1 件**を検出．最小形は **7 ノードで決着**し，fresh solver でも単独再現する
(= TT eviction でも GHI でもない，局面固有の決定的バグ)．

### 2. 分岐を局所化する

`verify_proof` がどの分岐で `None` を返したかを追う診断 env `VDIAG` を追加し，7 ノードの全体像を得た:

```
[vdiag] L0 OR checks=4 proven_cands=["5b4a(len2)"] mate1ply=miss
[vdiag] L2 FALSE-mate1ply 1g1e in_check=true defenses=["P*1d"]
[vdiag] L2 OR checks=8 proven_cands=[] -> None
[vdiag] L1 AND legal=2 escape=1d1c -> None
[vdiag] L0 OR -> None
```

`mate1ply` が `1g1e` (香が 1e の後手歩を取る) を 1 手詰と申告しているが，実際は `P*1d` の合駒で受かる．

### 3. 根本原因

`can_interpose_bb` は王手手適用後の占有 `occ_after` を受け取りながら，
**合駒の二歩判定と移動合駒の要員列挙だけ移動前の `self.piece_bb` を読んでいた**．

**王手手自身が守備の歩を取ってその筋の二歩を解消する**場合，取られた歩を数えてしまい
「歩の合駒は非合法」と誤判定する → 実際には受かる局面を 1 手詰と申告する．

```
局面 (後手玉 1c / 後手歩 1e / 後手持駒 歩):
1g1+N+N+B+P1l/9/4Np+P1k/l1p1p1pp1/3PsnP1p/+r4P3/1pPG3PL/p2S1SGbP/SRK6 b GLPp 143

先手 1g1e (香が 1e の歩を取る) → 1 筋の王手
  修正前: 1 筋に後手歩あり (移動前の 1e を見ている) → 歩合不可 → 「詰み」と誤判定
  実際  : 1e の歩は今取られた → 1 筋の二歩が解消 → P*1d で受かる (詰みでない)
```

**修正**: 守備駒のビットボードを `def_occ_after` でマスクして取られた駒を除外する
(`between` に依存しないためループ外へ巻き上げ)．

方向性の確認:
- **二歩判定**: 過大に数える → 合駒を非合法と誤判定 → **偽の詰み (unsound)** ← 本件
- **移動合駒の要員**: 過大に数える → 逃れ手ありと誤判定 → **詰みの取りこぼし (完全性)**

どちらも「盤上に無い駒を数える」という同一原因なので，まとめて解消した．

### 4. 検証器の穴を塞ぐ

`MATE1PLY_VERIFY=1` は「1 手詰と申告した手が真の 1 手詰か」を実 replay で照合する診断だが，
**production が実際に通る 3 経路を全て素通りしていた**:

| 経路 | 用途 | 修正前 | 修正後 |
|---|---|---|---|
| `mate1ply_fused` | look-ahead の既定 | 未検証 (`M1_FUSED_DISABLE` 時のみ) | 検証 |
| `mate1ply_cached_near2` | look-ahead (逆王手 fallback) | 未検証 | 検証 |
| `mate1ply_with_cached_checks` | STRICT verify の参照実装 | 未検証 | 検証 |

soundness 専用チェック `verify_mate1ply_sound` を新設して全経路に挿した
(`verify_mate1ply` と違い full scan との一致照合を伴わないため，参照実装自身からも再帰せずに呼べる)．

併せて統計 report を **STRICT verify フェーズの後**へ移動．従来は探索直後に出していたため
verify 中に検出した偽 1 手詰が集計から漏れ，`FALSE MATE` 行が出ているのに
サマリは `FALSE_MATE(bug)=0` と表示する矛盾があった．

## Changes

| ファイル | 内容 |
|---|---|
| `rust/maou_shogi/src/board.rs` | **本体修正**．`can_interpose_bb` の守備駒 bb を `def_occ_after` でマスク．doc に (a) 完全性 / (b) soundness の 2 失敗モードを明記 |
| `rust/maou_shogi/src/dfpn/movegen/mate1ply.rs` | `verify_mate1ply_sound` 新設 + 3 経路へ挿入．統計に `sound_checks` を追加 |
| `rust/maou_shogi/src/dfpn/search/mod.rs` | `VDIAG` env 追加．`report_mate1ply_stats()` を verify フェーズ後へ移動 |
| `rust/maou_shogi/src/dfpn/search/pv.rs` | `verify_proof` の各 `None` 分岐に `VDIAG` トレース |
| `rust/maou_shogi/src/dfpn/tests.rs` | 回帰 2 件 + 再現ハーネス `test_false_proof_hunt` (`#[ignore]`) |
| `CLAUDE.md` | `[SLOW]` 表に 1 行 + soundness スイープ手順 (reviews 承認済) |
| `reviews/2026-07-27-dfpn-false-proof-test-docs.md` | 上記 CLAUDE.md 変更の提案 (`status: applied`, `applied_in: f221561`) |

版数: `maou_shogi` 5.9.1 → **5.9.2** (fix → patch)．Python 側 `src/` は無変更のため `pyproject.toml` は据え置き．

## Impact

**Breaking Changes**: なし．公開 API・データ形式・move 表現に変更なし．

**Behavior**:
- dfpn が **これまで取りこぼしていた詰みを一部拾うようになる** (偽 1 手詰に引きずられて本物の詰みを見落としていたため)．再現局面では `Unknown` → **3 手詰 `5b4a 1d1c L*1d`** に変わる
- ハンター seed=1 の `mated` が 1011 → **1012** (取りこぼしを 1 件回収)
- **canonical は完全不変** — 29te 396,516 nodes / 39te 17,593,615 nodes，PV とも bit-identical

**Performance**: 守備駒 bb の算出を `for to in between` ループ外へ巻き上げたため，
合駒判定はむしろ僅かに軽い．診断は全て env gate 下 (`VDIAG` / `MATE1PLY_VERIFY`) で既定 OFF．
`VDIAG` の分岐は verify フェーズのみ (探索 hot path に乗らない)．

**Dependencies**: 追加なし (再現ハーネスは外部 rand を避けて LCG を内製)．

## Testing

**新規テスト**:
- `test_no_false_mate1ply_when_check_capture_clears_nifu` — 二歩解消により `P*1d` が合法になることと，
  `mate1ply` が返す手が真の 1 手詰であることを検証
- `test_no_false_proof_when_check_capture_clears_nifu` — root 局面が `FalseProof` にならず 3 手詰を返すこと．
  **正解 `5b4a 1d1c L*1d` は user 確認済み oracle**
- `test_false_proof_hunt` (`#[ignore]`, `[SLOW]`) — 偽証明ハンター本体

**結果**:

| 対象 | 結果 |
|---|---|
| maou_shogi | **198 passed** (196 + 回帰 2) / fixture 7 / kifu_parity 3 / doc 1 |
| maou_search | 76 passed + parity 2 |
| maou_usi | 112 passed |
| Python (pre-commit `test` フック) | passed |
| canonical 29te / 39te | **396,516 / 17,593,615 nodes，PV bit-identical** |
| workspace clippy / fmt | clean |

**広域スイープ**:
- 偽証明ハンター seed 1–10 × 約 **31 万局面** → `false_proof` **0** (修正前は seed=1 で 1 件)
- `MATE1PLY_VERIFY=1` スイープ seed 1–5 → `FALSE MATE` **0 件**．
  非空であることを確認済み (20 局だけで `sound_checks=1599` 発火)

**検証器が本当に効くことの確認**: `board.rs` の修正を一時的に revert して再実行し，
`[mate1ply] FALSE MATE site=cached_checks m=1g1e sfen=...` が出ることを確認した
(= 今後同種の回帰が入れば捕まる)．

## Technical Details

`can_interpose_bb` は `&self` (移動前の盤) を持ちつつ，王手手適用後の状態を
`occ_after` / `pinned_after` といった引数で受け取る「仮想適用」方式で判定する．
このとき **守備側から消える駒は `to_sq` の 1 枚だけ** (王手手がそこを取った場合)．
打ち手は駒を取らないので例外はない．よって `piece_bb[def] & def_occ_after` が
過不足なく「王手手適用後に盤上に残る守備駒」になる．

`between` の各マスに依存しないため，9 種の駒別 bb をループ外で 1 回だけ算出している．

なお `can_capture_checker_bb` にも同じ `_def_occ` の未使用引数があるが，
そちらは `checker_sq` への利きを見るため **`to_sq` にいた駒は構造上ヒットしない**
(自マスを攻撃する駒は無い) ので，同種の誤判定は起きない．本 PR では触っていない．

## Review Notes

**重点的に見てほしい箇所**:
1. `board.rs` `can_interpose_bb` — `def_occ_after` マスクが過不足ないか
   (「消えるのは `to_sq` の 1 枚だけ」という前提の妥当性)
2. `mate1ply.rs` `mate1ply_with_cached_checks` の cached 分岐 —
   `check_cache` の slice 借用中に `verify_mate1ply_sound` を呼ぶため，
   `has_checks` を先に確定させてから呼んでいる
3. 回帰テストが pin している **3 手詰 `5b4a 1d1c L*1d`** (user 確認済み)

**未解決 / follow-up**:
- GPU 実測で観測された **126 件が全て本件由来かは未検証**．ランダム局面での発生率は
  1/31k と低い一方，実戦の leaf-mate 局面は詰み密度が桁違いに高いため相関は妥当だが断定はできない．
  実モデル自己対局を `MATE1PLY_VERIFY=1` で回すのが決着方法
- `can_capture_checker_bb` / `mate1ply` 周辺に他の pre-existing な staleness が無いかの棚卸し

## Checklist

- [x] Code formatted and linted (ruff, isort, cargo fmt)
- [x] Type checking passes (mypy)
- [x] All tests pass (Rust 全クレート + Python)
- [x] Regression tests added for bug fix (2 件)
- [x] Canonical (29te / 39te) 照合済み — node 数・PV とも不変
- [x] Architecture compliance verified (Rust 内部のみ; レイヤ跨ぎなし)
- [x] Docstrings added/updated (日本語記述規則 準拠)
- [x] Rust crate version bumped (maou_shogi 5.9.1 → 5.9.2)
- [x] CLAUDE.md updated (reviews 起票 → applied 化まで完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StoavMgFCQ5qj5zFKaj7cD
