### PR TITLE
chore: pre-commit hook を更新し，ruff の適用ルール範囲を明示固定する

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,19 @@ repos:
   - id: check-toml
   - id: check-added-large-files
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.10.7
+  rev: 0.12.1
   hooks:
   - id: uv-lock
 - repo: https://github.com/pycqa/isort
-  rev: 8.0.1
+  rev: 9.0.0b1
   hooks:
   - id: isort
 - repo: https://github.com/pre-commit/pre-commit
-  rev: v4.5.1
+  rev: v4.6.1
   hooks:
   - id: validate_manifest
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.13.9
+  rev: v4.17.0
   hooks:
   - id: commitizen
 - repo: local
@@ -56,7 +56,7 @@ repos:
     pass_filenames: false
     always_run: true
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.4
+  rev: v0.16.1
   hooks:
   - id: ruff-check
     args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.76.0"
+version = "0.76.1"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}
@@ -220,3 +220,17 @@ line_length = 64
 [tool.ruff]
 line-length = 64
 indent-width = 4
+
+[tool.ruff.lint]
+# 適用ルールを明示的に固定する (重要):
+#   これは ruff 0.15 までの暗黙デフォルトと同一の集合であり，
+#   本設定を入れても検出結果は変わらない (0.15.4 / 0.16.1 いずれも 0 件)．
+#   明示する理由は ruff がマイナー更新でデフォルトルールセットを
+#   変えることがあるため．実際 0.16 では pyupgrade / pylint / bugbear /
+#   simplify / tryceratops / datetimez 等が既定で有効になり，
+#   同一コードに対し 508 件が新規検出された (2026-08-04)．
+#   hook 引数が --fix のため，放置すると版上げのたびに
+#   未レビューの一括自動書き換えが走る．
+#   ルールを増やすときは「版上げの副作用」ではなく
+#   ここへの明示的な追記として行うこと．
+select = ["E4", "E7", "E9", "F"]

--- a/src/maou/interface/analysis_gui.py
+++ b/src/maou/interface/analysis_gui.py
@@ -32,9 +32,7 @@ from maou.app.analysis.analysis_session import (  # noqa: F401
 from maou.app.analysis.analysis_session import (
     build_variation_tree as build_variation_tree,
 )
-from maou.app.analysis.analysis_session import (
-    current_node,
-)
+from maou.app.analysis.analysis_session import current_node
 from maou.app.analysis.analysis_session import (
     goto_node as goto_node,
 )

--- a/tests/maou/interface/test_infer.py
+++ b/tests/maou/interface/test_infer.py
@@ -9,9 +9,7 @@ import math
 import pytest
 
 from maou._rust.maou_search import evaluate as rust_evaluate
-from maou._rust.maou_search import (
-    winrate_to_eval,
-)
+from maou._rust.maou_search import winrate_to_eval
 from maou.interface.infer import infer
 
 HIRATE = (

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.76.0"
+version = "0.76.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- #429 (pre-commit autoupdate) の内容を，**lint ポリシーを変えない形**で取り込む
- `[tool.ruff.lint] select` を明示し，ruff のデフォルトルールセット変更の影響を恒久的に遮断する
- #429 自体はクローズ済み (未署名 commit でマージ不能だったため)

## Problem

### ruff 0.16 が暗黙にルール範囲を激変させる

`pyproject.toml` の `[tool.ruff]` には `line-length` と `indent-width` しか無く，
**適用ルールは ruff の暗黙デフォルトに依存**していた．
ruff 0.16 はこのデフォルトを大幅に拡張したため，同一コード・同一設定で結果が変わる：

| ruff | 結果 |
|---|---|
| 0.15.4 (更新前) | `All checks passed!` (0 件) |
| 0.16.1 (更新後・`select` 無し) | **508 件** / 約 37 ルールファミリ |

508 件の内訳 (上位)：

| ルール | 件数 | 自動修正 |
|---|---|---|
| `BLE001` blind-except | 52 | 不可 |
| `RUF100` unused-noqa | 43 | 可 |
| `UP037` quoted-annotation | 39 | 可 |
| `PLR0402` manual-from-import | 38 | 可 |
| `RUF059` unused-unpacked-variable | 30 | 不可 |
| `PLC0414` useless-import-alias | 27 | 不可 |
| `I001` unsorted-imports | 23 | 可 |

**これらは潜在バグではなく，このプロジェクトが採用を決めたことのないルール**
(pyupgrade / pylint / bugbear / simplify / tryceratops / datetimez 等) です．

さらに hook 引数が `--fix` のため，そのまま更新すると
**245 件が 97 ファイルで無レビューに自動書き換え**される状態でした．
危険な例：

- `RUF100` — このリポジトリは flake8 も併用しており (`.flake8` あり)，
  ruff から見て不要な `# noqa` を消すと flake8 が落ちうる
- `UP037` — 前方参照・循環 import があると引用符除去で実行時エラー
- `I001` — 独立した isort フックと競合する (ruff 内蔵 isort とは別実装)

### #429 は未署名 commit でマージ不能だった

`pre-commit autoupdate` ワークフローが runner 上で `git commit` していたため，
main ruleset の "Commits must have verified signatures" に弾かれていました．

## Solution

### `select` の明示固定 (本 PR の主眼)

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```

これは **ruff 0.15 までの暗黙デフォルトと同一集合**であり，検出結果は変わりません．
明示することで今後 ruff がデフォルトを変えても影響を受けなくなります．

ルールを増やしたい場合は「版上げの副作用」ではなく，
ここへの明示的な追記として意図的に行う運用にします．

### hook 更新 (#429 の内容)

| repo | before | after |
|---|---|---|
| `astral-sh/uv-pre-commit` | 0.10.7 | 0.12.1 |
| `pycqa/isort` | 8.0.1 | 9.0.0b1 |
| `pre-commit/pre-commit` | v4.5.1 | v4.6.1 |
| `commitizen` | v4.13.9 | v4.17.0 |
| `astral-sh/ruff-pre-commit` | v0.15.4 | v0.16.1 |

## Impact

**Breaking Changes**: なし．lint の適用ルール範囲は更新前と同一です．

**Code changes**: isort 9 による import 整形が 2 ファイル．
単一 import の括弧を 1 行に畳むだけで**意味の変更はありません**
(いずれも `line-length = 64` に収まる 58 / 50 文字)．
`# noqa: F401` や `as` 再エクスポートも保持されています．

```diff
-from maou.app.analysis.analysis_session import (
-    current_node,
-)
+from maou.app.analysis.analysis_session import current_node
```

**Version**: `src/maou/interface/analysis_gui.py` が変わるため
`pyproject.toml` を 0.76.0 -> 0.76.1 に bump (整形のみのため patch)．
`uv.lock` はこれに追随する 1 行のみ．

## Testing

**ruff の等価性検証** (本 PR の要):

| 条件 | 結果 |
|---|---|
| ruff 0.15.4 (更新前の実際の挙動) | `All checks passed!` |
| ruff 0.16.1 + `select` 無し | 508 件 |
| ruff 0.16.1 + `select` 明示 (本 PR) | **`All checks passed!`** |
| ruff 0.16.1 format (本 PR) | `285 files already formatted` |

更新前と更新後で検出結果が一致することを実測で確認しました．

**pre-commit 全フック** (`--all-files`)：

- 1 回目: isort のみ Failed (= 2 ファイルを整形)．他は全 Passed
- 2 回目: **`PRECOMMIT_EXIT_2ND=0` / 全 Passed**

`test` (pytest 全体) / `mypy` / `ruff check` / `ruff format` /
`uv-lock` / `check-cli-docs` を含みます．

## Review Notes

**重点**:

1. **`select = ["E4", "E7", "E9", "F"]` が本当に従来と等価か** —
   上表の実測で担保していますが，この集合が ruff 0.15 の暗黙デフォルトである
   という前提の確認をお願いします
2. **isort 9.0.0b1 が pre-release である点** — `pre-commit autoupdate` が
   最新タグを取る仕様上 beta を拾っています．安定版に戻す場合は
   `rev: 8.0.1` の 1 行変更で済みます

**フォローアップ (本 PR には含めない)**:

- 508 件のルール採用は独立した判断として別途検討する余地があります．
  特に `B023` (function-uses-loop-variable, 13 件) や
  `RUF012` (mutable-class-default, 5 件) は実バグ族なので，
  優先的に opt-in する候補です
- `DTZ005` (12 件) は本リポジトリが JST 固定運用のため，
  機械的な修正が仕様と矛盾しうる点に注意が必要です
- **PR に Rust ビルド CI / テスト CI が無い**問題は未解決です
  (`check-version-bump` が唯一のチェック)．#428 の revert (#437) の
  原因でもあり，`cargo check` + `uv lock --check` の追加を推奨します

## Checklist

- [x] 更新前後で lint 検出結果が一致することを実測
- [x] pre-commit 全フック Passed (2 回目 exit 0)
- [x] pytest 全体 Passed
- [x] `src/` 変更に伴う version bump (0.76.1)
- [x] Commits carry the `Co-Authored-By` trailer
- [x] PR body ends with the Claude Code footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
