### PR TITLE
feat(search): 受け方向詰み探索の発火量を数える計器を入れる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "maou_rust"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "arrow",
  "arrow-pyarrow",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "maou_search"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "maou_shogi",
  "ort",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/design/usi-engine/verification.md
+++ b/docs/design/usi-engine/verification.md
@@ -474,6 +474,222 @@ GPU が評価している間の**遊んでいる CPU 時間**で起きるため�
 `..._keeps_better_unproven_move` で pin)．千日手模様の指し手選択が変わるので，
 **棋力 A/B の前に千日手判定の回帰 (`reasons` の `repetition` 件数) も見ること**．
 
+## 4.7 受け方向の詰み探索 (`--ab-mode defmate`) — GPU 検証
+
+環境構築は §1 のとおり (wheel + `ldconfig` + モデル配置)．以下は
+**その続きから流す Colab の python セル列**．
+
+### セル 1 — 共通設定と pin 局面
+
+```python
+# 4.7-1. 共通設定．以降のセルはこの変数を使う．
+import json, re, subprocess, statistics, time
+
+MODEL = "/content/model_fp16.onnx"
+GPU = ["--model-path", MODEL, "--tensorrt", "--cuda",
+       "--threads", "1", "--batch-size", "64",
+       "--trt-cache-dir", "/content/trt_cache"]
+
+# 自己対局で実際に踏んだ局面 (game_0006)．
+BLUNDER = "l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1NR3/1G1PPg3/1S2K1+b2/LN7 b BSgsnl8p 117"
+MATED   = "l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1N4/1G1PPR3/1S2K1+b2/LN1s5 b BGSgnl8p 119"
+QUIET   = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+
+def run_search(sfen, time_ms=11000, defensive=True):
+    """maou search を叩いて bestmove / 候補 / Stats を返す."""
+    cmd = (["maou", "search", "--sfen", sfen, "--time-ms", str(time_ms)]
+           + GPU + (["--defensive-mate"] if defensive else ["--no-defensive-mate"]))
+    out = subprocess.run(cmd, capture_output=True, text=True).stdout
+    best = re.search(r"^Bestmove:\s*(\S+)", out, re.M)
+    winrate = re.search(r"^WinRate:\s*([\d.]+)", out, re.M)
+    stats = dict(re.findall(r"(\w+)=([\w.-]+)", re.search(r"^Stats:.*", out, re.M).group(0)))
+    cands = re.findall(r"^(\S+) \(visits=(\d+),.*?(proven=\w+)?\)$", out, re.M)
+    return {"best": best.group(1) if best else None,
+            "winrate": float(winrate.group(1)) if winrate else None,
+            "stats": stats, "cands": cands, "raw": out}
+
+print("ok")
+```
+
+TensorRT 有効時は teardown 回避のため destructor を走らせずに終了するが
+(§8.5)，**出力は flush 済みで exit code も 0** なので `subprocess` で問題なく
+拾える．
+
+### セル 2 — Stage A: 機構が実機で発火するか
+
+```python
+# 4.7-2. Stage A: pin 局面 3 つで発火と着手を確認する (各 11 秒 × 4 回 ≒ 1 分)．
+def check(label, cond, detail):
+    print(f"[{'OK ' if cond else 'NG '}] {label}: {detail}")
+    return cond
+
+ok = True
+
+# A-1 敗着局面 (まだ受かる / 合法手 4)．
+r = run_search(BLUNDER); rb = run_search(BLUNDER, defensive=False)
+n_loss = sum(1 for c in r["cands"] if c[2])
+ok &= check("A-1 bestmove", r["best"] == "5h6i", f"{r['best']} (対照 {rb['best']})")
+ok &= check("A-1 除外手数", n_loss == 3, f"proven=loss が {n_loss} 手")
+ok &= check("A-1 発火", int(r["stats"]["filtered_root_moves"]) >= 1,
+            f"filtered_root_moves={r['stats']['filtered_root_moves']} "
+            f"defensive_mates={r['stats']['defensive_mates']}")
+for mv, v, pv in r["cands"]:
+    print(f"      {mv:6s} visits={int(v):>8,} {pv or ''}")
+
+# A-2 被詰み局面 (もう詰んでいる)．
+r = run_search(MATED); rb = run_search(MATED, defensive=False)
+ok &= check("A-2 勝率", r["winrate"] == 0.0, f"{r['winrate']} (対照 {rb['winrate']})")
+ok &= check("A-2 発火", int(r["stats"]["defensive_mates"]) >= 1,
+            f"defensive_mates={r['stats']['defensive_mates']}")
+
+# A-3 静かな局面 (偽陽性ゼロ)．
+r = run_search(QUIET)
+ok &= check("A-3 偽陽性なし",
+            int(r["stats"]["defensive_mates"]) == 0
+            and int(r["stats"]["filtered_root_moves"]) == 0,
+            f"defensive_mates={r['stats']['defensive_mates']} "
+            f"filtered_root_moves={r['stats']['filtered_root_moves']}")
+
+print("\nStage A:", "PASS" if ok else "FAIL — 下の判定表を参照")
+```
+
+| 判定 | 期待 | 外れたときに疑うこと |
+|---|---|---|
+| A-1 bestmove = `5h6i` | 唯一の受かる手 | 対照と同じ手なら未発火か gate 外れ |
+| A-1 `proven=loss` が 3 手 | 4f4g(mate-41) / 5h5i(mate-1) / 5h6h(mate-29) | 予算不足なら `--time-ms` を上げる |
+| A-2 `WinRate = 0.0` | 被詰みの正直な報告 | 対照は 0.49 前後の互角 |
+| A-3 両カウンタ 0 | 偽陽性ゼロ | **0 でなければ即調査** (偽の被詰みは自滅につながる) |
+
+**`filtered_root_moves` が 3 未満でも異常ではない** — 木の proven 伝播
+(leaf-mate 経由) が先に確定させた手はフィルタが上書きしないため内訳は動く．
+**見るべきは「除外が 3 手」と「bestmove = 5h6i」**．
+
+DevContainer / mock 評価器での実測 (参考値．GPU では内訳が動く):
+
+```
+Bestmove: 5h6i
+5h6i (visits=990,    winrate=0.4846)               ← 選ばれた
+5h6h (visits=541509, winrate=0.4987, proven=loss)
+4f4g (visits=482872, winrate=0.4988, proven=loss)  ← 対局で選んだ敗着
+5h5i (visits=1744,   winrate=0.1197, proven=loss)
+Stats: ... leaf_mates=6439 defensive_mates=19 filtered_root_moves=2 ...
+```
+
+**visits では敗着が 50 万回で圧倒的なのに 990 回の手が選ばれる** — MCTS の
+訪問分布では敗着が勝っており，確定値の除外だけが手を変えている．
+A-2 は `WinRate 0.0000` / `defensive_mates=50` / `filtered_root_moves=0`
+(既に詰みなら候補選別はしない = 設計どおり)．
+
+### セル 3 — Stage B: CPU 競合で探索速度を奪わないか
+
+```python
+# 4.7-3. Stage B: 静かな局面で nps を on/off 比較する (各 15 秒 × 2 回)．
+import os
+print("vCPU:", os.cpu_count(),
+      "/ 常駐スレッド = MCTS 1 + 攻め dfpn 1 + 受け dfpn 1 + leaf-mate 1 = 4")
+
+on  = run_search(QUIET, time_ms=15000, defensive=True)
+off = run_search(QUIET, time_ms=15000, defensive=False)
+nps_on, nps_off = int(on["stats"]["nps"]), int(off["stats"]["nps"])
+drop = (1 - nps_on / nps_off) * 100
+print(f"nps on={nps_on:,} off={nps_off:,} → 低下 {drop:.1f}%")
+print(f"充填率 on={float(on['stats']['avg_batch'])/64:.2f} "
+      f"off={float(off['stats']['avg_batch'])/64:.2f} "
+      f"(外れ値を見たら充填率と collisions を必ず併記する — §1)")
+print("判定:", "許容 (<5%)" if drop < 5 else "要調査 (>=5%) — 並列度は上げない")
+```
+
+**静かな局面で測る**こと．gate 該当は全局面の 7.6% (終盤 21.6%) なので，
+静かな局面での低下はそのまま「常時払う税」になる．
+5% 以上なら `--defensive-mate-threads` を上げずに Stage C へ進む．
+
+### セル 4 — Stage C: 棋力 A/B
+
+```python
+# 4.7-4. Stage C: A/B 40 局．持ち時間モード必須 / --parallel 1 必須 / GPU 必須．
+!maou selfplay --ab-mode defmate --clock-ms 300000 --inc-ms 10000 \
+    --games 40 --parallel 1 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 1 --batch-size 64 --trt-cache-dir /content/trt_cache \
+    --output /content/ab_defmate.jsonl --kifu-dir /content/kifu_defmate
+```
+
+regime ゲート (先に通すこと):
+
+- **持ち時間モード必須** — 固定 playout 予算では敗着フィルタが使える壁時計が
+  変わる (フィルタは MCTS 終了の停止フラグで打ち切られる)
+- **`--parallel 1` 必須** — フィルタが CPU を使うので同時対局は互いを歪める
+- **GPU 必須** — CPU 22 p/s では手の分布が別物になる
+
+**期待効果の見積り**: CPU 全数走査では 30 局中 7 局 (23%) に「避けられた
+強制詰みの敗着」があった．1 局あたり平均 0.23 手の改善であり，
+**n=40 が検出できる ~150 Elo 級に届くかは未知**．有意にならなくても
+機構が効いていないことにはならない — だから Stage D を併せて見る．
+
+### セル 5 — Stage D: 棋譜による直接確認 (Elo より感度が高い)
+
+```python
+# 4.7-5. Stage D: A/B の棋譜を走査し「避けられた敗着」を A/B で数える．
+#   1. 合法手 <= 16 を gate  2. 各合法手を指した後を攻め方向 dfpn で判定
+#   3. 「指した手が敗着 かつ 安全な代替手が存在した」を数える
+import glob, re
+from maou._rust import maou_shogi as S
+
+START = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+STAGES = [1_000, 50_000, 500_000]   # production と同じ段階予算
+
+def scan(path):
+    """1 局を走査し，避けられた敗着の明細を返す (A/B の割当は CSA の N+ から)."""
+    text = open(path).read()
+    m = re.search(r"^N\+(.*)$", text, re.M)
+    black_is_a = (m.group(1).strip().upper() == "A") if m else True
+    rec = S.parse_csa_str(text)[0]
+    b = S.PyBoard(); b.set_sfen(rec.sfen or START)
+    hits = []
+    for i, mv in enumerate(rec.moves):
+        legal = b.legal_moves()
+        if len(legal) <= 16:
+            played = S.move_to_usi(mv)
+            unresolved, losing, safe = list(legal), [], []
+            for budget in STAGES:
+                nxt = []
+                for m2 in unresolved:
+                    b.push(m2); child = b.sfen(); b.pop()
+                    # find_shortest=False 必須 — 既定 (True) は最小性を確定
+                    # できないと Unknown を返し，長手数の詰みを見逃す
+                    r = S.solve_tsume(child, nodes=budget,
+                                      find_shortest=False, timeout_secs=60)
+                    (losing if r.status == "checkmate" else
+                     safe if r.status == "no_checkmate" else nxt).append(m2)
+                unresolved = nxt
+                if not unresolved:
+                    break
+            if played in [S.move_to_usi(x) for x in losing] and safe:
+                side = "A" if ((i + 1) % 2 == 1) == black_is_a else "B"
+                hits.append({"ply": i + 1, "side": side, "played": played,
+                             "safe": [S.move_to_usi(x) for x in safe][:3]})
+        b.push(mv)
+    return hits
+
+tally = {"A": 0, "B": 0}
+for path in sorted(glob.glob("/content/kifu_defmate/game_*.csa")):
+    for h in scan(path):
+        tally[h["side"]] += 1
+        print(f"  {path.split('/')[-1]} ply{h['ply']:3d} [{h['side']}] "
+              f"{h['played']} → 安全手 {h['safe']}")
+print(f"\n避けられた敗着: A={tally['A']} B={tally['B']}")
+print("判定:", "機構は効いている" if tally["A"] < tally["B"] else "要調査")
+```
+
+判定: **A 側の件数が B 側より少なければ機構は効いている**．Elo が有意で
+なくても，この差は直接観測できる (30 局の事前走査では 7 件あった)．
+
+### 記録先
+
+結果は §9 のとおり worklog + compass へ．A/B が有意でなかった場合も
+**「発火したが Elo 差は検出限界未満」と「発火しなかった」を必ず区別して
+書くこと** — 前者は追試の対象，後者は実装のバグである．
+
 ## 5. 未決 5: バッチ aggregator の採否
 
 同時対局数を振って **wall clock ベースの playouts/秒** (`throughput:` 行) を

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.72.0"
+version = "0.73.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-08-01-defensive-mate-gpu-verification.md
+++ b/reviews/2026-08-01-defensive-mate-gpu-verification.md
@@ -1,0 +1,168 @@
+---
+title: 受け方向詰み探索の GPU 検証手順を verification.md に追加する
+date: 2026-08-01
+status: pending
+target:
+  - docs/design/usi-engine/verification.md
+risk: low
+reversibility: trivial
+---
+
+# 提案: §4.7 に受け方向詰み探索 (`--ab-mode defmate`) の検証手順を追加する
+
+## Trigger
+
+user 指示「Colab の L4 で GPU 環境確認を実施するので，検証方法を提示して
+ほしい」．PR #424 (`8412f48`) でマージした受け方向詰み探索の GPU 検証．
+
+CPU 側の全数走査は済んでいる (gate 該当 7.6% / 30 局中 7 局に避けられた敗着)．
+GPU で確かめるのは **(a) 機構が実機で発火するか / (b) CPU 競合で探索速度を
+奪わないか / (c) 棋力に効くか** の 3 点．
+
+## 前提 — 計器
+
+発火量を数えられなければ「効果なし」と結論してはいけない (計測規律)．
+`SearchStats` に 2 つのカウンタを追加した:
+
+- `defensive_mates` — 受け方向が「手番側が詰まされる」と証明した回数
+  (root + 王手中の葉)．**0 なら機構が発火していない**
+- `filtered_root_moves` — 敗着として除外した root 候補手の数．
+  **0 なら着手選択に影響していない**
+
+`maou search` の出力行と PyO3 の `PySearchResult` に出る
+(`maou analyze-game` も同じ `SearchEngine` 経由なので棋譜の再解析で拾える)．
+
+---
+
+# 検証手順 (本レビューの追加対象)
+
+環境は §1 のとおり．以下は共通の GPU 引数とする:
+
+```
+GPU="--threads 1 --batch-size 64 --tensorrt --cuda --trt-cache-dir trt_cache/"
+MODEL="--model-path model_20260725_044443_vit-19.8m_32_fp16.onnx"
+```
+
+## Stage A — 機構が実機で発火するか (3 局面 / 数分)
+
+自己対局で実際に踏んだ局面を pin してある．**期待値まで一致すること**を見る．
+
+### A-1 敗着局面 (まだ受かる / 合法手 4)
+
+```
+maou search --sfen 'l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1NR3/1G1PPg3/1S2K1+b2/LN7 b BSgsnl8p 117' \
+  --time-ms 11000 $MODEL $GPU
+```
+
+| 期待 | 値 |
+|---|---|
+| bestmove | **5h6i** (唯一の受かる手) |
+| 候補一覧 | 残り 3 手すべてに `proven=loss` (4f4g / 5h5i / 5h6h) |
+| `filtered_root_moves` | **1 以上** |
+| `defensive_mates` | **1 以上** |
+
+**`filtered_root_moves` が 3 未満でも異常ではない** — 木の proven 伝播
+(leaf-mate 経由) が先に確定させた手はフィルタが上書きしないため，内訳は
+実行ごとに動く．**見るべきは「除外が 3 手」と「bestmove = 5h6i」**．
+
+対照 (`--no-defensive-mate`): `filtered_root_moves=0`．対局では 4f4g を選び
+11 手後に詰まされた．**bestmove が変わることがこの機構の存在理由**なので，
+両者で同じ手が出た場合は発火していないか gate に掛かっていないかを疑う．
+
+DevContainer / mock 評価器での実測 (参考値．GPU では内訳が動く):
+
+```
+Bestmove: 5h6i
+5h6i (visits=990,    winrate=0.4846, proven なし)
+5h6h (visits=541509, winrate=0.4987, proven=loss)
+4f4g (visits=482872, winrate=0.4988, proven=loss)   ← 対局で選んだ敗着
+5h5i (visits=1744,   winrate=0.1197, proven=loss)
+Stats: ... leaf_mates=6439 defensive_mates=19 filtered_root_moves=2 ...
+```
+
+**visits では 5h6h / 4f4g が 50 万回で圧倒的なのに 990 回の 5h6i が選ばれる**
+— MCTS の訪問分布では敗着が勝っており，確定値の除外だけが手を変えている．
+
+### A-2 被詰み局面 (もう詰んでいる / 合法手 3)
+
+```
+maou search --sfen 'l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1N4/1G1PPR3/1S2K1+b2/LN1s5 b BGSgnl8p 119' \
+  --time-ms 11000 $MODEL $GPU
+```
+
+| 期待 | 値 |
+|---|---|
+| `defensive_mates` | **1 以上** |
+| `WinRate` | **0.0000** (対照は 0.49 前後の互角) |
+| bestmove | 5h6i (最長抵抗 = mate-40) |
+| `filtered_root_moves` | **0** — 既に詰んでいるので候補選別はしない (設計どおり) |
+
+**ここが「相手の手番だけ詰みが見えて自分の手番では互角を示す」の直接の反証**．
+DevContainer / mock 実測: `WinRate: 0.0000` / `defensive_mates=50` /
+`filtered_root_moves=0`．
+
+### A-3 静かな局面 (偽陽性ゼロと無害性)
+
+```
+maou search --sfen 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1' \
+  --time-ms 11000 $MODEL $GPU
+```
+
+期待: `defensive_mates=0` かつ `filtered_root_moves=0`．
+**偽の被詰みは投了・自滅につながるので，ここが 0 でなければ即調査**．
+DevContainer / mock 実測: `WinRate: 0.5000` / 両カウンタ 0．
+
+## Stage B — CPU 競合で探索速度を奪わないか
+
+Stage A-3 と同じ静かな局面で `--defensive-mate` / `--no-defensive-mate` の
+`nps` を比べる．GPU 律速なら差は小さいはず．
+
+先に `nproc` で vCPU 数を確認する — 常駐スレッドは
+MCTS 1 + 攻め dfpn 1 + 受け dfpn 1 + leaf-mate 1 = **4 本**になる．
+`--defensive-mate-threads` を上げる場合はさらに増える．
+
+| 判定 | 基準 |
+|---|---|
+| 許容 | nps 低下 5% 未満 |
+| 要調査 | 5% 以上 → `--defensive-mate-threads 1` のまま A/B へ (並列度を上げない) |
+
+**gate 該当が全局面の 7.6% (終盤 21.6%) なので，静かな局面での低下は
+そのまま「常時払う税」になる**．ここは終盤の局面ではなく静かな局面で測る．
+
+## Stage C — 棋力 A/B (`--ab-mode defmate`)
+
+```
+maou selfplay --ab-mode defmate --clock-ms 300000 --inc-ms 10000 \
+  --games 40 --parallel 1 $MODEL $GPU \
+  --output ab_defmate.jsonl --kifu-dir kifu_defmate/
+```
+
+regime ゲート (先に通すこと):
+
+- **持ち時間モード必須** — 固定 playout 予算では敗着フィルタが使える壁時計が
+  変わってしまう (フィルタは MCTS 終了の停止フラグで打ち切られる)
+- **`--parallel 1` 必須** — フィルタが CPU を使うので同時対局は互いを歪める
+- **GPU 必須** — CPU 22 p/s では手の分布が別物になる
+
+**期待効果の見積り**: CPU 全数走査では 30 局中 7 局 (23%) に「避けられた
+強制詰みの敗着」があった．1 局あたり平均 0.23 手の改善であり，
+**n=40 が検出できる ~150 Elo 級に届くかは未知**．有意にならなくても
+機構が効いていないことにはならない — だから Stage D を併せて見る．
+
+## Stage D — 棋譜による直接確認 (Elo より感度が高い)
+
+`--kifu-dir` の CSA を CPU 側と同じ走査に掛け，**A 側の敗着回数が B 側より
+減っているか**を見る．これが最も直接的な効果指標:
+
+1. 各局面で合法手 ≤ 16 を gate
+2. 各合法手を指した後の局面を攻め方向 dfpn (`find_shortest=false`) で判定
+3. 「指した手が敗着 かつ 安全な代替手が存在した」件数を A/B で比較
+
+判定: **A 側の件数が B 側より少なければ機構は効いている**．Elo が有意で
+なくても，この差は直接観測できる．
+
+## 記録先
+
+結果は §9 のとおり worklog + compass へ．A/B が有意でなかった場合も
+**「発火したが Elo 差は検出限界未満」と「発火しなかった」を必ず区別して
+書くこと** — 前者は追試の対象，後者は実装のバグである．

--- a/reviews/2026-08-01-defensive-mate-gpu-verification.md
+++ b/reviews/2026-08-01-defensive-mate-gpu-verification.md
@@ -1,7 +1,8 @@
 ---
 title: 受け方向詰み探索の GPU 検証手順を verification.md に追加する
 date: 2026-08-01
-status: pending
+status: applied
+applied_in: PENDING
 target:
   - docs/design/usi-engine/verification.md
 risk: low
@@ -13,7 +14,8 @@ reversibility: trivial
 ## Trigger
 
 user 指示「Colab の L4 で GPU 環境確認を実施するので，検証方法を提示して
-ほしい」．PR #424 (`8412f48`) でマージした受け方向詰み探索の GPU 検証．
+ほしい」「Colab の python セルで実行する形式に修正したうえで承認する」．
+PR #424 (`8412f48`) でマージした受け方向詰み探索の GPU 検証．
 
 CPU 側の全数走査は済んでいる (gate 該当 7.6% / 30 局中 7 局に避けられた敗着)．
 GPU で確かめるのは **(a) 機構が実機で発火するか / (b) CPU 競合で探索速度を
@@ -21,126 +23,163 @@ GPU で確かめるのは **(a) 機構が実機で発火するか / (b) CPU 競�
 
 ## 前提 — 計器
 
-発火量を数えられなければ「効果なし」と結論してはいけない (計測規律)．
-`SearchStats` に 2 つのカウンタを追加した:
+発火量を数えられなければ「効果なし」と結論してはいけない (計測規律 §10.2)．
+`SearchStats` に 2 つのカウンタがある (PR #425):
 
 - `defensive_mates` — 受け方向が「手番側が詰まされる」と証明した回数
   (root + 王手中の葉)．**0 なら機構が発火していない**
 - `filtered_root_moves` — 敗着として除外した root 候補手の数．
   **0 なら着手選択に影響していない**
 
-`maou search` の出力行と PyO3 の `PySearchResult` に出る
+`maou search` の Stats 行と PyO3 `PySearchResult` に出る
 (`maou analyze-game` も同じ `SearchEngine` 経由なので棋譜の再解析で拾える)．
 
 ---
 
-# 検証手順 (本レビューの追加対象)
+# 検証手順 (本レビューの追加対象 — verification.md §4.7)
 
-環境は §1 のとおり．以下は共通の GPU 引数とする:
+環境構築は §1 のとおり (wheel + `ldconfig` + モデル配置)．以下は
+**その続きから流す Colab の python セル列**．
 
+## セル 1 — 共通設定と pin 局面
+
+```python
+# 4.7-1. 共通設定．以降のセルはこの変数を使う．
+import json, re, subprocess, statistics, time
+
+MODEL = "/content/model_fp16.onnx"
+GPU = ["--model-path", MODEL, "--tensorrt", "--cuda",
+       "--threads", "1", "--batch-size", "64",
+       "--trt-cache-dir", "/content/trt_cache"]
+
+# 自己対局で実際に踏んだ局面 (game_0006)．
+BLUNDER = "l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1NR3/1G1PPg3/1S2K1+b2/LN7 b BSgsnl8p 117"
+MATED   = "l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1N4/1G1PPR3/1S2K1+b2/LN1s5 b BGSgnl8p 119"
+QUIET   = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+
+def run_search(sfen, time_ms=11000, defensive=True):
+    """maou search を叩いて bestmove / 候補 / Stats を返す."""
+    cmd = (["maou", "search", "--sfen", sfen, "--time-ms", str(time_ms)]
+           + GPU + (["--defensive-mate"] if defensive else ["--no-defensive-mate"]))
+    out = subprocess.run(cmd, capture_output=True, text=True).stdout
+    best = re.search(r"^Bestmove:\s*(\S+)", out, re.M)
+    winrate = re.search(r"^WinRate:\s*([\d.]+)", out, re.M)
+    stats = dict(re.findall(r"(\w+)=([\w.-]+)", re.search(r"^Stats:.*", out, re.M).group(0)))
+    cands = re.findall(r"^(\S+) \(visits=(\d+),.*?(proven=\w+)?\)$", out, re.M)
+    return {"best": best.group(1) if best else None,
+            "winrate": float(winrate.group(1)) if winrate else None,
+            "stats": stats, "cands": cands, "raw": out}
+
+print("ok")
 ```
-GPU="--threads 1 --batch-size 64 --tensorrt --cuda --trt-cache-dir trt_cache/"
-MODEL="--model-path model_20260725_044443_vit-19.8m_32_fp16.onnx"
+
+TensorRT 有効時は teardown 回避のため destructor を走らせずに終了するが
+(§8.5)，**出力は flush 済みで exit code も 0** なので `subprocess` で問題なく
+拾える．
+
+## セル 2 — Stage A: 機構が実機で発火するか
+
+```python
+# 4.7-2. Stage A: pin 局面 3 つで発火と着手を確認する (各 11 秒 × 4 回 ≒ 1 分)．
+def check(label, cond, detail):
+    print(f"[{'OK ' if cond else 'NG '}] {label}: {detail}")
+    return cond
+
+ok = True
+
+# A-1 敗着局面 (まだ受かる / 合法手 4)．
+r = run_search(BLUNDER); rb = run_search(BLUNDER, defensive=False)
+n_loss = sum(1 for c in r["cands"] if c[2])
+ok &= check("A-1 bestmove", r["best"] == "5h6i", f"{r['best']} (対照 {rb['best']})")
+ok &= check("A-1 除外手数", n_loss == 3, f"proven=loss が {n_loss} 手")
+ok &= check("A-1 発火", int(r["stats"]["filtered_root_moves"]) >= 1,
+            f"filtered_root_moves={r['stats']['filtered_root_moves']} "
+            f"defensive_mates={r['stats']['defensive_mates']}")
+for mv, v, pv in r["cands"]:
+    print(f"      {mv:6s} visits={int(v):>8,} {pv or ''}")
+
+# A-2 被詰み局面 (もう詰んでいる)．
+r = run_search(MATED); rb = run_search(MATED, defensive=False)
+ok &= check("A-2 勝率", r["winrate"] == 0.0, f"{r['winrate']} (対照 {rb['winrate']})")
+ok &= check("A-2 発火", int(r["stats"]["defensive_mates"]) >= 1,
+            f"defensive_mates={r['stats']['defensive_mates']}")
+
+# A-3 静かな局面 (偽陽性ゼロ)．
+r = run_search(QUIET)
+ok &= check("A-3 偽陽性なし",
+            int(r["stats"]["defensive_mates"]) == 0
+            and int(r["stats"]["filtered_root_moves"]) == 0,
+            f"defensive_mates={r['stats']['defensive_mates']} "
+            f"filtered_root_moves={r['stats']['filtered_root_moves']}")
+
+print("\nStage A:", "PASS" if ok else "FAIL — 下の判定表を参照")
 ```
 
-## Stage A — 機構が実機で発火するか (3 局面 / 数分)
-
-自己対局で実際に踏んだ局面を pin してある．**期待値まで一致すること**を見る．
-
-### A-1 敗着局面 (まだ受かる / 合法手 4)
-
-```
-maou search --sfen 'l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1NR3/1G1PPg3/1S2K1+b2/LN7 b BSgsnl8p 117' \
-  --time-ms 11000 $MODEL $GPU
-```
-
-| 期待 | 値 |
-|---|---|
-| bestmove | **5h6i** (唯一の受かる手) |
-| 候補一覧 | 残り 3 手すべてに `proven=loss` (4f4g / 5h5i / 5h6h) |
-| `filtered_root_moves` | **1 以上** |
-| `defensive_mates` | **1 以上** |
+| 判定 | 期待 | 外れたときに疑うこと |
+|---|---|---|
+| A-1 bestmove = `5h6i` | 唯一の受かる手 | 対照と同じ手なら未発火か gate 外れ |
+| A-1 `proven=loss` が 3 手 | 4f4g(mate-41) / 5h5i(mate-1) / 5h6h(mate-29) | 予算不足なら `--time-ms` を上げる |
+| A-2 `WinRate = 0.0` | 被詰みの正直な報告 | 対照は 0.49 前後の互角 |
+| A-3 両カウンタ 0 | 偽陽性ゼロ | **0 でなければ即調査** (偽の被詰みは自滅につながる) |
 
 **`filtered_root_moves` が 3 未満でも異常ではない** — 木の proven 伝播
-(leaf-mate 経由) が先に確定させた手はフィルタが上書きしないため，内訳は
-実行ごとに動く．**見るべきは「除外が 3 手」と「bestmove = 5h6i」**．
-
-対照 (`--no-defensive-mate`): `filtered_root_moves=0`．対局では 4f4g を選び
-11 手後に詰まされた．**bestmove が変わることがこの機構の存在理由**なので，
-両者で同じ手が出た場合は発火していないか gate に掛かっていないかを疑う．
+(leaf-mate 経由) が先に確定させた手はフィルタが上書きしないため内訳は動く．
+**見るべきは「除外が 3 手」と「bestmove = 5h6i」**．
 
 DevContainer / mock 評価器での実測 (参考値．GPU では内訳が動く):
 
 ```
 Bestmove: 5h6i
-5h6i (visits=990,    winrate=0.4846, proven なし)
+5h6i (visits=990,    winrate=0.4846)               ← 選ばれた
 5h6h (visits=541509, winrate=0.4987, proven=loss)
-4f4g (visits=482872, winrate=0.4988, proven=loss)   ← 対局で選んだ敗着
+4f4g (visits=482872, winrate=0.4988, proven=loss)  ← 対局で選んだ敗着
 5h5i (visits=1744,   winrate=0.1197, proven=loss)
 Stats: ... leaf_mates=6439 defensive_mates=19 filtered_root_moves=2 ...
 ```
 
-**visits では 5h6h / 4f4g が 50 万回で圧倒的なのに 990 回の 5h6i が選ばれる**
-— MCTS の訪問分布では敗着が勝っており，確定値の除外だけが手を変えている．
+**visits では敗着が 50 万回で圧倒的なのに 990 回の手が選ばれる** — MCTS の
+訪問分布では敗着が勝っており，確定値の除外だけが手を変えている．
+A-2 は `WinRate 0.0000` / `defensive_mates=50` / `filtered_root_moves=0`
+(既に詰みなら候補選別はしない = 設計どおり)．
 
-### A-2 被詰み局面 (もう詰んでいる / 合法手 3)
+## セル 3 — Stage B: CPU 競合で探索速度を奪わないか
 
-```
-maou search --sfen 'l8/3k1s3/2nppp3/1lG4p1/p1p1+R4/P1P1N4/1G1PPR3/1S2K1+b2/LN1s5 b BGSgnl8p 119' \
-  --time-ms 11000 $MODEL $GPU
-```
+```python
+# 4.7-3. Stage B: 静かな局面で nps を on/off 比較する (各 15 秒 × 2 回)．
+import os
+print("vCPU:", os.cpu_count(),
+      "/ 常駐スレッド = MCTS 1 + 攻め dfpn 1 + 受け dfpn 1 + leaf-mate 1 = 4")
 
-| 期待 | 値 |
-|---|---|
-| `defensive_mates` | **1 以上** |
-| `WinRate` | **0.0000** (対照は 0.49 前後の互角) |
-| bestmove | 5h6i (最長抵抗 = mate-40) |
-| `filtered_root_moves` | **0** — 既に詰んでいるので候補選別はしない (設計どおり) |
-
-**ここが「相手の手番だけ詰みが見えて自分の手番では互角を示す」の直接の反証**．
-DevContainer / mock 実測: `WinRate: 0.0000` / `defensive_mates=50` /
-`filtered_root_moves=0`．
-
-### A-3 静かな局面 (偽陽性ゼロと無害性)
-
-```
-maou search --sfen 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1' \
-  --time-ms 11000 $MODEL $GPU
+on  = run_search(QUIET, time_ms=15000, defensive=True)
+off = run_search(QUIET, time_ms=15000, defensive=False)
+nps_on, nps_off = int(on["stats"]["nps"]), int(off["stats"]["nps"])
+drop = (1 - nps_on / nps_off) * 100
+print(f"nps on={nps_on:,} off={nps_off:,} → 低下 {drop:.1f}%")
+print(f"充填率 on={float(on['stats']['avg_batch'])/64:.2f} "
+      f"off={float(off['stats']['avg_batch'])/64:.2f} "
+      f"(外れ値を見たら充填率と collisions を必ず併記する — §1)")
+print("判定:", "許容 (<5%)" if drop < 5 else "要調査 (>=5%) — 並列度は上げない")
 ```
 
-期待: `defensive_mates=0` かつ `filtered_root_moves=0`．
-**偽の被詰みは投了・自滅につながるので，ここが 0 でなければ即調査**．
-DevContainer / mock 実測: `WinRate: 0.5000` / 両カウンタ 0．
+**静かな局面で測る**こと．gate 該当は全局面の 7.6% (終盤 21.6%) なので，
+静かな局面での低下はそのまま「常時払う税」になる．
+5% 以上なら `--defensive-mate-threads` を上げずに Stage C へ進む．
 
-## Stage B — CPU 競合で探索速度を奪わないか
+## セル 4 — Stage C: 棋力 A/B
 
-Stage A-3 と同じ静かな局面で `--defensive-mate` / `--no-defensive-mate` の
-`nps` を比べる．GPU 律速なら差は小さいはず．
-
-先に `nproc` で vCPU 数を確認する — 常駐スレッドは
-MCTS 1 + 攻め dfpn 1 + 受け dfpn 1 + leaf-mate 1 = **4 本**になる．
-`--defensive-mate-threads` を上げる場合はさらに増える．
-
-| 判定 | 基準 |
-|---|---|
-| 許容 | nps 低下 5% 未満 |
-| 要調査 | 5% 以上 → `--defensive-mate-threads 1` のまま A/B へ (並列度を上げない) |
-
-**gate 該当が全局面の 7.6% (終盤 21.6%) なので，静かな局面での低下は
-そのまま「常時払う税」になる**．ここは終盤の局面ではなく静かな局面で測る．
-
-## Stage C — 棋力 A/B (`--ab-mode defmate`)
-
-```
-maou selfplay --ab-mode defmate --clock-ms 300000 --inc-ms 10000 \
-  --games 40 --parallel 1 $MODEL $GPU \
-  --output ab_defmate.jsonl --kifu-dir kifu_defmate/
+```python
+# 4.7-4. Stage C: A/B 40 局．持ち時間モード必須 / --parallel 1 必須 / GPU 必須．
+!maou selfplay --ab-mode defmate --clock-ms 300000 --inc-ms 10000 \
+    --games 40 --parallel 1 \
+    --model-path /content/model_fp16.onnx --tensorrt --cuda \
+    --threads 1 --batch-size 64 --trt-cache-dir /content/trt_cache \
+    --output /content/ab_defmate.jsonl --kifu-dir /content/kifu_defmate
 ```
 
 regime ゲート (先に通すこと):
 
 - **持ち時間モード必須** — 固定 playout 予算では敗着フィルタが使える壁時計が
-  変わってしまう (フィルタは MCTS 終了の停止フラグで打ち切られる)
+  変わる (フィルタは MCTS 終了の停止フラグで打ち切られる)
 - **`--parallel 1` 必須** — フィルタが CPU を使うので同時対局は互いを歪める
 - **GPU 必須** — CPU 22 p/s では手の分布が別物になる
 
@@ -149,17 +188,63 @@ regime ゲート (先に通すこと):
 **n=40 が検出できる ~150 Elo 級に届くかは未知**．有意にならなくても
 機構が効いていないことにはならない — だから Stage D を併せて見る．
 
-## Stage D — 棋譜による直接確認 (Elo より感度が高い)
+## セル 5 — Stage D: 棋譜による直接確認 (Elo より感度が高い)
 
-`--kifu-dir` の CSA を CPU 側と同じ走査に掛け，**A 側の敗着回数が B 側より
-減っているか**を見る．これが最も直接的な効果指標:
+```python
+# 4.7-5. Stage D: A/B の棋譜を走査し「避けられた敗着」を A/B で数える．
+#   1. 合法手 <= 16 を gate  2. 各合法手を指した後を攻め方向 dfpn で判定
+#   3. 「指した手が敗着 かつ 安全な代替手が存在した」を数える
+import glob, re
+from maou._rust import maou_shogi as S
 
-1. 各局面で合法手 ≤ 16 を gate
-2. 各合法手を指した後の局面を攻め方向 dfpn (`find_shortest=false`) で判定
-3. 「指した手が敗着 かつ 安全な代替手が存在した」件数を A/B で比較
+START = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+STAGES = [1_000, 50_000, 500_000]   # production と同じ段階予算
+
+def scan(path):
+    """1 局を走査し，避けられた敗着の明細を返す (A/B の割当は CSA の N+ から)."""
+    text = open(path).read()
+    m = re.search(r"^N\+(.*)$", text, re.M)
+    black_is_a = (m.group(1).strip().upper() == "A") if m else True
+    rec = S.parse_csa_str(text)[0]
+    b = S.PyBoard(); b.set_sfen(rec.sfen or START)
+    hits = []
+    for i, mv in enumerate(rec.moves):
+        legal = b.legal_moves()
+        if len(legal) <= 16:
+            played = S.move_to_usi(mv)
+            unresolved, losing, safe = list(legal), [], []
+            for budget in STAGES:
+                nxt = []
+                for m2 in unresolved:
+                    b.push(m2); child = b.sfen(); b.pop()
+                    # find_shortest=False 必須 — 既定 (True) は最小性を確定
+                    # できないと Unknown を返し，長手数の詰みを見逃す
+                    r = S.solve_tsume(child, nodes=budget,
+                                      find_shortest=False, timeout_secs=60)
+                    (losing if r.status == "checkmate" else
+                     safe if r.status == "no_checkmate" else nxt).append(m2)
+                unresolved = nxt
+                if not unresolved:
+                    break
+            if played in [S.move_to_usi(x) for x in losing] and safe:
+                side = "A" if ((i + 1) % 2 == 1) == black_is_a else "B"
+                hits.append({"ply": i + 1, "side": side, "played": played,
+                             "safe": [S.move_to_usi(x) for x in safe][:3]})
+        b.push(mv)
+    return hits
+
+tally = {"A": 0, "B": 0}
+for path in sorted(glob.glob("/content/kifu_defmate/game_*.csa")):
+    for h in scan(path):
+        tally[h["side"]] += 1
+        print(f"  {path.split('/')[-1]} ply{h['ply']:3d} [{h['side']}] "
+              f"{h['played']} → 安全手 {h['safe']}")
+print(f"\n避けられた敗着: A={tally['A']} B={tally['B']}")
+print("判定:", "機構は効いている" if tally["A"] < tally["B"] else "要調査")
+```
 
 判定: **A 側の件数が B 側より少なければ機構は効いている**．Elo が有意で
-なくても，この差は直接観測できる．
+なくても，この差は直接観測できる (30 局の事前走査では 7 件あった)．
 
 ## 記録先
 

--- a/reviews/2026-08-01-defensive-mate-gpu-verification.md
+++ b/reviews/2026-08-01-defensive-mate-gpu-verification.md
@@ -2,7 +2,7 @@
 title: 受け方向詰み探索の GPU 検証手順を verification.md に追加する
 date: 2026-08-01
 status: applied
-applied_in: PENDING
+applied_in: 62d47b7
 target:
   - docs/design/usi-engine/verification.md
 risk: low

--- a/rust/maou_rust/Cargo.toml
+++ b/rust/maou_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_rust"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 
 [lib]

--- a/rust/maou_rust/src/maou_search.rs
+++ b/rust/maou_rust/src/maou_search.rs
@@ -69,7 +69,10 @@ impl SearchRootChild {
 ///   `warmup_ms` (ルート評価/エンジンビルドの所要; 計測
 ///   区間外) / `elapsed_ms` / `nps` / `max_depth` / `repetitions`
 ///   (千日手検出数) / `proven_nodes` (AND-OR 確定ノード数) / `leaf_mates`
-///   (leaf-mate が葉で詰みを証明した回数) / `nodes_used` / `collisions` /
+///   (leaf-mate が葉で詰みを証明した回数) / `defensive_mates` (受け方向が
+///   「手番側が詰まされる」と証明した回数 — **0 なら機構が未発火**) /
+///   `filtered_root_moves` (敗着として除外した root 候補手数 — **0 なら
+///   着手選択に影響していない**) / `nodes_used` / `collisions` /
 ///   `eval_batches` / `avg_batch` / `gc_runs`．
 #[pyclass(frozen, name = "SearchResult")]
 struct PySearchResult {
@@ -101,6 +104,10 @@ struct PySearchResult {
     proven_nodes: u64,
     #[pyo3(get)]
     leaf_mates: u64,
+    #[pyo3(get)]
+    defensive_mates: u64,
+    #[pyo3(get)]
+    filtered_root_moves: u64,
     #[pyo3(get)]
     nodes_used: u32,
     #[pyo3(get)]
@@ -162,6 +169,8 @@ fn to_py_result(r: SearchResult) -> PySearchResult {
         repetitions: r.stats.repetitions,
         proven_nodes: r.stats.proven_nodes,
         leaf_mates: r.stats.leaf_mates,
+        defensive_mates: r.stats.defensive_mates,
+        filtered_root_moves: r.stats.filtered_root_moves,
         nodes_used: r.stats.nodes_used,
         collisions: r.stats.collisions,
         eval_batches: r.stats.eval_batches,

--- a/rust/maou_search/Cargo.toml
+++ b/rust/maou_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_search"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 description = "MCTS-based single-position search engine for shogi (pure Rust, batched evaluation)"
 

--- a/rust/maou_search/src/search.rs
+++ b/rust/maou_search/src/search.rs
@@ -571,9 +571,17 @@ pub struct SearchStats {
     /// AND-OR 伝播で勝敗/引き分けが確定した内部ノード数 (葉の終端マークは
     /// 含まない)．
     pub proven_nodes: u64,
-    /// leaf-mate 探索が葉で詰みを証明して勝ち確定にした回数
-    /// ([`SearchOptions::leaf_mate`] 有効時)．
+    /// leaf-mate 探索が葉で**攻め方向**の詰みを証明して勝ち確定にした回数
+    /// ([`SearchOptions::leaf_mate`] 有効時)．受け方向は
+    /// [`SearchStats::defensive_mates`] に排他で数える．
     pub leaf_mates: u64,
+    /// 受け方向の詰み探索が「手番側が詰まされる」と証明した回数
+    /// (root 1 回 + 王手中の葉ごと)．[`SearchStats::leaf_mates`] とは排他
+    /// (攻め方向はあちら)．**0 なら機構が発火していない**．
+    pub defensive_mates: u64,
+    /// 敗着フィルタが「指すと相手に詰まされる」として除外した root 候補手の数．
+    /// **0 なら選択に影響していない**．
+    pub filtered_root_moves: u64,
     /// 使用したノード数 (GC 実行後はその時点の残存数)．
     pub nodes_used: u32,
     /// 子ノード生成の CAS 競合で捨てられたノード数 (GC で回収される)．
@@ -730,6 +738,7 @@ struct Shared<'a, E: Evaluator> {
     repetitions: AtomicU64,
     proven_nodes: AtomicU64,
     leaf_mates: AtomicU64,
+    defensive_mates: AtomicU64,
     max_depth: AtomicU16,
     /// ルート並行 dfpn が詰みを証明したか (dfpn スレッドが立てる)．
     dfpn_found: Arc<AtomicBool>,
@@ -804,7 +813,12 @@ impl<E: Evaluator> Shared<'_, E> {
                 continue; // compact 済み — index 無効化，破棄 (偽証明防止)
             }
             if self.pool.get(res.idx).try_mark_proven(res.proven) {
-                self.leaf_mates.fetch_add(1, Ordering::Relaxed);
+                // 攻め方向と受け方向は**排他に数える** (足すと二重計上になる)．
+                if res.proven == proven::LOSS {
+                    self.defensive_mates.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    self.leaf_mates.fetch_add(1, Ordering::Relaxed);
+                }
             }
             propagate_proven_from(self, &res.path);
         }
@@ -1718,6 +1732,8 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
                     repetitions: 0,
                     proven_nodes: 0,
                     leaf_mates: 0,
+                    defensive_mates: 0,
+                    filtered_root_moves: 0,
                     nodes_used: 0,
                     leaked_nodes: 0,
                     gc_runs: 0,
@@ -1818,6 +1834,7 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
             repetitions: AtomicU64::new(0),
             proven_nodes: AtomicU64::new(0),
             leaf_mates: AtomicU64::new(0),
+            defensive_mates: AtomicU64::new(0),
             max_depth: AtomicU16::new(0),
             dfpn_found: Arc::new(AtomicBool::new(false)),
             dfpn_mate: Arc::new(Mutex::new(None)),
@@ -2026,6 +2043,7 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
         // 「あと 1 手で詰まされる」局面はどちらにも掛からない．
         // 反映先を `proven = Some(0.0)` にすることで，既存の負け確定除外
         // (`select_best_root_index`) がそのまま効く．
+        let mut filtered_root_moves = 0usize;
         {
             let losing = shared
                 .dfpn_losing_moves
@@ -2035,10 +2053,18 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
                 for c in root_children.iter_mut() {
                     if c.proven.is_none() && losing.contains(&c.mv) {
                         c.proven = Some(0.0);
+                        filtered_root_moves += 1;
                     }
                 }
             }
         }
+
+        // 受け方向 root dfpn の証明 (被詰み) — 報告値の差し替えと統計の両方で使う
+        let dfpn_mated = shared
+            .dfpn_mated
+            .lock()
+            .expect("dfpn mated lock は poison しない")
+            .clone();
 
         // 負け確定除外の robust child + root 確定手の優先 (build_snapshot と共有)
         let root_proven = root_node.proven_value();
@@ -2075,6 +2101,9 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
             repetitions: shared.repetitions.load(Ordering::Relaxed),
             proven_nodes: shared.proven_nodes.load(Ordering::Relaxed),
             leaf_mates: shared.leaf_mates.load(Ordering::Relaxed),
+            defensive_mates: shared.defensive_mates.load(Ordering::Relaxed)
+                + u64::from(dfpn_mated.is_some()),
+            filtered_root_moves: filtered_root_moves as u64,
             nodes_used: shared.pool.used(),
             leaked_nodes: shared.leaked_nodes.load(Ordering::Relaxed),
             gc_runs,
@@ -2099,11 +2128,6 @@ impl<'e, E: Evaluator> Searcher<'e, E> {
         // 攻め方向の証明が同時に立つことは (両者が同時に詰ませ合うことは) ない
         // が，万一のときは攻め方向を優先する — 自分が先に詰ませられるなら
         // それが実現するため．
-        let dfpn_mated = shared
-            .dfpn_mated
-            .lock()
-            .expect("dfpn mated lock は poison しない")
-            .clone();
         let (best_move, winrate, pv, stop) = if let Some(mate) = dfpn_mate {
             (Some(mate[0]), 1.0, mate, StopCause::RootProven)
         } else if let Some(defense) = dfpn_mated {

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -285,6 +285,13 @@ pub struct SearchOutcome {
     /// 「機構が実対局で何回発火し，どれだけ得したか」の計測に使う (設計 §12
     /// 未決 6)．統計目的のみで対局判断には使わない．
     pub carried_visits: u64,
+    /// 受け方向の詰み探索が「手番側が詰まされる」と証明した回数
+    /// (root + 王手中の葉)．**0 なら機構が発火していない** — レバーの効果を
+    /// 論じる前にこれを数える (計測規律)．
+    pub defensive_mates: u64,
+    /// 敗着フィルタが「指すと相手に詰まされる」として除外した root 候補手の数．
+    /// **0 なら着手選択に影響していない**．
+    pub filtered_root_moves: u64,
 }
 
 /// 探索バックエンド (実装: [`MaouSearchBackend`]，テスト: fake)．
@@ -1355,6 +1362,8 @@ mod tests {
 
     fn default_outcome() -> SearchOutcome {
         SearchOutcome {
+            defensive_mates: 0,
+            filtered_root_moves: 0,
             best_usi: Some("7g7f".to_string()),
             winrate: 0.6,
             pv: vec!["7g7f".to_string(), "3c3d".to_string()],

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -338,6 +338,8 @@ fn to_outcome(r: &SearchResult) -> SearchOutcome {
     let carried_visits = root_visits.saturating_sub(r.stats.playouts + r.stats.terminal_backprops);
     SearchOutcome {
         carried_visits,
+        defensive_mates: r.stats.defensive_mates,
+        filtered_root_moves: r.stats.filtered_root_moves,
         best_usi: r.best_move.map(|m| m.to_usi()),
         winrate: r.winrate,
         pv: r.pv.iter().map(|m| m.to_usi()).collect(),

--- a/src/maou/app/search/run.py
+++ b/src/maou/app/search/run.py
@@ -187,7 +187,10 @@ class SearchRunner:
                 f"max_depth={result.max_depth} "
                 f"repetitions={result.repetitions} "
                 f"proven_nodes={result.proven_nodes} "
-                f"leaf_mates={result.leaf_mates} stop={result.stop}"
+                f"leaf_mates={result.leaf_mates} "
+                f"defensive_mates={result.defensive_mates} "
+                f"filtered_root_moves={result.filtered_root_moves} "
+                f"stop={result.stop}"
             ),
         }
         if config.board_view:

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.72.0"
+version = "0.73.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `SearchStats` に `defensive_mates` / `filtered_root_moves` を追加し，受け方向詰み探索の**発火量を数えられる**ようにする
- `maou search` の出力行・PyO3 `PySearchResult`・`SearchOutcome` に露出
- `leaf_mates` (攻め方向) とは**排他**に数える (同じ経路を通るので加算すると二重計上)

## Problem

PR #424 で受け方向詰み探索を入れたが，**発火回数を数える手段が無かった**．

計測規律 (`docs/design/position-search/index.md` §10.2 / compass § TRIPWIRES) は

- 「レバー A/B で『効果なし』と結論する前に → 機構の発火を別軸で確認する」
- 「検証器・診断が『異常なし』を返したら → **非空性 (発火件数) を数える**」

を要求している．計器が無いと，GPU で A/B が有意にならなかったときに
**「発火したが Elo 差が検出限界未満」と「そもそも発火していない (実装のバグ)」を
区別できない**．前者は追試の対象だが後者は回帰である．

## Solution

`SearchStats` に 2 つ:

| フィールド | 意味 | 0 のとき |
|---|---|---|
| `defensive_mates` | 受け方向が「手番側が詰まされる」と証明した回数 (root + 王手中の葉) | **機構が発火していない** |
| `filtered_root_moves` | 敗着として除外した root 候補手の数 | **着手選択に影響していない** |

`leaf_mates` は同じ `apply_mate_results` を通るため，受け方向を足すと二重計上に
なる．**攻め方向 (WIN) と受け方向 (LOSS) で排他に数える**ようにした．

## Changes

- `rust/maou_search/src/search.rs`: `SearchStats` 2 フィールド + `Shared.defensive_mates` カウンタ．`collect_result` で敗着フィルタの畳み込み数を数え，root 受け方向の証明を加算．`dfpn_mated` の読み出しを統計より前へ移動
- `rust/maou_usi/src/agent.rs` / `backend.rs`: `SearchOutcome` に 2 項目 (USI / CSA / 自己対局が拾える)
- `rust/maou_rust/src/maou_search.rs`: `PySearchResult` に `#[pyo3(get)]` で露出
- `src/maou/app/search/run.py`: `maou search` の Stats 行に追加

## Impact

**Breaking Changes**: なし (統計フィールドの追加のみ)．
`leaf_mates` の意味が「攻め方向のみ」に狭まるが，PR #424 以前の値と同義になる
(#424 で一時的に受け方向を含んでいたのを分離した)．

**Performance**: `AtomicU64` の `fetch_add` 1 個と `Vec` の線形探索 (root 候補手数 ≤ 数百)．探索ホットパスではない．

## Testing

DevContainer / mock 評価器で実際に踏んだ 3 局面を確認:

| 局面 | 結果 |
|---|---|
| **ply117** (まだ受かる) | bestmove が **5h6i**，残り 3 手が `proven=loss`．`defensive_mates=19` / `filtered_root_moves=2` |
| **ply119** (もう詰んでいる) | **`WinRate 0.0000`**，`defensive_mates=50` / `filtered_root_moves=0` (既に詰みなら候補選別はしない = 設計どおり) |
| 初期局面 | 両カウンタ **0** (偽陽性なし)，`WinRate 0.5000` |

ply117 の候補一覧が示唆的:

```
5h6i (visits=990,    winrate=0.4846)              ← 選ばれた
5h6h (visits=541509, winrate=0.4987, proven=loss)
4f4g (visits=482872, winrate=0.4988, proven=loss) ← 対局で選んだ敗着
5h5i (visits=1744,   winrate=0.1197, proven=loss)
```

**visits では敗着が 50 万回で圧倒的なのに 990 回の手が選ばれる** — MCTS の
訪問分布では敗着が勝っており，確定値の除外だけが手を変えている．

全体: Rust 全テスト green / Python 926 passed / clippy・fmt・mypy clean / pre-commit 全 pass．

## Review Notes

**重点**: `apply_mate_results` の排他カウント (`leaf_mates` と `defensive_mates` を
足して元の `leaf_mates` になること) と，`collect_result` で `dfpn_mated` の
読み出し位置を統計の前へ移した差分．

**Follow-up**: 自己対局の JSONL に ply ごとの発火を載せるには USI `info` 経由の
plumbing が要る．今回は入れていない — 棋譜の再解析 (`maou analyze-game` は同じ
`SearchEngine` を通る) で ply ごとに取れるため．

GPU 検証手順は `reviews/2026-08-01-defensive-mate-gpu-verification.md` (pending)．

## Checklist

- [x] Code formatted and linted (ruff，isort，cargo fmt)
- [x] Type checking passes (mypy，clippy)
- [x] All tests pass
- [x] 実局面での動作確認 (3 局面)
- [x] Architecture compliance verified
- [x] Docstrings added/updated
- [x] 版数 bump (maou 0.73.0 / maou_search 0.31.0 / maou_usi 0.27.0 / maou_rust 0.45.0)
- [x] Commits carry the `Co-Authored-By` trailer
- [x] PR body ends with the Claude Code footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5weHGn7odXxiyRwiYrSmn