### PR TITLE
feat(search): 初回推論の固定費を予算の外で前払いする (CLI / SearchEngine)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -114,11 +114,31 @@ Stats: playouts=38 terminal_backprops=1 nps=435 eval_batches=5 avg_batch=7.6 col
   when the GPU does the same amount of work. A collision count that grows with
   `--threads` is the usual cause of a low fill rate (a collision submits the
   partially collected batch immediately).
-  `warmup_ms` is the one-time root evaluation cost (the first inference, which
-  triggers the TensorRT engine build/load) — it is measured **outside** the
-  timed region, so `nps`/`elapsed_ms` reflect only the search itself. With
-  TensorRT the first run's `warmup_ms` can be tens of seconds; subsequent runs
-  reusing `--trt-cache-dir` drop to a few seconds.
+  `warmup_ms` is the one-time root evaluation cost — it is measured **outside**
+  the timed region, so `nps`/`elapsed_ms` reflect only the search itself.
+
+### The time budget and warmup
+
+`--time-ms` bounds the **search**, not the process. Before the budget starts,
+the CLI runs one throwaway inference to pay the lazy initialization cost
+(TensorRT engine build/load, CUDA context creation) up front, so the full
+`--time-ms` is available for playouts.
+
+This matters with a cold TensorRT cache: building an engine takes tens of
+seconds, and if it were paid inside the budget a short `--time-ms` would finish
+with `playouts=0` and a meaningless `Bestmove`. Reusing `--trt-cache-dir` drops
+the cost to roughly a second.
+
+Wall-clock time is therefore `warmup + --time-ms`, which is longer than
+`--time-ms`. That is deliberate for a CLI: you asked for N milliseconds *of
+search*.
+
+> [!NOTE]
+> The engine-playing paths do **not** work this way — there the budget covers
+> everything after `go`, because a GUI or game server measures from the move it
+> sends to the `bestmove` it receives, and overrunning loses on time. They avoid
+> the same trap by warming up earlier: USI during `isready` (before `readyok`),
+> `maou floodgate` before the first game, and `maou selfplay` at startup.
 
 ## Example invocation
 

--- a/docs/design/position-search/index.md
+++ b/docs/design/position-search/index.md
@@ -195,6 +195,47 @@ pub struct SearchLimits { pub max_playouts: Option<u64>, pub time_ms: Option<u64
 - playout 上限はバッチ粒度により最大 `threads × batch_size` 超過し得る (仕様)．
 - 将来: depth 予算，詰将棋ソルバーと同様のノード数予算の意味論統一 (未決)．
 
+### 5.1 初回推論の固定費 (warmup) をどこで払うか (実装済み — maou_search v0.28.0)
+
+ONNX Runtime の TensorRT EP は**最初の推論時に**エンジンをビルドする
+(cold cache で数十秒)．CUDA EP もコンテキスト初期化を初回に行う．
+
+時間予算の期限は `budget_start` (= 呼び出し側が `go` を受けた時刻) 起点で
+張る．これは対局経路の要件であり**緩めない** — GUI/サーバは指し手送信から
+`bestmove` 受信までを消費時間として計るため，予算の外で払った時間はそのまま
+持ち時間の超過になる (回帰テスト `test_wall_clock_stays_within_time_budget`
+が過去のバグ 2 件を記録している)．
+
+したがって**固定費は「1 手ぶんの予算を張る前」に前払いする**．
+`maou_search::warmup` (平手初期局面を 1 回評価するだけ) を各経路の適切な
+位置で呼ぶ:
+
+| 経路 | 前払いの位置 | 根拠 |
+|---|---|---|
+| USI | `isready` 処理中 (`readyok` を返す前) | GUI は `isready` に時間制限を課さない |
+| CSA (floodgate) | 対局ループ開始前 (プロセス内 1 回) | 連続対局で共有 |
+| 自己対局 | driver 起動時 (全対局で共有) | 同上 |
+| CLI `maou search` | 探索開始前 | 予算 = 探索時間．壁時計は warmup + 予算 |
+| `SearchEngine` (棋譜解析) | コンストラクタ | 局面ごとに予算を配分するため，初手だけ削られるのを防ぐ |
+
+**CLI と対局経路で予算の意味が違う**ことは意図的である．CLI は計測・検査の
+道具で「N ミリ秒*探索*する」が期待される挙動．対局経路は「`go` から N
+ミリ秒以内に `bestmove` を返す」が要件．予算セマンティクス自体
+(`budget_start` 起点) は両者で共通で，違うのは前払いの有無だけ．
+
+実機で踏んだ事象 (Colab L4 / TensorRT cold cache): `maou search --time-ms
+3000` に対しエンジンビルドが 32.2 秒かかり `playouts=0` / `warmup_ms=32227`
+となった．このとき `best_move` は §6 の基準で合法手生成順の先頭になり，
+評価に基づかない手が返る．
+
+却下した代替案:
+
+- **`SearchLimits` に `exclude_warmup` フラグを足す**: 予算セマンティクスに
+  分岐が増え，対局経路で誤って有効化すると切れ負けに直結する．前払いは
+  呼び出し側で完結するので探索側に選択肢を持たせる必要がない．
+- **`maou search` に `--warmup/--no-warmup` を露出する**: 前払いしない側に
+  用途がない (playouts=0 になるだけ)．
+
 ## 6. 最終手選択 (実装済み — maou_search v0.15.0)
 
 採用基準 (2026-07-11 確定．優先順):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.66.0"
+version = "0.67.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-07-29-warmup-outside-cli-budget.md
+++ b/reviews/2026-07-29-warmup-outside-cli-budget.md
@@ -1,7 +1,7 @@
 ---
 title: warmup を予算の外で前払いする位置づけを設計 doc に明記する
 date: 2026-07-29
-status: pending
+status: approved
 target:
   - docs/design/position-search/index.md
 risk: low
@@ -45,7 +45,10 @@ Stats: playouts=0 ... elapsed_ms=175 warmup_ms=32227 stop=time_limit
 一方で CLI (`maou search`) は対局経路ではなく計測・検査の道具であり，
 「指定した秒数だけ探索する」が期待される挙動．
 
-## 提案する記述 (§3.5 として新設)
+## 提案する記述 (§5.1 として新設)
+
+> 起票時は §3.5 としていたが，その番号は既存 (木の表現とメモリ)．
+> 予算の話なので §5「予算 API と停止」の配下に置く．
 
 > ### 3.5 初回推論の固定費 (warmup) をどこで払うか
 >

--- a/reviews/2026-07-29-warmup-outside-cli-budget.md
+++ b/reviews/2026-07-29-warmup-outside-cli-budget.md
@@ -1,0 +1,91 @@
+---
+title: warmup を予算の外で前払いする位置づけを設計 doc に明記する
+date: 2026-07-29
+status: pending
+target:
+  - docs/design/position-search/index.md
+risk: low
+reversibility: easy
+---
+
+# 提案: 「初回推論の固定費をどこで払うか」を設計 doc に節として起こす
+
+## Trigger
+
+user 指示「searchのときだけwarm_upを予算に入れないようにすることはできますか？
+USIエンジンとして稼働する場合やCSAサーバでの対局時はtensorRTエンジンの生成を
+予算に入れるのは正しいですが，searchコマンドの時は指定した秒数を探索してほしい
+ので別計算にしてほしい」．
+
+実機で踏んだ事象 (Colab L4 / TensorRT cold cache):
+
+```
+Bestmove: 1g1f
+Eval: -16578.61
+Stats: playouts=0 ... elapsed_ms=175 warmup_ms=32227 stop=time_limit
+```
+
+`maou search --time-ms 3000` に対しエンジンビルドが 32.2 秒かかり，予算を
+使い切って playout が 0 になった．`Bestmove` は合法手生成順の先頭
+(`select_best_root_index`，search.rs:349) で，評価に基づく手ではない．
+
+## 現状の設計記述
+
+`docs/design/position-search/index.md` は時間予算の起点について明示的な節を
+持たない．実装側 (`rust/maou_search/src/search.rs:1446-1461`) には
+
+> `budget_start` は**呼び出し側が `go` を受け取った時刻**．[...]
+> ただし**期限は budget_start 起点**で，warmup も予算に数える．
+
+とあり，回帰テスト `test_wall_clock_stays_within_time_budget`
+(search.rs:2542) が「起点が warmup の後だと予算をはみ出す」過去のバグを
+記録している．つまり **warmup を予算に数えるのは対局経路にとって必須**で，
+これを緩めてはならない．
+
+一方で CLI (`maou search`) は対局経路ではなく計測・検査の道具であり，
+「指定した秒数だけ探索する」が期待される挙動．
+
+## 提案する記述 (§3.5 として新設)
+
+> ### 3.5 初回推論の固定費 (warmup) をどこで払うか
+>
+> ONNX Runtime の TensorRT EP は**最初の推論時に**エンジンをビルドする
+> (cold cache で数十秒)．CUDA EP もコンテキスト初期化を初回に行う．
+>
+> 時間予算の期限は `budget_start` (= 呼び出し側が `go` を受けた時刻) 起点で
+> 張る．これは対局経路の要件であり緩めない — GUI/サーバは指し手送信から
+> `bestmove` 受信までを消費時間として計るため，予算の外で払った時間は
+> そのまま持ち時間の超過になる (§ 回帰テスト
+> `test_wall_clock_stays_within_time_budget`)．
+>
+> したがって**固定費は「1 手ぶんの予算を張る前」に前払いする**．
+> `maou_search::warmup` (平手初期局面を 1 回評価) を各経路の適切な位置で
+> 呼ぶ:
+>
+> | 経路 | 前払いの位置 | 根拠 |
+> |---|---|---|
+> | USI | `isready` 処理中 (`readyok` を返す前) | GUI は `isready` に時間制限を課さない |
+> | CSA (floodgate) | 対局ループ開始前 (プロセス内 1 回) | 連続対局で共有 |
+> | 自己対局 | driver 起動時 (全対局で共有) | 同上 |
+> | CLI `maou search` | 探索開始前 | 予算 = 探索時間．壁時計は warmup + 予算 |
+> | `SearchEngine` (棋譜解析) | コンストラクタ | 局面ごとに予算を配分するため，初手だけ削られるのを防ぐ |
+>
+> **CLI と対局経路で予算の意味が違う**ことは意図的である．CLI は計測・検査の
+> 道具で「N ミリ秒*探索*する」が期待される挙動．対局経路は「`go` から N
+> ミリ秒以内に `bestmove` を返す」が要件．予算セマンティクス自体
+> (`budget_start` 起点) は両者で共通で，違うのは前払いの有無だけ．
+
+## 却下した代替案
+
+- **`SearchLimits` に `exclude_warmup` フラグを足す**: 予算セマンティクスに
+  分岐が増え，対局経路で誤って有効化すると切れ負けに直結する．前払いは
+  呼び出し側で完結するので探索側に選択肢を持たせる必要がない．
+- **`maou search` に `--warmup/--no-warmup` を露出する**: 前払いしない側に
+  用途がない (playouts=0 になるだけ)．オプションを増やす価値がない．
+
+## 影響
+
+- 実装は済んでいる (この提案は durable doc への反映のみ)．
+- `maou search` の壁時計は `warmup + --time-ms` になる．cold cache の
+  TensorRT では初回のみ数十秒伸びる．
+- 対局経路 (USI / CSA / 自己対局) の予算挙動は**不変**．

--- a/reviews/2026-07-29-warmup-outside-cli-budget.md
+++ b/reviews/2026-07-29-warmup-outside-cli-budget.md
@@ -1,7 +1,8 @@
 ---
 title: warmup を予算の外で前払いする位置づけを設計 doc に明記する
 date: 2026-07-29
-status: approved
+status: applied
+applied_in: 613f5c6
 target:
   - docs/design/position-search/index.md
 risk: low

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_search.rs
+++ b/rust/maou_rust/src/maou_search.rs
@@ -171,6 +171,13 @@ fn to_py_result(r: SearchResult) -> PySearchResult {
 }
 
 /// GIL を解放して探索を実行する (solve_tsume と同じパターン)．
+///
+/// 探索の**前に** [`maou_search::warmup`] で初回推論 (TensorRT エンジンビルド
+/// 等) を済ませる．時間予算は `search_with_history` の呼び出し時刻を起点に
+/// 張られるため，これを予算の内側で払うと短い予算では playout が 0 になる
+/// (実測: cold cache の TensorRT で 32 秒．`--time-ms 3000` が丸ごと消えた)．
+/// USI が `isready`，CSA が対局開始前に同じ前払いをしているのと揃える —
+/// CLI では「指定した秒数だけ探索する」が期待される挙動．
 fn run_search<E: Evaluator>(
     py: Python<'_>,
     evaluator: E,
@@ -180,6 +187,7 @@ fn run_search<E: Evaluator>(
     limits: SearchLimits,
 ) -> PySearchResult {
     let result = py.detach(move || {
+        maou_search::warmup(&evaluator);
         let searcher = Searcher::new(&evaluator, options);
         searcher.search_with_history(&board, &history, &limits)
     });
@@ -491,7 +499,9 @@ struct SearchEngine {
 impl SearchEngine {
     #[new]
     #[pyo3(signature = (*, model_path=None, threads=None, batch_size=None, use_cuda=None, use_tensorrt=None, trt_engine_cache_dir=None, pad_buckets=None))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
+        py: Python<'_>,
         model_path: Option<String>,
         threads: Option<usize>,
         batch_size: Option<usize>,
@@ -511,6 +521,15 @@ impl SearchEngine {
             trt_engine_cache_dir,
             pad_buckets,
         )?;
+        // 初回推論 (TensorRT エンジンビルド等) をここで前払いする — USI の
+        // `isready` と同じ位置づけ．`search` の時間予算は呼び出しごとに
+        // 張られるので，これを怠ると最初の 1 局面だけ予算を食い潰される
+        // (棋譜解析は局面ごとに予算を配分するため影響が大きい)
+        py.detach(|| match &evaluator {
+            EngineEvaluator::Mock(ev) => maou_search::warmup(ev),
+            #[cfg(feature = "onnx")]
+            EngineEvaluator::Onnx(ev) => maou_search::warmup(ev),
+        });
         Ok(SearchEngine {
             evaluator,
             threads,

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/evaluator.rs
+++ b/rust/maou_search/src/evaluator.rs
@@ -7,7 +7,11 @@
 //! 探索側には「合法手ごとの事前確率 + 手番側勝率」だけを渡す．
 
 use maou_shogi::board::Board;
+use maou_shogi::movegen::generate_legal_moves;
 use maou_shogi::moves::Move;
+
+/// 平手初期局面の SFEN．
+pub const STARTPOS_SFEN: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
 
 /// 評価リクエスト 1 件 (葉局面とその合法手)．
 pub struct EvalItem {
@@ -32,6 +36,26 @@ pub struct EvalResult {
 pub trait Evaluator: Send + Sync {
     /// 複数局面をまとめて評価する．
     fn evaluate_batch(&self, items: &[EvalItem]) -> Vec<EvalResult>;
+}
+
+/// 平手初期局面を 1 回評価して初回推論の固定費を前払いする (warmup)．
+///
+/// ONNX Runtime の TensorRT EP は**最初の推論時に**エンジンをビルドする
+/// (キャッシュがなければ数十秒かかる)．探索の時間予算は `go` 受領時刻を
+/// 起点に張るため，この固定費を予算の内側で払うと短い予算では playout が
+/// 0 になる．そこで**予算を張る前に**本関数で 1 回推論を通しておく．
+///
+/// 呼び出し箇所は「1 手ぶんの予算の外側」— USI は `isready`，CSA は対局
+/// 開始前，CLI (`maou search`) と `SearchEngine` は探索開始前．
+///
+/// 結果は捨てる (副作用としての初期化だけが目的)．
+pub fn warmup<E: Evaluator + ?Sized>(evaluator: &E) {
+    let mut board = Board::empty();
+    board
+        .set_sfen(STARTPOS_SFEN)
+        .expect("STARTPOS_SFEN は正当な SFEN");
+    let moves = generate_legal_moves(&mut board.clone());
+    let _ = evaluator.evaluate_batch(&[EvalItem { board, moves }]);
 }
 
 /// splitmix64 (決定論的擬似乱数生成)．
@@ -98,15 +122,37 @@ impl Evaluator for MockEvaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maou_shogi::movegen::generate_legal_moves;
-
-    const STARTPOS: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     fn startpos_item() -> EvalItem {
         let mut board = Board::empty();
-        board.set_sfen(STARTPOS).expect("startpos は正当な SFEN");
+        board
+            .set_sfen(STARTPOS_SFEN)
+            .expect("startpos は正当な SFEN");
         let moves = generate_legal_moves(&mut board);
         EvalItem { board, moves }
+    }
+
+    /// 呼び出し回数とバッチ内容を記録する評価器 (warmup の検証用)．
+    struct CountingEvaluator {
+        calls: AtomicUsize,
+        last_batch: Mutex<Vec<usize>>,
+    }
+
+    impl Evaluator for CountingEvaluator {
+        fn evaluate_batch(&self, items: &[EvalItem]) -> Vec<EvalResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_batch.lock().expect("poisoned") =
+                items.iter().map(|i| i.moves.len()).collect();
+            items
+                .iter()
+                .map(|i| EvalResult {
+                    priors: vec![0.0; i.moves.len()],
+                    value: 0.5,
+                })
+                .collect()
+        }
     }
 
     #[test]
@@ -130,5 +176,41 @@ mod tests {
         let b = ev.evaluate_batch(&[startpos_item()]);
         assert_eq!(a[0].priors, b[0].priors);
         assert_eq!(a[0].value, b[0].value);
+    }
+
+    #[test]
+    fn test_warmup_runs_exactly_one_inference() {
+        let ev = CountingEvaluator {
+            calls: AtomicUsize::new(0),
+            last_batch: Mutex::new(Vec::new()),
+        };
+        warmup(&ev);
+        assert_eq!(
+            ev.calls.load(Ordering::SeqCst),
+            1,
+            "warmup は推論をちょうど 1 回だけ走らせる"
+        );
+    }
+
+    #[test]
+    fn test_warmup_evaluates_startpos_with_all_legal_moves() {
+        // 平手初期局面の合法手は 30 手．TensorRT のエンジンは shape ごとに
+        // ビルドされるため，warmup が実運用と同じ 1 局面バッチを通すことが重要
+        let ev = CountingEvaluator {
+            calls: AtomicUsize::new(0),
+            last_batch: Mutex::new(Vec::new()),
+        };
+        warmup(&ev);
+        let batch = ev.last_batch.lock().expect("poisoned").clone();
+        assert_eq!(batch, vec![30], "1 局面 × 合法手 30 手のバッチ");
+    }
+
+    #[test]
+    fn test_startpos_sfen_parses() {
+        let mut board = Board::empty();
+        board
+            .set_sfen(STARTPOS_SFEN)
+            .expect("STARTPOS_SFEN は正当な SFEN");
+        assert_eq!(generate_legal_moves(&mut board).len(), 30);
     }
 }

--- a/rust/maou_search/src/lib.rs
+++ b/rust/maou_search/src/lib.rs
@@ -49,7 +49,7 @@ pub mod search;
 pub mod tree;
 
 pub use eval::winrate_to_eval;
-pub use evaluator::{EvalItem, EvalResult, Evaluator, MockEvaluator};
+pub use evaluator::{warmup, EvalItem, EvalResult, Evaluator, MockEvaluator, STARTPOS_SFEN};
 #[cfg(feature = "onnx")]
 pub use onnx::OnnxEvaluator;
 pub use position::{build_board_and_history, PositionSetupError};

--- a/rust/maou_search/src/search.rs
+++ b/rust/maou_search/src/search.rs
@@ -1806,8 +1806,8 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
 mod tests {
     use super::*;
     use crate::evaluator::MockEvaluator;
+    use crate::STARTPOS_SFEN as STARTPOS;
 
-    const STARTPOS: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
     /// 先手: 5三歩・金 1 枚 (持駒)，後手: 5一玉のみ．G*5b (5二金打) の 1 手詰め．
     const MATE_IN_1: &str = "4k4/9/4P4/9/9/9/9/9/9 b G 1";
 
@@ -2468,6 +2468,82 @@ mod tests {
             std::thread::sleep(self.per_item * items.len() as u32);
             self.inner.evaluate_batch(items)
         }
+    }
+
+    /// 初回推論だけが極端に遅い評価器 (TensorRT のエンジンビルドを模す)．
+    ///
+    /// ONNX Runtime の TensorRT EP は最初の `evaluate_batch` でエンジンを
+    /// ビルドするため，1 回目だけ数十秒かかり 2 回目以降は速い．
+    struct SlowFirstCallEvaluator {
+        first_call_delay: Duration,
+        called: AtomicBool,
+        inner: MockEvaluator,
+    }
+
+    impl SlowFirstCallEvaluator {
+        fn new(first_call_delay: Duration) -> Self {
+            SlowFirstCallEvaluator {
+                first_call_delay,
+                called: AtomicBool::new(false),
+                inner: MockEvaluator::new(0),
+            }
+        }
+    }
+
+    impl Evaluator for SlowFirstCallEvaluator {
+        fn evaluate_batch(&self, items: &[EvalItem]) -> Vec<crate::EvalResult> {
+            if !self.called.swap(true, Ordering::SeqCst) {
+                std::thread::sleep(self.first_call_delay);
+            }
+            self.inner.evaluate_batch(items)
+        }
+    }
+
+    /// **warmup を予算の外で前払いすると探索できる**ことの回帰テスト．
+    ///
+    /// 期限は `budget_start` (= 呼び出し時刻) 起点なので，初回推論の固定費を
+    /// 予算の内側で払うと短い予算では playout が 0 になる．実機で
+    /// `maou search --time-ms 3000` が TensorRT の cold cache (32 秒の
+    /// エンジンビルド) で playouts=0 になった (2026-07-29)．
+    ///
+    /// 予算セマンティクス自体は変えない (USI/CSA の切れ負け防止に必要) —
+    /// 呼び出し側が予算を張る前に [`crate::warmup`] を呼ぶ，が解法．
+    #[test]
+    fn test_warmup_before_budget_enables_search_under_short_budget() {
+        const BUDGET_MS: u64 = 300;
+        // 初回推論が予算より長い = 前払いしなければ確実に playout 0 になる
+        let first_call = Duration::from_millis(BUDGET_MS * 2);
+        let opts = || SearchOptions {
+            threads: 1,
+            batch_size: 4,
+            node_capacity: 1 << 12,
+            ..pure_mcts_opts()
+        };
+        let limits = SearchLimits {
+            time_ms: Some(BUDGET_MS),
+            ..SearchLimits::default()
+        };
+        let mut board = Board::empty();
+        board.set_sfen(STARTPOS).expect("startpos");
+
+        // 前払いなし: 初回推論 (= root 評価) が予算を食い切る
+        let cold = SlowFirstCallEvaluator::new(first_call);
+        let cold_result = Searcher::new(&cold, opts()).search(&board, &limits);
+
+        // 前払いあり: 予算の外で初回推論を済ませてから探索する
+        let warm = SlowFirstCallEvaluator::new(first_call);
+        crate::warmup(&warm);
+        let warm_result = Searcher::new(&warm, opts()).search(&board, &limits);
+
+        assert_eq!(
+            cold_result.stats.playouts, 0,
+            "前払いしなければ初回推論で予算を使い切る (この前提が崩れたらテストが無意味)"
+        );
+        assert!(
+            warm_result.stats.playouts > 0,
+            "前払いすれば予算ぶん探索できる: playouts={}",
+            warm_result.stats.playouts
+        );
     }
 
     /// **壁時計が時間予算を超えないこと**の回帰テスト．

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -22,7 +22,9 @@ use crate::time::{allocate, should_stop, TimeBudget, TimeStrategyConfig};
 pub type Emit<'a> = dyn FnMut(EngineCommand) + 'a;
 
 /// 平手初期局面 (USI `position startpos`)．
-pub const STARTPOS_SFEN: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+///
+/// 定義は [`maou_search::STARTPOS_SFEN`] が正 (warmup と共有する単一実装)．
+pub use maou_search::STARTPOS_SFEN;
 
 /// `USI_Hash` (MB) → ノードプール容量の換算に使う 1 ノードあたりの概算バイト数．
 ///

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -10,16 +10,14 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use maou_search::{
-    build_board_and_history, EvalItem, Evaluator, MockEvaluator, ReusableTree, RootSnapshot,
-    SearchLimits, SearchOptions, SearchResult, Searcher, StopCause,
+    build_board_and_history, MockEvaluator, ReusableTree, RootSnapshot, SearchLimits,
+    SearchOptions, SearchResult, Searcher, StopCause,
 };
-use maou_shogi::board::Board;
 use maou_shogi::dfpn::{DfPnSolver, TsumeResult};
-use maou_shogi::movegen::generate_legal_moves;
 
 use crate::agent::{
     EngineConfig, GoRules, ProgressSnapshot, SearchBackend, SearchBudget, SearchObserver,
-    SearchOutcome, STARTPOS_SFEN,
+    SearchOutcome,
 };
 use crate::protocol::CheckmateResult;
 
@@ -70,20 +68,10 @@ pub(crate) fn build_evaluator(config: &EngineConfig) -> Result<EngineEvaluator, 
 /// 平手初期局面を 1 回評価して初回推論の固定費 (TensorRT エンジンビルド/
 /// CUDA 初期化) を前払いする (USI では `isready` 中，自己対局では起動時)．
 pub(crate) fn warmup_evaluator(evaluator: &EngineEvaluator) -> Result<(), String> {
-    let mut board = Board::empty();
-    board
-        .set_sfen(STARTPOS_SFEN)
-        .map_err(|e| format!("startpos SFEN must parse: {e:?}"))?;
-    let moves = generate_legal_moves(&mut board.clone());
-    let item = [EvalItem { board, moves }];
     match evaluator {
-        EngineEvaluator::Mock(e) => {
-            let _ = e.evaluate_batch(&item);
-        }
+        EngineEvaluator::Mock(e) => maou_search::warmup(e),
         #[cfg(feature = "onnx")]
-        EngineEvaluator::Onnx(e) => {
-            let _ = e.evaluate_batch(&item);
-        }
+        EngineEvaluator::Onnx(e) => maou_search::warmup(e),
     }
     Ok(())
 }
@@ -358,6 +346,8 @@ fn to_outcome(r: &SearchResult) -> SearchOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::STARTPOS_SFEN;
+    use maou_shogi::movegen::generate_legal_moves;
     use std::sync::atomic::Ordering;
 
     fn config() -> EngineConfig {

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.66.0"
+version = "0.67.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 背景

Colab L4 の実機で `maou search --time-ms 3000` が **playouts=0** で返った:

```
Bestmove: 1g1f
Eval: -16578.61
Stats: playouts=0 ... elapsed_ms=175 warmup_ms=32227 stop=time_limit
```

TensorRT の cold cache でエンジンビルドに **32.2 秒**かかり、3 秒の予算を使い切っていた。
`Bestmove: 1g1f` は合法手生成順の先頭 (`select_best_root_index`) で、評価に基づく手ではない。

## 方針

時間予算の期限は `budget_start` (呼び出し側が `go` を受けた時刻) 起点で、warmup も予算に数える。
**これは対局経路の要件なので変えない** — GUI/サーバは指し手送信から `bestmove` 受信までを消費時間として計るため、
予算の外で払った時間はそのまま持ち時間の超過になる (`test_wall_clock_stays_within_time_budget` が過去のバグを記録)。

代わりに **予算を張る前に前払いする**。USI が `isready`、CSA が対局開始前に既にやっていたことを、CLI と `SearchEngine` にも適用した。

| 経路 | 前払いの位置 | 状態 |
|---|---|---|
| USI | `isready` 中 (`readyok` 前) | 既存 |
| CSA (floodgate) | 対局ループ開始前 | 既存 |
| 自己対局 | driver 起動時 | 既存 |
| CLI `maou search` | 探索開始前 | **本 PR** |
| `SearchEngine` (棋譜解析) | コンストラクタ | **本 PR** |

## 変更内容

- `maou_search` に `warmup` / `STARTPOS_SFEN` を追加。平手初期局面を 1 回評価するだけの関数
- `maou_rust` の `run_search` と `SearchEngine.__init__` から呼ぶ (GIL は解放したまま)
- `maou_usi::backend::warmup_evaluator` と `agent::STARTPOS_SFEN` を `maou_search` の単一実装へ委譲 (定数とロジックの重複解消)

`SearchEngine` をコンストラクタで前払いすることで、棋譜解析 (局面ごとに予算を配分する) の最初の 1 局面だけ削られる問題も同時に解消する。

## 破壊的変更

`maou search` の壁時計が `warmup + --time-ms` になる (従来は概ね `--time-ms` に収まっていた)。
`--time-ms` は「探索に使う時間」の意味に変わる。**対局経路の予算挙動は不変**。

## 検証

`test_warmup_before_budget_enables_search_under_short_budget` を追加。初回だけ遅い評価器 (エンジンビルドを模す) で、
**前払いなし = playouts 0 / 前払いあり = playouts > 0** を決定論的に固定した。

CPU には遅延初期化がないため **実機 CPU 計測では差が出ない** (TensorRT/CUDA 固有の問題)。
`--time-ms 3000` で playouts=60 と、変更前と同じ結果になることは確認済み (非回帰)。

Rust `maou_search` 91 + `maou_usi` 133 + E2E / Python 1,683 passed + 47 skipped / clippy・fmt clean / pre-commit 全 Passed。
`search.rs` の探索セマンティクス (選択・伝播・予算判定) には触れていないため canonical 29te/39te は非該当。

## 未マージの提案

`reviews/2026-07-29-warmup-outside-cli-budget.md` (`status: pending`) を同梱。
「初回推論の固定費をどこで払うか」を `docs/design/position-search/index.md` に §3.5 として起こす提案で、
承認後に反映する (CLAUDE.md の memory-architecture 規定に従い docs/design は直接編集していない)。

## 版数

`maou` 0.66.0 → **0.67.0** / `maou_search` 0.27.0 → **0.28.0** / `maou_usi` 0.22.0 → **0.22.1** / `maou_rust` 0.38.0 → **0.39.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)