### PR TITLE
feat: search-values の律速を切り分けられるようにする

### DIFF
--- a/docs/commands/utility_search_values.md
+++ b/docs/commands/utility_search_values.md
@@ -137,7 +137,14 @@ maou pre-process --input-path hcpe_val/ --output-dir pre_val/
 | `--threads INT` | `1` | 探索スレッド数． |
 | `--batch-size INT` | `8` | 評価バッチサイズ．GPU では 64 以上． |
 | `--root-dfpn / --no-root-dfpn` | `True` | ルート並行 dfpn 詰み探索． |
+| `--root-dfpn-nodes INT` | Rust 既定 (2,000,000) | ルート dfpn のノード予算．`--min-ply 60` は戦術的に濃い局面を狙って選ぶので，詰み探索が壁時計を支配しうる．下げて切り分ける． |
+| `--root-dfpn-depth INT` | Rust 既定 | ルート dfpn の深さ上限． |
 | `--leaf-mate / --no-leaf-mate` | `True` | MCTS の葉の短手詰み探索． |
+| `--leaf-mate-nodes INT` | Rust 既定 (50) | leaf-mate 1 回あたりのノード予算． |
+| `--leaf-mate-threads INT` | Rust 既定 (1) | leaf-mate 専用スレッド数． |
+| `--defensive-mate / --no-defensive-mate` | Rust 既定 | 受け方向の詰み探索 (root 敗着フィルタ)．**局面ごとの CPU 側の仕事**． |
+| `--defensive-mate-threads INT` | Rust 既定 | root 敗着フィルタの並列度． |
+| `--pad-buckets / --no-pad-buckets` | Rust 既定 (固定 padding) | TensorRT の評価バッチを `--batch-size` へ固定 padding せず 2 冪バケットへ切り上げる．**1 局面 1 探索で毎回 root から立ち上げるので序盤の葉は少なく，固定 padding だと 1 件の評価が `--batch-size` 件分のコストを払う**． |
 | `--cuda / --no-cuda` | `False` | CUDA Execution Provider (`onnx-cuda` 付き wheel が必要)． |
 | `--tensorrt / --no-tensorrt` | `False` | TensorRT Execution Provider (`onnx-tensorrt` 付き wheel が必要)． |
 | `--trt-cache-dir PATH` | optional | TensorRT エンジンキャッシュ保存先． |
@@ -168,15 +175,47 @@ Searching positions:  12%|█▏  | 122093/1000000 [2:41:07<19:19:02, 12.6pos/s,
 | `searchWinRate` | `Float32` | 手番側から見た探索の勝率 (0-1)．`resultValue` と同じ規約． |
 | `playouts` | `Int32` | 実際に消化した playout 数． |
 | `stop` | `String` | 探索の停止理由 (`playout_limit` / `root_proven` など)． |
+| `elapsedMs` | `Int32` | 1 局面あたりの探索時間 (ミリ秒)．**律速の切り分け用**．0.82.0 以前の出力には無く null になる． |
 
-## Cost
+## Cost (実測)
 
-L4 (10,257 playouts/s, batch 64, fp16 TRT+CUDA) で 800 playouts/局面なら
-**約 0.078 秒/局面**．木の再利用が効かない独立探索なので自己対局より
-1 局面あたりは割高だが，**必要な局面だけ選べる**．
+**公称 playouts/s からの割り算を根拠にしない．** 当初この節は
+「10,257 playouts/s ÷ 800 = 0.078 秒/局面 ⇒ 1M = 22 時間」と書いていたが，
+これは compass § TRIPWIRE「公称パラメータを信じない」に反しており，
+GPU によって 2.7 倍ずれる．
 
-| 局面数 | L4 時間 (800 playouts) | 同 (200 playouts) |
+| GPU | 実測 | 1 局面あたり |
 |---|---|---|
-| 100k | 2.2 時間 | 0.5 時間 |
-| 1M | 22 時間 | 5.4 時間 |
-| 19M (ply≥60 の全量) | 411 時間 | 103 時間 |
+| G4 | 1M = **22 時間** (Colab Pro の連続 24 時間に収まる) | 0.079 秒 |
+| L4 | 300k = **18 時間** | **0.216 秒** |
+
+**この用途は自己対局と違って木の再利用が効かず，毎回 root から探索を立ち上げる**
+ため，公称のスループットは出ない．
+
+## 律速の切り分け
+
+出力には `playouts` / `stop` / `elapsedMs` を記録しているので，
+**本番実行そのものが計測になる**．別途 A/B を組まなくても後から追える．
+
+```bash
+uv run python -c "
+import polars as pl
+d = pl.read_ipc('search_values.feather', memory_map=False)
+print(d.group_by('stop').len().sort('len', descending=True).to_dicts())
+print('playouts 中央値', d['playouts'].median(),
+      '/ 800 未満の割合', (d['playouts'] < 800).mean())
+print('elapsedMs 中央値', d['elapsedMs'].median())"
+```
+
+- `stop` が `root_proven` 中心 / `playouts` が 800 に届かない
+  → **時間は playout でなく詰み探索に行っている**．
+  `--root-dfpn-nodes` を下げる，`--no-defensive-mate` を試す
+- `playouts` が 800 に張り付いていて `elapsedMs` が大きい
+  → **評価バッチが埋まっていない可能性**．`--pad-buckets` /
+  `--threads` を上げる / `--batch-size` を下げるを試す
+
+いずれも**教師の質を変えうる**ので，速度だけで既定を決めない
+(詰みが証明された局面の探索値は 0/1 の真値になり教師として最良)．
+
+`elapsedMs` は 0.82.0 で追加した．**それ以前の出力には無いが，読み込み時に
+null で補われるので `--resume` はそのまま継続できる**．

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.81.0"
+version = "0.82.0"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-08-07-search-values-cost-and-knobs.md
+++ b/reviews/2026-08-07-search-values-cost-and-knobs.md
@@ -1,7 +1,8 @@
 ---
 title: search-values のコスト表を実測へ訂正し，探索予算の knob を公開する
 date: 2026-08-07
-status: pending
+status: applied
+applied_in: TBD
 target:
   - docs/commands/utility_search_values.md
 risk: low

--- a/reviews/2026-08-07-search-values-cost-and-knobs.md
+++ b/reviews/2026-08-07-search-values-cost-and-knobs.md
@@ -2,7 +2,7 @@
 title: search-values のコスト表を実測へ訂正し，探索予算の knob を公開する
 date: 2026-08-07
 status: applied
-applied_in: TBD
+applied_in: 956d546
 target:
   - docs/commands/utility_search_values.md
 risk: low

--- a/reviews/2026-08-07-search-values-cost-and-knobs.md
+++ b/reviews/2026-08-07-search-values-cost-and-knobs.md
@@ -1,0 +1,96 @@
+---
+title: search-values のコスト表を実測へ訂正し，探索予算の knob を公開する
+date: 2026-08-07
+status: pending
+target:
+  - docs/commands/utility_search_values.md
+risk: low
+reversibility: easy
+---
+
+# 提案: コスト表を実測値へ差し替え，未公開の探索予算 knob を CLI へ出す
+
+## 背景
+
+`docs/commands/utility_search_values.md` の Cost 節は
+**公称 10,257 playouts/s を 800 で割った 0.078 秒/局面**を根拠に
+「1M = 22 時間」と書いた．これは compass § TRIPWIRE
+「**公称パラメータを信じない．実装を直接叩いて発火量を予測**」に反しており，
+実測と食い違う．
+
+user 実測:
+
+| GPU | 実測 | 1 局面あたり |
+|---|---|---|
+| **G4** | 1M = 22 時間 | 0.079 秒 |
+| **L4** | 300k = 18 時間 | **0.216 秒** |
+
+**G4 が L4 の 2.7 倍速い**という結果になっており，
+`compass § North-star` に「L4 batch 64 = 10,257 p/s」と記録されている値は
+search-values の L4 実測と整合しない (どちらかのラベルか条件が誤っている)．
+
+user 制約: **G4 は高価なので学習に温存し，search-values は安い GPU で回したい**．
+したがって「なぜ遅いのか」を切り分ける価値がある．
+
+## 実装の穴 (コード確認済み)
+
+`SearchEngine` / `search()` が受け取るのに **CLI が出していない** knob がある．
+そのため現状は原因の切り分けすらできない．
+
+| knob | 受け取り先 | 既定 | CLI |
+|---|---|---|---|
+| `pad_buckets` | `SearchEngine.__init__` | False (= `batch_size` へ固定 padding) | **未公開** |
+| `root_dfpn_nodes` | `search()` | **2,000,000** | 未公開 (on/off のみ) |
+| `root_dfpn_depth` | `search()` | 2047 | 未公開 |
+| `leaf_mate_nodes` / `leaf_mate_threads` | `search()` | 50 / 1 | 未公開 (on/off のみ) |
+| `defensive_mate` / `defensive_mate_threads` | `search()` | Rust 既定 (root 敗着フィルタ) | **未公開** |
+
+## 想定される律速 (未検証．A/B で切り分ける)
+
+1. **CPU 側の詰み探索**．`--min-ply 60` は**戦術的に濃い局面を狙って選んでいる**
+   ので dfpn の最悪ケースにあたる．`root_dfpn` の既定予算は 2,000,000 ノードで，
+   さらに `defensive_mate` (root 敗着フィルタ) も走る．
+   **これが支配的なら GPU の種類はほとんど効かず，vCPU 数の差が G4/L4 の差を
+   説明する**．user の目的 (安い GPU で回す) にとって最良のシナリオ．
+2. **batch が埋まらず padding が無駄になる**．TensorRT は既定で全評価バッチを
+   `batch_size` (64) へ padding する．**この用途は 1 局面 1 探索で毎回 root から
+   立ち上げる**ので序盤の playout は葉が少ない．compass の実測
+   `cost(n) ≈ 0.15 + 0.084·n` ms より，1 件を 64 へ padding すると 5.5 ms／
+   実 1 件なら 0.23 ms で **24 倍の無駄**．`pad_buckets=True` (2 冪バケット) が
+   効く可能性があるが**未公開なので試せない**．
+3. 木の再利用が効かない — B 案の構造的コスト．自己対局 (A 案) は手をまたいで
+   subtree を再利用でき評価キューも埋まり続けるので，1 レコードあたりでは
+   A の方が安い可能性がある (ただし A の 0.11 秒/レコードも同じ公称値からの
+   計算なので**同様に信用できない**)．
+
+## 変更内容
+
+### 1. `docs/commands/utility_search_values.md`
+
+- Cost 節を**実測値の表**へ差し替え (G4 / L4 の両方，1 局面あたりの秒数を明記)．
+  公称 playouts/s からの割り算は**根拠にしない**と明記
+- 「律速の切り分け」節を追加: 手元の出力から `stop` 分布と `playouts` 分布を
+  見れば詰み探索が支配的かどうかが分かること，200 局面 A/B の手順
+- 追加する knob (`--pad-buckets` / `--root-dfpn-nodes` / `--leaf-mate-nodes` /
+  `--defensive-mate`) を CLI options 表へ追加
+
+### 2. src/ (併せて実施)
+
+上記 knob を CLI → interface → `SearchValueOption` → `SearchEngine`/`search()`
+へ通す．**既定値は現行の挙動を保つ** (すべて Rust 既定へ委譲)．
+
+## 検討したが採用しなかった案
+
+- **詰み探索を既定で切る**: 詰みが証明された局面の探索値は**教師として最良**
+  (0/1 の真値になる) なので，速度のためだけに既定を変えるのは
+  compass § VETOES「レバーは A/B で確認してから既定化」に反する．
+  knob を出して測れるようにするだけに留める
+- **`playouts` を既定で下げる**: 教師の質が変わる．質とコストの曲線が未測定
+- **複数局面を 1 つの評価キューへ混ぜる (`search_many`)**: batch 埋まらず問題の
+  本質的な解だが **Rust の新機能**であり，まず律速を切り分けてから判断する
+
+## リスク
+
+- **低**: knob 追加は既定動作を変えない
+- **未検証**: 上の律速仮説はどちらも未測定．A/B の結果次第で提案が変わる
+- 版数は `maou 0.81.0` → `0.82.0` (CLI オプション追加 = feat 相当)

--- a/src/maou/app/pre_process/search_value.py
+++ b/src/maou/app/pre_process/search_value.py
@@ -45,11 +45,18 @@ from tqdm.auto import tqdm
 logger: logging.Logger = logging.getLogger(__name__)
 
 #: 出力 feather のスキーマ．``id`` は前処理出力の ``id`` と同じ Zobrist hash．
+#:
+#: ``playouts`` / ``stop`` / ``elapsedMs`` は**律速の切り分け用**に持つ．
+#: 本番実行そのものが計測になるので，別途 A/B を組まなくても「時間が playout に
+#: 行っているのか詰み探索に行っているのか」を後から追える．
+#: ``elapsedMs`` は 0.82.0 で追加したため**古い出力には無い**
+#: (`_with_current_schema` が null で補う)．
 SEARCH_VALUE_SCHEMA: dict[str, pl.DataType] = {
     "id": pl.UInt64(),
     "searchWinRate": pl.Float32(),
     "playouts": pl.Int32(),
     "stop": pl.String(),
+    "elapsedMs": pl.Int32(),
 }
 
 
@@ -70,7 +77,17 @@ class SearchValueOption:
         threads: 探索スレッド数．
         batch_size: 評価バッチサイズ．GPU では 64 以上．
         root_dfpn: ルート並行 dfpn 詰み探索を行うか．
+        root_dfpn_nodes: ルート dfpn のノード予算 (None で Rust 既定 2,000,000)．
+        root_dfpn_depth: ルート dfpn の深さ上限 (None で Rust 既定)．
         leaf_mate: 葉の短手詰み探索を行うか．
+        leaf_mate_nodes: leaf-mate 1 回あたりのノード予算 (None で Rust 既定)．
+        leaf_mate_threads: leaf-mate 専用スレッド数 (None で Rust 既定)．
+        defensive_mate: 受け方向の詰み探索 (root 敗着フィルタ)．None で Rust 既定．
+        defensive_mate_threads: root 敗着フィルタの並列度 (None で Rust 既定)．
+        pad_buckets: TensorRT の padding を `batch_size` 固定でなく 2 冪バケットへ
+            切り上げる．**この用途は 1 局面 1 探索で毎回 root から立ち上げるので
+            葉が少なく，固定 padding だと 1 件の評価が `batch_size` 件分のコストを
+            払う**．None で Rust 既定 (固定 padding)．
         cuda: CUDA Execution Provider を使うか．
         tensorrt: TensorRT Execution Provider を使うか．
         trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
@@ -92,7 +109,14 @@ class SearchValueOption:
     threads: int = 1
     batch_size: int = 8
     root_dfpn: bool = True
+    root_dfpn_nodes: int | None = None
+    root_dfpn_depth: int | None = None
     leaf_mate: bool = True
+    leaf_mate_nodes: int | None = None
+    leaf_mate_threads: int | None = None
+    defensive_mate: bool | None = None
+    defensive_mate_threads: int | None = None
+    pad_buckets: bool | None = None
     cuda: bool = False
     tensorrt: bool = False
     trt_engine_cache_dir: Path | None = None
@@ -243,11 +267,43 @@ def apply_search_values(
     )
 
 
+def _with_current_schema(df: pl.DataFrame) -> pl.DataFrame:
+    """古い出力を現行スキーマへ揃える．
+
+    `elapsedMs` は 0.82.0 で追加した．**既に走っている実行の出力を捨てさせない**
+    ため，欠けている列は null で補って `--resume` を継続できるようにする．
+
+    Args:
+        df: 読み込んだ既存出力．
+
+    Returns:
+        `SEARCH_VALUE_SCHEMA` の列を揃えた DataFrame．
+    """
+    missing = [
+        c for c in SEARCH_VALUE_SCHEMA if c not in df.columns
+    ]
+    if missing:
+        logger.info(
+            "Backfilling %s from an older output format",
+            ", ".join(missing),
+        )
+        df = df.with_columns(
+            [
+                pl.lit(
+                    None, dtype=SEARCH_VALUE_SCHEMA[c]
+                ).alias(c)
+                for c in missing
+            ]
+        )
+    return df.select(list(SEARCH_VALUE_SCHEMA))
+
+
 def _frame(
     ids: list[int],
     win_rates: list[float],
     playouts: list[int],
     stops: list[str],
+    elapsed_ms: list[int],
 ) -> pl.DataFrame:
     """探索結果の列から `SEARCH_VALUE_SCHEMA` の DataFrame を作る．
 
@@ -256,6 +312,7 @@ def _frame(
         win_rates: 手番側から見た探索の勝率．
         playouts: 消化した playout 数．
         stops: 停止理由．
+        elapsed_ms: 1 局面あたりの探索時間 (ミリ秒)．
 
     Returns:
         `SEARCH_VALUE_SCHEMA` の DataFrame．
@@ -270,6 +327,9 @@ def _frame(
                 "playouts", playouts, dtype=pl.Int32
             ),
             "stop": pl.Series("stop", stops, dtype=pl.String),
+            "elapsedMs": pl.Series(
+                "elapsedMs", elapsed_ms, dtype=pl.Int32
+            ),
         },
         schema=SEARCH_VALUE_SCHEMA,
     )
@@ -327,8 +387,10 @@ class SearchValueCollector:
             既存の出力 (無ければ空の DataFrame)．
         """
         if option.resume and option.output_path.exists():
-            done = pl.read_ipc(
-                option.output_path, memory_map=False
+            done = _with_current_schema(
+                pl.read_ipc(
+                    option.output_path, memory_map=False
+                )
             )
             self.logger.info(
                 "Resuming: %d positions already searched",
@@ -511,6 +573,7 @@ class SearchValueCollector:
             batch_size=option.batch_size,
             use_cuda=option.cuda,
             use_tensorrt=option.tensorrt,
+            pad_buckets=option.pad_buckets,
             trt_engine_cache_dir=(
                 str(option.trt_engine_cache_dir)
                 if option.trt_engine_cache_dir
@@ -522,6 +585,7 @@ class SearchValueCollector:
         win_rates: list[float] = []
         playouts: list[int] = []
         stops: list[str] = []
+        elapsed: list[int] = []
         progress = tqdm(
             self._iter_targets(option, selected),
             total=len(selected),
@@ -535,36 +599,51 @@ class SearchValueCollector:
                 max_playouts=option.max_playouts,
                 time_ms=option.time_ms,
                 root_dfpn=option.root_dfpn,
+                root_dfpn_nodes=option.root_dfpn_nodes,
+                root_dfpn_depth=option.root_dfpn_depth,
                 leaf_mate=option.leaf_mate,
+                leaf_mate_nodes=option.leaf_mate_nodes,
+                leaf_mate_threads=option.leaf_mate_threads,
+                defensive_mate=option.defensive_mate,
+                defensive_mate_threads=option.defensive_mate_threads,
             )
             ids.append(hash_id)
             win_rates.append(float(result.winrate))
             playouts.append(int(result.playouts))
             stops.append(str(result.stop))
+            elapsed.append(int(result.elapsed_ms))
             # 途中経過を落とさない: 実運用では数十万局面を数日かけて回すので，
             # 最後にしか書かないと中断で全損する (--resume はここに依存する)
             if n % option.flush_interval == 0:
                 self._write(
                     _merge(
                         done,
-                        _frame(ids, win_rates, playouts, stops),
+                        _frame(
+                            ids,
+                            win_rates,
+                            playouts,
+                            stops,
+                            elapsed,
+                        ),
                     ),
                     option.output_path,
                     quiet=True,
                 )
                 progress.set_postfix(
                     mean_wr=f"{np.mean(win_rates):.3f}",
+                    ms=f"{np.mean(elapsed):.0f}",
                     flushed=n,
                 )
         progress.close()
 
-        fresh = _frame(ids, win_rates, playouts, stops)
+        fresh = _frame(ids, win_rates, playouts, stops, elapsed)
         merged = _merge(done, fresh)
         self._write(merged, option.output_path)
         return {
             "searched": str(len(fresh)),
             "total": str(len(merged)),
             "mean_win_rate": f"{np.mean(win_rates):.4f}",
+            "mean_elapsed_ms": f"{np.mean(elapsed):.0f}",
             "output": str(option.output_path),
         }
 

--- a/src/maou/infra/console/search_values.py
+++ b/src/maou/infra/console/search_values.py
@@ -90,10 +90,57 @@ from maou.infra.console.common import handle_exception
     help="Run the root parallel dfpn mate search.",
 )
 @click.option(
+    "--root-dfpn-nodes",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Node budget for the root dfpn search (Rust default: 2,000,000). "
+    "--min-ply 60 deliberately selects tactically dense positions, so mate "
+    "proving can dominate the wall time; lower this to find out.",
+)
+@click.option(
+    "--root-dfpn-depth",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Depth limit for the root dfpn search (Rust default).",
+)
+@click.option(
     "--leaf-mate/--no-leaf-mate",
     default=True,
     show_default=True,
     help="Run the short mate search at MCTS leaves.",
+)
+@click.option(
+    "--leaf-mate-nodes",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Node budget per leaf-mate call (Rust default: 50).",
+)
+@click.option(
+    "--leaf-mate-threads",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Dedicated leaf-mate threads (Rust default: 1).",
+)
+@click.option(
+    "--defensive-mate/--no-defensive-mate",
+    default=None,
+    help="Run the defensive mate search (root losing-move filter). It is "
+    "CPU-side work per position. Omit to keep the Rust default.",
+)
+@click.option(
+    "--defensive-mate-threads",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Parallelism of the root losing-move filter (Rust default).",
+)
+@click.option(
+    "--pad-buckets/--no-pad-buckets",
+    default=None,
+    help="Round TensorRT evaluation batches up to power-of-two buckets "
+    "instead of padding every batch to --batch-size. This workload runs one "
+    "cold search per position, so early playouts have few leaves and fixed "
+    "padding makes a 1-leaf batch cost a full --batch-size batch. Omit to "
+    "keep the Rust default (fixed padding).",
 )
 @click.option(
     "--cuda/--no-cuda",
@@ -151,7 +198,14 @@ def search_values(
     threads: int,
     batch_size: int,
     root_dfpn: bool,
+    root_dfpn_nodes: int | None,
+    root_dfpn_depth: int | None,
     leaf_mate: bool,
+    leaf_mate_nodes: int | None,
+    leaf_mate_threads: int | None,
+    defensive_mate: bool | None,
+    defensive_mate_threads: int | None,
+    pad_buckets: bool | None,
     cuda: bool,
     tensorrt: bool,
     trt_cache_dir: Path | None,
@@ -189,7 +243,14 @@ def search_values(
         threads=threads,
         batch_size=batch_size,
         root_dfpn=root_dfpn,
+        root_dfpn_nodes=root_dfpn_nodes,
+        root_dfpn_depth=root_dfpn_depth,
         leaf_mate=leaf_mate,
+        leaf_mate_nodes=leaf_mate_nodes,
+        leaf_mate_threads=leaf_mate_threads,
+        defensive_mate=defensive_mate,
+        defensive_mate_threads=defensive_mate_threads,
+        pad_buckets=pad_buckets,
         cuda=cuda,
         tensorrt=tensorrt,
         trt_engine_cache_dir=trt_cache_dir,

--- a/src/maou/interface/search_value_interface.py
+++ b/src/maou/interface/search_value_interface.py
@@ -25,7 +25,14 @@ def collect_search_values(
     threads: int = 1,
     batch_size: int = 8,
     root_dfpn: bool = True,
+    root_dfpn_nodes: int | None = None,
+    root_dfpn_depth: int | None = None,
     leaf_mate: bool = True,
+    leaf_mate_nodes: int | None = None,
+    leaf_mate_threads: int | None = None,
+    defensive_mate: bool | None = None,
+    defensive_mate_threads: int | None = None,
+    pad_buckets: bool | None = None,
     cuda: bool = False,
     tensorrt: bool = False,
     trt_engine_cache_dir: Path | None = None,
@@ -47,7 +54,14 @@ def collect_search_values(
         threads: 探索スレッド数．
         batch_size: 評価バッチサイズ．
         root_dfpn: ルート並行 dfpn 詰み探索を行うか．
+        root_dfpn_nodes: ルート dfpn のノード予算 (None で Rust 既定)．
+        root_dfpn_depth: ルート dfpn の深さ上限 (None で Rust 既定)．
         leaf_mate: 葉の短手詰み探索を行うか．
+        leaf_mate_nodes: leaf-mate 1 回あたりのノード予算 (None で Rust 既定)．
+        leaf_mate_threads: leaf-mate 専用スレッド数 (None で Rust 既定)．
+        defensive_mate: 受け方向の詰み探索 (None で Rust 既定)．
+        defensive_mate_threads: root 敗着フィルタの並列度 (None で Rust 既定)．
+        pad_buckets: TensorRT の padding を 2 冪バケットへ切り上げるか．
         cuda: CUDA Execution Provider を使うか．
         tensorrt: TensorRT Execution Provider を使うか．
         trt_engine_cache_dir: TensorRT エンジンキャッシュ保存先．
@@ -83,7 +97,14 @@ def collect_search_values(
         threads=threads,
         batch_size=batch_size,
         root_dfpn=root_dfpn,
+        root_dfpn_nodes=root_dfpn_nodes,
+        root_dfpn_depth=root_dfpn_depth,
         leaf_mate=leaf_mate,
+        leaf_mate_nodes=leaf_mate_nodes,
+        leaf_mate_threads=leaf_mate_threads,
+        defensive_mate=defensive_mate,
+        defensive_mate_threads=defensive_mate_threads,
+        pad_buckets=pad_buckets,
         cuda=cuda,
         tensorrt=tensorrt,
         trt_engine_cache_dir=trt_engine_cache_dir,

--- a/tests/maou/app/pre_process/test_search_value.py
+++ b/tests/maou/app/pre_process/test_search_value.py
@@ -18,6 +18,7 @@ from maou.app.pre_process.search_value import (
     SearchValueOption,
     _merge,
     _ply_of,
+    _with_current_schema,
     apply_search_values,
     select_positions,
 )
@@ -133,6 +134,9 @@ def _values(
                 "stop",
                 ["playout_limit"] * len(ids),
                 dtype=pl.String,
+            ),
+            "elapsedMs": pl.Series(
+                "elapsedMs", [120] * len(ids), dtype=pl.Int32
             ),
         },
         schema=SEARCH_VALUE_SCHEMA,
@@ -312,3 +316,38 @@ class TestOverwriteGuard:
             self._option(out)
         )
         assert result["searched"] == "0"
+
+
+class TestOlderOutputFormat:
+    """0.82.0 より前の出力 (``elapsedMs`` 無し) を捨てさせない．
+
+    既に数十万件を貯めている実行があるので，列が増えたら読めなくなる，
+    では困る．欠けている列は null で補って `--resume` を続けられること．
+    """
+
+    def _old(self) -> pl.DataFrame:
+        return _values([1, 2], [0.4, 0.6]).drop("elapsedMs")
+
+    def test_backfills_missing_column(self) -> None:
+        out = _with_current_schema(self._old())
+        assert list(out.columns) == list(SEARCH_VALUE_SCHEMA)
+        assert out["elapsedMs"].null_count() == 2
+
+    def test_keeps_existing_values(self) -> None:
+        out = _with_current_schema(self._old())
+        assert out["id"].to_list() == [1, 2]
+        assert out["searchWinRate"].to_list() == pytest.approx(
+            [0.4, 0.6], abs=1e-6
+        )
+
+    def test_current_format_is_untouched(self) -> None:
+        cur = _values([1], [0.5])
+        assert _with_current_schema(cur).equals(cur)
+
+    def test_merges_with_new_rows(self) -> None:
+        merged = _merge(
+            _with_current_schema(self._old()),
+            _values([3], [0.7]),
+        )
+        assert sorted(merged["id"].to_list()) == [1, 2, 3]
+        assert merged["elapsedMs"].null_count() == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.81.0"
+version = "0.82.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

`maou utility search-values` の**律速を切り分けられる状態にする**．調査自体は user 指示により後回しで，本 PR は計測手段の用意までを行う．

## コスト表が誤っていた

Cost 節は **公称 10,257 playouts/s を 800 で割った 0.078 秒/局面**を根拠に「1M = 22 時間」と書いていた．これは compass § TRIPWIRE「**公称パラメータを信じない．実装を直接叩いて発火量を予測**」に自分で違反しており，GPU によって 2.7 倍ずれる．

| GPU | 実測 (user) | 1 局面あたり |
|---|---|---|
| G4 | 1M = **22 時間** (Colab Pro の連続 24 時間に収まる) | 0.079 秒 |
| L4 | 300k = **18 時間** | **0.216 秒** |

**この用途は自己対局と違って木の再利用が効かず，毎回 root から探索を立ち上げる**ため公称スループットは出ない．なお compass に「L4 batch 64 = 10,257 p/s」と記録されている値は L4 実測と整合せず，どちらかの条件が誤っている (未解決)．

user 制約: **G4 は高価なので学習に温存し，search-values は安い GPU で回したい**．

## 律速の候補 (いずれも未検証)

1. **CPU 側の詰み探索** — `--min-ply 60` は戦術的に濃い局面を狙って選ぶので dfpn の最悪ケース．`root_dfpn` の既定予算は **2,000,000 ノード**で，さらに `defensive_mate` (root 敗着フィルタ) も走る．これが支配的なら **GPU の種類はほとんど効かず vCPU 差が G4/L4 の差を説明する** — 安い GPU で回したい目的には最良のシナリオ
2. **評価バッチが埋まらない** — TensorRT は既定で全バッチを `batch_size` (64) へ padding する．1 局面 1 探索で毎回 root から立ち上げるので序盤の葉は数個．compass の `cost(n) ≈ 0.15+0.084n` ms から、1 件を 64 へ padding すると 5.5 ms／実 1 件なら 0.23 ms で **24 倍の無駄**

## 変更

### 未公開だった knob を出す (既定動作は不変)

`SearchEngine` / `search()` が受け取るのに CLI が出しておらず、**切り分けすらできない状態**だった．すべて Rust 既定へ委譲するので既定動作は変わらない．

`--root-dfpn-nodes` / `--root-dfpn-depth` / `--leaf-mate-nodes` / `--leaf-mate-threads` / `--defensive-mate` / `--defensive-mate-threads` / `--pad-buckets`

### 出力に `elapsedMs` を追加

`playouts` / `stop` と併せて **本番実行そのものが計測になる**．別途 A/B を組まなくても、貯まったファイルから後で追える．

```bash
uv run python -c "
import polars as pl
d = pl.read_ipc('search_values.feather', memory_map=False)
print(d.group_by('stop').len().sort('len', descending=True).to_dicts())
print('playouts 中央値', d['playouts'].median(), '/ 800 未満', (d['playouts']<800).mean())
print('elapsedMs 中央値', d['elapsedMs'].median())"
```

- `root_proven` 中心 / `playouts` が 800 に届かない → **時間は詰み探索**
- `playouts` が 800 に張り付き `elapsedMs` が大きい → **バッチ埋まらず**

### 既に貯めている出力を捨てない

`elapsedMs` は新しい列なので、**30 万件を貯めている実行のファイルには無い**．読み込み時に null で補い `--resume` を継続できるようにした (`_with_current_schema`)．

実際に旧コード (0.81.0) で作ったファイルで検証:
```
Backfilling elapsedMs / Resuming: 8 positions / searched 5, total 13
列: [id, searchWinRate, playouts, stop, elapsedMs]
elapsedMs: null(旧行) 8 / 実測(新行) [247, 279, 263, 248, 252]
```

## テスト

- 1,751 passed / 47 skipped、ruff・mypy clean、pre-commit 全 hook パス
- 旧スキーマの backfill / 既存値の保持 / 現行形式が無変更 / 新旧のマージを 4 ケースで固定
- 実データで旧コード出力からの `--resume` 継続と、新 knob (`--no-defensive-mate --root-dfpn-nodes 5000 --leaf-mate-nodes 20 --pad-buckets`) の実行を確認

## 破壊的変更

なし．knob はすべて既定で Rust 既定へ委譲、`elapsedMs` は旧出力を null 埋めで受ける．

版数 0.81.0 → 0.82.0．

## 次

律速の調査 (200 局面 A/B、または貯まったファイルの `stop`/`elapsedMs` 分布) は**後回し**．速度のためだけに詰み探索の既定を変えるのは避ける — 詰みが証明された局面の探索値は 0/1 の真値になり教師として最良なので、compass § VETOES「レバーは A/B で確認してから既定化」に従う．

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4hK6B1Psxz9z5DcUMyY48
