### PR TITLE
fix(learn)!: 配線されていない head 再開オプションを削除し合法手マスクの doc を実態に合わせる

### DIFF
--- a/docs/commands/learn_model.md
+++ b/docs/commands/learn_model.md
@@ -90,8 +90,6 @@ ViTエンコーダのGPU活性化メモリを約93%削減するオプション�
 | `--stage2-test-ratio FLOAT` | `0.0` | Stage 2検証データ分割比率．0.0で分割なし，0.1で10%を検証用に使用．ストリーミングモードでは未対応． |
 | `--freeze-backbone` | `false` | Freeze backbone parameters (embedding, backbone, pool, hand projection).【F:src/maou/infra/console/learn_model.py†L437-L441】 |
 | `--trainable-layers INT` | `None` | Number of trailing backbone layer groups to keep trainable. `0` = freeze all backbone layers. Unset = all layers trainable. **マルチステージ時の層分離**: 設定すると Stage 1/2 では最初の `(total - N)` グループのみを訓練し，Stage 3 では末尾 N グループのみを訓練する．ResNet は投射層 (Pool+Linear) 経由，MLP-Mixer/ViT は LayerNorm+Mean Pooling 経由で出力次元を合わせる．【F:src/maou/infra/console/learn_model.py†L443-L451】 |
-| `--resume-reachable-head-from PATH` | optional | Reachable squares head parameter file to resume training (Stage 1).【F:src/maou/infra/console/learn_model.py†L508-L512】 |
-| `--resume-legal-moves-head-from PATH` | optional | Legal moves head parameter file to resume training (Stage 2).【F:src/maou/infra/console/learn_model.py†L514-L518】 |
 
 ### Loss, optimizer, and scheduler controls
 

--- a/docs/loss-functions.md
+++ b/docs/loss-functions.md
@@ -113,8 +113,9 @@ Ridnik et al., "Asymmetric Loss For Multi-Label Classification", ICCV 2021
 #### ターゲット形式
 
 前処理パイプラインで棋譜から出現率マップ(ソフトターゲット)を計算し，
-float16の確率分布として保存する．`normalize_policy_targets` で
-`legal_move_mask` を適用した上で確率分布に正規化する．
+確率分布として保存する．`normalize_policy_targets` で
+`legal_move_mask` を適用した上で確率分布に正規化する
+(ただし現行のマスクはダミーであり実質的な絞り込みは起きない．後述)．
 
 #### 選択理由
 
@@ -125,24 +126,52 @@ float16の確率分布として保存する．`normalize_policy_targets` で
   損失値の解釈性が向上する
 - **reduction="batchmean"**: バッチ平均で正規化し，バッチサイズに依存しない安定した勾配を得る
 
-#### 合法手マスキング
+#### 合法手マスキング — 機構はあるが**現在は発動していない**
 
 Policy損失の計算時，`legal_move_mask` を用いて非合法手のlogitsを `-inf` に設定した上で
-`log_softmax` を適用する．これにより確率質量が合法手(平均~20手)のみに分配される．
+`log_softmax` を適用する経路が実装されている．
 
 ```python
 masked_logits = outputs_policy.masked_fill(~legal_move_mask.bool(), float("-inf"))
 policy_log_probs = F.log_softmax(masked_logits, dim=1)
 ```
 
-**効果**:
+しかし **Stage 3 に供給される `legal_move_mask` は全要素 1 のダミー**である
+(`dataset.py` / `streaming_dataset.py` の `torch.ones_like`)．前処理出力スキーマに
+合法手の情報が無いためで，結果として:
 
-- **学習効率の向上**: softmaxの有効次元が1496→~20に縮小され，
-  モデルが非合法手の抑制に勾配を費やす必要がなくなる
-- **ターゲットとの整合性**: `normalize_policy_targets` も同じ `legal_move_mask` で
-  正規化しているため，モデル出力とターゲットの確率空間が一致する
-- **テンソル次元は不変**: 出力テンソルは依然として1496次元であり，
-  推論時のインデックス→指し手への復元に影響しない
+- `masked_fill` は恒等変換になり，`log_softmax` は **1496 次元全体**で正規化される
+- `normalize_policy_targets` の `targets * mask` も 1 倍で無変更
+- **`legal_move_mask=None` を渡した場合と勾配まで完全に一致する**
+
+つまりこの節が想定していた「有効次元が1496→~20に縮小される」効果は**得られていない**．
+モデルは非合法手のlogitsを押し下げる学習に勾配を費やしている．
+
+**実害は限定的**である．推論時は Rust 側 (`rust/maou_search/src/onnx.rs`) が
+合法手のラベルに対応するlogitsだけを取り出してsoftmaxを取るため，
+非合法手が指されることはない．学習時マスクの欠如による差は
+「非合法手に割かれる確率質量の分だけ合法手側の勾配が減衰する」ことに留まる．
+
+**実測 (2026-08-03, floodgate 342局面 / ViT-19.8M)**:
+
+| 指標 | 値 |
+|---|---|
+| 非合法手へ漏れている確率質量 (平均) | 0.0158 |
+| 同 p50 / p90 / p99 / max | 0.0063 / 0.0385 / 0.1525 / 0.3293 |
+| argmax が非合法手だった局面 | 0 / 342 |
+| top-5 に非合法手が混入した枠 | 79 / 1710 (4.6%) |
+
+漏れの平均が1.6%であり，マスクを実効化してもsoftmaxの分母は平均1.016倍しか
+変わらない．棋力への影響は検出限界未満と判断し，**前処理出力への合法手列追加は
+見送っている**(2026-08-03, user判断)．
+
+なお `policy_top5_accuracy` / `policy_f1` / `policy_top1_win_rate` は
+raw 1496次元の `topk` / `argmax` で計算しているため，上表のとおり
+**非合法手が混入し得る**(top-5の4.6%)．これらの指標は推論時の確率空間とは
+別の空間を測っている点に注意すること．
+
+**テンソル次元は不変**: 出力テンソルは1496次元であり，
+推論時のインデックス→指し手への復元には影響しない．
 
 ### Value損失: BCEWithLogitsLoss
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.74.1"
+version = "0.75.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-08-03-legal-mask-docs-and-dead-options.md
+++ b/reviews/2026-08-03-legal-mask-docs-and-dead-options.md
@@ -2,7 +2,7 @@
 title: 合法手マスキングの doc 訂正とデッド CLI オプションの削除
 date: 2026-08-03
 status: applied
-applied_in: PENDING_SHA
+applied_in: e8868e3
 target:
   - docs/loss-functions.md
   - docs/commands/learn_model.md

--- a/reviews/2026-08-03-legal-mask-docs-and-dead-options.md
+++ b/reviews/2026-08-03-legal-mask-docs-and-dead-options.md
@@ -1,0 +1,105 @@
+---
+title: 合法手マスキングの doc 訂正とデッド CLI オプションの削除
+date: 2026-08-03
+status: applied
+applied_in: PENDING_SHA
+target:
+  - docs/loss-functions.md
+  - docs/commands/learn_model.md
+risk: low
+reversibility: easy
+---
+
+# 提案: 合法手マスキングの実態を doc に反映し，未配線の CLI オプションを削除する
+
+## 背景
+
+合法手情報が学習プロセスで使われているかを調査した結果，**Stage 3 では事実上
+どこでも使われていない**ことが判明した．
+
+- Stage 3 に供給される `legal_move_mask` は `torch.ones_like` のダミー
+  (`dataset.py` / `streaming_dataset.py`)．前処理出力スキーマに合法手の列が無い
+- 全要素 1 のため `masked_fill(~all_True, -inf)` は恒等変換になり，
+  **`legal_move_mask=None` を渡した場合と勾配まで一致する**
+- `callbacks.py` の policy 系メトリクスはマスクを一切参照せず raw 1496 次元で計算
+- Stage 2 の legal-moves head は保存されるだけで Stage 3 は backbone しか読まない
+- ONNX 出力は `["policy", "value"]` の 2 つのみ
+
+一方 **推論時は完全にマスクされている**．`rust/maou_search/src/onnx.rs` が
+`generate_legal_moves` の結果に対応する logits だけを gather して softmax を取るため，
+非合法手が指されることはない．
+
+## 実測 (発火量プローブ)
+
+compass の TRIPWIRE「GPU 時間を使うレバー A/B の前に → 実装を直接叩いて発火量を
+予測」に従い，学習済みモデルが非合法手へ漏らしている確率質量を測定した．
+これはマスクを実効化したときに softmax の分母が変わる量の上限にあたる．
+
+対象: floodgate golden 棋譜 342 局面 / `model_20260725_044443_vit-19.8m` / CPU EP
+
+| 指標 | 値 |
+|---|---|
+| 非合法手への確率質量 (平均) | 0.0158 |
+| 同 p50 / p90 / p99 / max | 0.0063 / 0.0385 / 0.1525 / 0.3293 |
+| argmax が非合法手 | 0 / 342 局面 |
+| top-5 に非合法手が混入 | 79 / 1710 枠 (4.6%) |
+
+漏れの平均が 1.6% であり，マスクを実効化しても合法手の確率は平均 1.016 倍に
+スケールするだけ．損失値の変化は 1% 前後で，n=40 の A/B が検出できる ~130 Elo
+には遠く及ばない (TRIPWIRE の言う「発火したが検出限界未満」に着地することが
+実装前に判明した)．
+
+**結論**: 前処理出力への合法手列追加とメトリクスの合法手化は**見送る**
+(user 判断, 2026-08-03)．doc の記述だけを実態に合わせる．
+
+## 変更内容
+
+### 1. `docs/loss-functions.md` — Stage 3 の「合法手マスキング」節
+
+現状の記述は「Policy損失の計算時，`legal_move_mask` を用いて…確率質量が
+合法手(平均~20手)のみに分配される」「学習効率の向上: softmaxの有効次元が
+1496→~20に縮小」と**実装済み機能として断定**していたが，一度も発動していない．
+
+見出しを「機構はあるが現在は発動していない」に改め，以下を追記した:
+
+- ダミーマスクにより `masked_fill` が恒等変換になること
+- 推論側 (`onnx.rs`) が合法手限定 softmax を行うため実害が限定的であること
+- 上記の実測値と，合法手列追加を見送った判断
+- `policy_top5_accuracy` / `policy_f1` / `policy_top1_win_rate` が
+  raw 1496 次元で計算されており非合法手が混入し得ること
+
+「ターゲット形式」節の `normalize_policy_targets` の記述にも注記を追加．
+
+### 2. `docs/commands/learn_model.md` — 削除したオプションの行を除去
+
+`--resume-reachable-head-from` / `--resume-legal-moves-head-from` の 2 行を削除．
+
+## 併せて実施したコード変更 (src/)
+
+`--resume-reachable-head-from` / `--resume-legal-moves-head-from` を削除した．
+
+これらは **click が受け取り `interface/learn.py` まで転送されるが，そこから先で
+一度も参照されない**デッドオプションだった．Stage 3 の `Network` は policy/value の
+2 head しか持たず (`network.py`)，対応する head が存在しないため配線先が無い．
+`ModelIO.split_state_dict` も legal-moves head の state dict を
+アンダースコア変数で明示的に破棄している．
+
+指定してもエラーにならず黙って無視されるため，「再開したつもりで再開していない」
+事故を招く．compass VETO「些末な warning・lint・pre-existing バグは defer せず
+即修正」に該当すると判断した．
+
+- `src/maou/infra/console/learn_model.py`: `@click.option` 2 件と関数引数・転送を削除
+- `src/maou/interface/learn.py`: 引数と docstring を削除
+- `tests/maou/infra/console/test_cli_option_compatibility.py`: 除外リストから 2 件削除
+
+将来 Stage 3 に補助 head を足す場合は，head の実装と同時にオプションを
+入れ直すのが筋 (現状は配線先の無いオプションだけが残っている状態だった)．
+
+## リスク
+
+- **低**: 削除した 2 オプションは指定しても何も起きなかったため，動作の変化は
+  「指定するとエラーになる」ことのみ．CLI 表面の破壊的変更にあたるため
+  minor bump とした (`maou 0.74.1` → `0.75.0`．0.x では破壊的変更を minor で
+  扱う既存慣行に従う — 例 `68c4c68` `feat(search)!:` が 0.71.0 → 0.72.0)．
+- doc 変更は記述のみで挙動に影響しない．
+- 逆行は容易．

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -572,18 +572,6 @@ def _build_adaptive_batch_config(
     help="Validation split ratio for Stage 2 (0.0 = no split, e.g. 0.1 = 10%% validation).",
 )
 @click.option(
-    "--resume-reachable-head-from",
-    type=click.Path(exists=True, path_type=Path),
-    help="Reachable squares head parameter file to resume training (Stage 1).",
-    required=False,
-)
-@click.option(
-    "--resume-legal-moves-head-from",
-    type=click.Path(exists=True, path_type=Path),
-    help="Legal moves head parameter file to resume training (Stage 2).",
-    required=False,
-)
-@click.option(
     "--no-streaming",
     is_flag=True,
     default=False,
@@ -726,8 +714,6 @@ def learn_model(
     stage2_hidden_dim: int | None,
     stage2_head_dropout: float,
     stage2_test_ratio: float,
-    resume_reachable_head_from: Path | None,
-    resume_legal_moves_head_from: Path | None,
     no_streaming: bool,
     policy_target_mode: str,
     value_target_mode: str,
@@ -960,8 +946,6 @@ def learn_model(
             learning_rate=learning_ratio or 0.001,
             model_dir=model_dir,
             resume_backbone_from=resume_backbone_from,
-            resume_reachable_head_from=resume_reachable_head_from,
-            resume_legal_moves_head_from=resume_legal_moves_head_from,
             compilation=compilation,
             detect_anomaly=detect_anomaly,
             test_ratio=test_ratio,

--- a/src/maou/interface/learn.py
+++ b/src/maou/interface/learn.py
@@ -945,8 +945,6 @@ def learn_multi_stage(
     learning_rate: float = 0.001,
     model_dir: Path | None = None,
     resume_backbone_from: Path | None = None,
-    resume_reachable_head_from: Path | None = None,
-    resume_legal_moves_head_from: Path | None = None,
     # Stage 3 parameters
     compilation: bool = False,
     detect_anomaly: bool = False,
@@ -1016,8 +1014,6 @@ def learn_multi_stage(
         learning_rate: Learning rate
         model_dir: Model output directory
         resume_backbone_from: Backbone checkpoint to resume from
-        resume_reachable_head_from: Reachable head checkpoint to resume from
-        resume_legal_moves_head_from: Legal moves head checkpoint to resume from
         compilation: Enable PyTorch compilation for Stage 3
         detect_anomaly: Enable anomaly detection for Stage 3
         test_ratio: Test set ratio for Stage 3

--- a/tests/maou/infra/console/test_cli_option_compatibility.py
+++ b/tests/maou/infra/console/test_cli_option_compatibility.py
@@ -71,8 +71,6 @@ def test_learn_model_options_available_in_benchmark_training() -> (
         "stage1-learning-rate",  # Stage 1学習率（不要）
         "stage2-learning-rate",  # Stage 2学習率（不要）
         "stage2-max-epochs",  # Stage 2最大エポック（不要）
-        "resume-reachable-head-from",  # Stage 1ヘッド再開（不要）
-        "resume-legal-moves-head-from",  # Stage 2ヘッド再開（不要）
         "log-dir",  # TensorBoardログディレクトリ（不要）
         "model-dir",  # モデル出力ディレクトリ（不要）
         "tensorboard-histogram-frequency",  # TensorBoard（不要）

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.74.1"
+version = "0.75.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 背景

合法手情報が学習プロセスで使われているかを調査した結果，**Stage 3 では事実上どこでも使われていない**ことが判明した．

- Stage 3 に供給される `legal_move_mask` は `torch.ones_like` のダミー
  (`dataset.py` / `streaming_dataset.py`)．前処理出力スキーマに合法手の列が無い
- 全要素 1 のため `masked_fill(~all_True, -inf)` は恒等変換になり，
  **`legal_move_mask=None` を渡した場合と勾配まで一致する**
- `callbacks.py` の policy 系メトリクスはマスクを一切参照せず raw 1496 次元で計算
- Stage 2 の legal-moves head は保存されるだけで Stage 3 は backbone しか読まない
- ONNX 出力は `["policy", "value"]` の 2 つのみ

一方**推論時は完全にマスクされている**．`rust/maou_search/src/onnx.rs:251-258` が
`generate_legal_moves` の結果に対応する logits だけを gather して softmax を取るため，
非合法手が指されることはない．

## 実測 (発火量プローブ)

合法手列を追加する価値を判断するため，学習済みモデルが非合法手へ漏らしている
確率質量を測定した．これはマスクを実効化したときに softmax の分母が変わる量の上限にあたる．

対象: floodgate golden 棋譜 342 局面 / `model_20260725_044443_vit-19.8m` / CPU EP

| 指標 | 値 |
|---|---|
| 非合法手への確率質量 (平均) | 0.0158 |
| 同 p50 / p90 / p99 / max | 0.0063 / 0.0385 / 0.1525 / 0.3293 |
| argmax が非合法手 | 0 / 342 局面 |
| top-5 に非合法手が混入 | 79 / 1710 枠 (4.6%) |

漏れの平均が 1.6% であり，マスクを実効化しても合法手の確率は平均 1.016 倍に
スケールするだけ．**前処理出力への合法手列追加とメトリクスの合法手化は見送る**
(user 判断)．doc の記述だけを実態に合わせる．

## 変更内容

### コード (src/)

`--resume-reachable-head-from` / `--resume-legal-moves-head-from` を削除．

click が受け取り `interface/learn.py` まで転送されるが，そこから先で**一度も
参照されない**デッドオプションだった．Stage 3 の `Network` は policy/value の
2 head しか持たず配線先が無い (`ModelIO.split_state_dict` も legal-moves head の
state dict をアンダースコア変数で明示的に破棄している)．

指定してもエラーにならず黙って無視されるため，「再開したつもりで再開していない」
事故を招く．

- `infra/console/learn_model.py`: `@click.option` 2 件と関数引数・転送を削除
- `interface/learn.py`: 引数と docstring を削除
- `tests/.../test_cli_option_compatibility.py`: 除外リストから 2 件削除

### ドキュメント

- `docs/loss-functions.md`: Stage 3「合法手マスキング」節を訂正．
  「確率質量が合法手(平均~20手)のみに分配される」「有効次元が 1496→~20 に縮小」と
  実装済み機能として断定していたが一度も発動していない．見出しを
  「機構はあるが現在は発動していない」に改め，実測値と見送り判断を追記
- `docs/commands/learn_model.md`: 削除した 2 オプションの行を除去

## 検証

- Python テスト **1,691 passed**
- `uv run mypy src/` clean / pre-commit 全 hook パス (`check-cli-docs` 含む)
- CLI から 2 オプションが消えたことを実行確認 (総オプション数 78 → 76)

## 版数

`maou 0.74.1` → `0.75.0`

CLI 表面の破壊的変更のため minor bump とした．0.x では破壊的変更を minor で扱う
既存慣行に従う (例: `68c4c68` `feat(search)!:` が 0.71.0 → 0.72.0)．

BREAKING CHANGE: `--resume-reachable-head-from` / `--resume-legal-moves-head-from`
を削除．指定していた場合はエラーになる (従来は黙って無視されていた)．

## review

`reviews/2026-08-03-legal-mask-docs-and-dead-options.md` (`status: applied`,
`applied_in: e8868e3`)．承認は事前に得ている．

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5weHGn7odXxiyRwiYrSmn