### PR TITLE
chore: uv.lock を 0.82.4 に追随させる (#446 の追従)

### DIFF
--- a/audits/2026-08-08-src-maou-app-learning.md
+++ b/audits/2026-08-08-src-maou-app-learning.md
@@ -353,23 +353,48 @@ on this path requires `python -m maturin develop --release` first
 (**24m34s** in this container; a `patchelf` rpath warning is harmless).
 
 The git pre-commit hook is **not installed** (`.git/hooks/pre-commit`
-absent); hooks were run manually via `pre-commit run --files`. Results:
+absent); hooks were run manually via `pre-commit run --files`.
+
+**During the run**, `uv-lock`, `test`, `mypy`, `ruff-check` and
+`ruff-format` all **failed** for one shared environment reason — they
+are `uv run`-based, and `uv run` re-resolves the project, which pulls
+`maou[tensorrt-infer]` → `tensorrt-cu12-libs` from `pypi.nvidia.com`,
+then blocked by the agent proxy (`403 to CONNECT`). Only
 `trim trailing whitespace`, `fix end of files`, `check toml`,
-`check for added large files`, **`check-cli-docs`** passed;
-`uv-lock`, `test`, `mypy`, `ruff-check`, `ruff-format` **failed**, all
-for the same environment reason — they are `uv run`-based, and `uv run`
-re-resolves the project, which pulls `maou[tensorrt-infer]` →
-`tensorrt-cu12-libs` from `pypi.nvidia.com`, unreachable here. The same
-tools run directly against `.venv` all pass:
+`check for added large files` and **`check-cli-docs`** could run.
+QA was therefore done by invoking the same tools directly against
+`.venv`, which all passed (ruff format/check clean, mypy 284 files
+clean, `pytest tests/maou/app/learning` 477 passed / 1 skipped).
 
-- `ruff format src/ tests/`: 285 files already formatted
-- `ruff check src/ tests/`: all checks passed
-- `mypy src/ tests/`: no issues in 284 source files
-- `pytest tests/maou/app/learning`: **476 passed, 1 skipped**
+**Resolved after the run.** `pypi.nvidia.com` was allowed through the
+proxy and the whole hook set was re-run against every file this branch
+changed. **All 12 hooks pass**, including the five that had been
+blocked:
 
-A stale `.mypy_cache` produced a spurious
-`AssertionError: Cannot find module for google`; `rm -rf .mypy_cache`
-cleared it.
+| Hook | During run | After allow |
+|---|---|---|
+| `uv-lock` | Failed | **Passed** |
+| `test` | Failed | **Passed** — 1716 passed, 54 skipped (full suite, not just this path) |
+| `mypy` | Failed | **Passed** |
+| `ruff-check` / `ruff-format` | Failed | **Passed** |
+
+So the QA claims above are no longer resting on hand-run substitutes —
+they are confirmed under the project's own toolchain, and against the
+**full** test suite rather than the `tests/maou/app/learning` subset.
+
+Two flakes worth knowing about for the next run:
+
+- The first post-allow `test` invocation failed on
+  `tests/maou/infra/console/test_usi_cli.py::test_usi_go_mate_e2e`
+  (`go mate 5000` returned `checkmate timeout` instead of `G*5b`); it
+  passed on re-run. It is a wall-clock-budgeted dfpn e2e test and the
+  machine was still loaded from the ~1GB tensorrt install. Unrelated to
+  `src/maou/app/learning`. Compare CLAUDE.md §"重いテスト (Rust dfpn)":
+  dfpn is ~6× slower in a debug build, so a time-budgeted mate test is
+  the first thing to fail under load.
+- A stale `.mypy_cache` produced a spurious
+  `AssertionError: Cannot find module for google`; `rm -rf .mypy_cache`
+  cleared it.
 
 **Step 2 note.** The first attempt at the simplify pass lost all four
 review agents to an API session limit and produced nothing; it was

--- a/uv.lock
+++ b/uv.lock
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.82.1"
+version = "0.82.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
#446 (merge 済み) の follow-up．`pypi.nvidia.com` がプロキシで許可された
ことで初めて実行できた検証の結果，取りこぼしが 1 件見つかったので修正する．

## 何が起きていたか

#446 の作業中，`uv run` 系の pre-commit hook (`uv-lock` / `test` /
`mypy` / `ruff-check` / `ruff-format`) は全て実行できなかった．
`uv run` がプロジェクトを再解決する際に
`maou[tensorrt-infer]` → `tensorrt-cu12-libs` を `pypi.nvidia.com` から
取得しようとし，プロキシが `403 to CONNECT` で遮断していたためである．

そのため #446 では，同じツールを `.venv` に直接実行して QA を代替した．
ruff / mypy / pytest は代替できたが，**`uv-lock` hook だけは代替手段が
無かった**．

## 見つかった取りこぼし

`uv.lock` の `maou` が **0.82.1 のまま**取り残されていた．#446 で
`pyproject.toml` を 0.82.1 → 0.82.4 と 3 回上げたが，それを検出する
`uv-lock` hook 自体が動いていなかったためである．

`pypi.nvidia.com` 許可後に `uv run` が通るようになり，lock が同期されて
差分として現れた．`uv lock --check` は現在 exit 0．

このリポジトリでは同種のズレが繰り返し起きている
(`e847950` 0.82.1 追随 / `266d915` 0.79.0 追随)．

## 検証

`pypi.nvidia.com` 許可後，#446 で触れた全ファイルに対して pre-commit を
再実行し，**12 hook すべて Passed**．遮断されていた 5 つを含む:

| Hook | #446 作業中 | 許可後 |
|---|---|---|
| `uv-lock` | Failed | **Passed** |
| `test` | Failed | **Passed** — 1716 passed / 54 skipped (全スイート) |
| `mypy` | Failed | **Passed** |
| `ruff-check` / `ruff-format` | Failed | **Passed** |

これにより #446 の QA 主張は，手動の代替実行ではなくプロジェクト本来の
ツールチェーンで，かつ `tests/maou/app/learning` の部分集合ではなく
**全スイート**で裏付けられた．監査記録の Environment notes をその事実に
更新している (「`uv run` は使用不能」と書いたままだったため)．

## 既知のフレーク (本 PR とは無関係)

許可直後の 1 回目の `test` で
`tests/maou/infra/console/test_usi_cli.py::test_usi_go_mate_e2e` が
`go mate 5000` に対し `checkmate timeout` を返して失敗し，再実行で通った．
約 1GB の tensorrt インストール直後で負荷が高かったためと見ている．
実時間予算つきの dfpn e2e テストであり，CLAUDE.md §「重いテスト
(Rust dfpn)」が述べるとおり負荷で最初に落ちる類のもの．監査記録に
次回のために記載した．

## 補足

`main` には #446 が merge 済みでブランチも削除されていたため，本 follow-up は
`main` から作り直すつもりだったが，リポジトリルール
(`Cannot force-push to this branch`) により rebase 後の force push が
拒否された．リモートのブランチは既にこの 2 コミットを持っており，
`main` に対する差分は rebase 版と同一 (下記 2 ファイルのみ) なので，
そのまま新規 PR として出している．

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQC3mojEtsKqN5696XYkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVQC3mojEtsKqN5696XYkD)_