### PR TITLE
feat(audit-backlog): 優先度を判断コストで機械的に決め，判断帯は PR 1 回のチェックにする

### DIFF
--- a/.claude/commands/audit-backlog.md
+++ b/.claude/commands/audit-backlog.md
@@ -1,6 +1,6 @@
 ---
-description: Consume the deferred and out-of-scope findings that /audit-and-fix left behind. Gathers them from audits/coverage.md's backlog tables, re-verifies each against HEAD, then classifies each by DECISION COST on a mechanical six-class ladder — P1-P3 need no user judgment and are fixed, PR'd and merged without asking; P4-P6 need judgment and stop for the user. Applies fixes on the normal route (version bump, regression test, reviews/ proposal for durable docs), deletes the resolved backlog rows, and records the run in audits/.
-argument-hint: [item-selector or class (P1..P6 / auto / judgment) | omit to run the auto band and then ask] [effort-level: low|medium|high|max, default medium]
+description: Consume the deferred and out-of-scope findings that /audit-and-fix left behind. Gathers them from audits/coverage.md's backlog tables, re-verifies each against HEAD, then classifies each by DECISION COST on a mechanical six-class ladder — P1-P3 need no user judgment and are fixed, PR'd and merged without asking; P4-P6 need judgment and become PRs carrying that decision. The user is asked ONCE, on the PR — the run stops mid-session only when the answer decides what code to write. PRs are stacked when they depend on each other so the order is visible. Applies fixes on the normal route (version bump, regression test, reviews/ proposal for durable docs), deletes the resolved backlog rows, and records the run in audits/.
+argument-hint: [item-selector or class (P1..P6 / auto / judgment) | omit to take everything] [effort-level: low|medium|high|max, default medium]
 ---
 
 `/audit-and-fix` deliberately leaves work behind. It defers findings that
@@ -14,9 +14,10 @@ owning-manifest version bump, regression test, `reviews/` proposal for
 durable docs, committed audit record.
 
 `$ARGUMENTS` is `[selector] [level]`, both optional:
-- **Omit the selector** to do the whole run: consume the auto band without
-  asking (step 3b), then stop and ask about the judgment band (step 3c).
-  This is the intended way to open the command.
+- **Omit the selector** to do the whole run: consume the auto band and
+  merge it (step 3b), then build the judgment band into PRs the user
+  decides on afterwards (step 3c). This is the intended way to open the
+  command, and it normally runs end to end without a question.
 - A selector may name a class (`P4`), a band (`auto`, `judgment`), item IDs
   from the listing (`P3-2,P4-1`), or a target path
   (`src/maou/interface`) to take everything aimed at it.
@@ -152,6 +153,57 @@ train and which validate.
 Severity has not stopped mattering; it has stopped being the *tier*. It is
 the sort key **inside** a class (step 3a).
 
+## Standing principle: the user checks the work once, on the PR
+
+Classifying a finding as P4/P5/P6 says a human has to decide. It does
+**not** say a human has to decide *now*, in the session, before the code
+exists.
+
+Those are different claims, and conflating them costs the user two reviews
+of the same finding: a question mid-session describing a fix that has not
+been written, and then the PR containing it. The first review is the
+weaker one — it is prose about a diff instead of the diff — and it blocks
+the run while it waits.
+
+So the default is **PR-only**: write the fix, open the PR, put the decision
+in the body, and do not merge. The PR *is* the question. It carries the
+diff, the QA output, the compatibility statement, and the alternative, and
+the user answers it by merging, commenting, or closing — at whatever
+moment suits them, with the auto band already on `main` and out of the way.
+
+### When the run may stop and ask anyway
+
+The exception is narrow and it is about **what code to write**, not about
+how risky the change is:
+
+> Stop and ask only when the branches of the decision produce **materially
+> different diffs**, and implementing the wrong one wastes work the user
+> would have to review and discard.
+
+Both halves must hold.
+
+- D8/D9 — "delete `file_level_split`" and "repair it" share no lines: one
+  removes a public name and its tests, the other rewrites the constructor.
+  Guessing wrong throws away the whole change. **Ask.**
+- D1 — "add `moveWinRate` to the dtype" and "drop it right after
+  conversion" are opposed designs of comparable size, each touching several
+  layers. **Ask.**
+- O4 — `test_ratio or 0.1` has exactly one repair; the judgment is whether
+  to accept that results change for anyone passing `0.0`. There is nothing
+  to write differently. **Do not ask — PR it.**
+- P5 and P6 items in general are *not* automatically asks. A dtype change
+  with one sensible form is a PR; two credible forms is a question.
+
+When the second half fails on its own — the branches differ but the diff is
+small and cheap to redo — implement the one you would recommend, and put
+the alternative in the PR body under the heading the user will answer. A
+30-line diff the user rejects costs less than the round-trip that avoided
+it.
+
+When you do ask, ask **once**, batching every outstanding fork into a
+single `AskUserQuestion`, after the auto band has merged. A second question
+in the same run means the first one was under-specified.
+
 ## Hard constraints
 
 - **Never `--no-verify`.** Pre-commit runs on every commit.
@@ -173,12 +225,19 @@ the sort key **inside** a class (step 3a).
 - **Respect the Code Exploration Policy.** Verification that needs to read
   multiple unfamiliar files is delegated to an `Explore` agent.
 - **Serena MCP tools are called one at a time** — never in parallel.
-- **Every selected item ends in one of three states**: resolved (fixed +
-  merged), re-triaged (still open, with sharpened reasoning recorded), or
-  rejected (won't do, recorded as such). Silently dropping a selected item
-  is the one outcome that is not allowed.
+- **Every selected item ends in one of four states**: resolved (fixed +
+  merged), in flight (fixed, PR open, awaiting the user), re-triaged (still
+  open, with sharpened reasoning recorded), or rejected (won't do, recorded
+  as such). Silently dropping a selected item is the one outcome that is
+  not allowed.
 - **A backlog row is deleted when its fix has merged — not when it is
   written.** An unmerged PR is an open finding (step 6a).
+- **Ask at most once per run, and only under the test above.** A judgment
+  class is a reason to open a PR unmerged, not a reason to interrupt.
+- **PRs that depend on each other are stacked** (step 5b) — a dependent PR
+  is based on the branch it depends on, never on `main`. Independent PRs
+  are based on `main` and say so. The stack is how a reader sees the order
+  without reading the diffs.
 
 ## Steps
 
@@ -223,11 +282,26 @@ the missing row, and say so in step 6 — but treat this as a ledger repair,
 not as a licence to gather from records generally. The reverse case (a row
 whose record is gone) is a broken link worth reporting too.
 
-**1e. Check for open PRs from earlier runs.** A previous run may have left
-judgment-band PRs open. List them (`mcp__github__list_pull_requests`) and
-report them alongside the backlog — an open PR and its still-present row
-are the same finding counted once, not two units of work. Do not open a
-second PR for a row that already has one.
+**1e. Check what earlier runs left in flight.** Judgment-band PRs are the
+normal end state of a run, so a cold session inherits them. List them
+(`mcp__github__list_pull_requests`) and, for each, report it alongside the
+backlog row it belongs to — an open PR and its still-present row are the
+same finding counted once, not two units of work. **Do not open a second PR
+for a row that already has one**; update the existing PR instead.
+
+Three follow-ups belong here rather than to a later step, because each is
+work an earlier run could not finish itself:
+
+- **Stale stacks.** A PR still based on a merged or deleted branch shows a
+  meaningless diff. Retarget and refresh it per 5b before anything else
+  reads it.
+- **Merged PRs whose rows are still present.** 6a deletes a row when its
+  fix *merges*, and the merge often happens after the run ended. Confirm
+  against `main` and delete the row now, noting it in this run's record.
+- **`reviews/` proposals left `pending` whose decision has since been
+  taken** (the PR carrying them merged, or the user answered on it). Apply
+  the proposal, commit, set `status: applied` + `applied_in: <sha>`. This
+  is the tail of 4d's non-drift branch, and nobody else picks it up.
 
 ### 2. Re-verify each candidate against HEAD
 
@@ -272,34 +346,47 @@ makes the classification auditable after the fact.
 both the cheapest and the least able to break anything, so a failure there
 surfaces before the run has spent effort on P3.
 
-Ungated P1/P2/P3 items are consumed in full. Gated ones are not: a gate
-moves the item into the judgment band, where it is reported in 3c with the
-gate as the reason.
+Ungated P1/P2/P3 items are consumed in full and merged (step 5d). Gated
+ones are not: a gate moves the item into the judgment band, where it
+becomes a PR whose body names the gate as the reason it is not merged.
 
 If the auto band is empty, say so in one line and go straight to 3c.
 
-**3c. Stop and ask about the judgment band (P4/P5/P6 + everything gated).**
-Ask via `AskUserQuestion`, after the auto band's PRs exist, so the user is
-answering with the safe work already visible and mergeable.
+**3c. Build the judgment band (P4/P5/P6 + everything gated) into PRs.**
+Per the one-check principle, this is normally *work*, not a question. For
+each item:
 
-Offer classes as coarse choices (e.g. "all of P4", "P4+P5") alongside
-individual IDs, and recommend a batch with the reason. For each item the
-question must carry **the decision itself**, not a request for permission:
-what the two branches are and what each costs. "Delete `file_level_split`
-or repair it? Deleting removes its tests and a public name; repairing means
-fixing the全ロード it forces at construction" is a question. "May I work on
-D8?" is not.
+1. Apply the split test from that principle — do the branches produce
+   materially different diffs, *and* would guessing wrong waste work worth
+   reviewing? If both hold, the item goes on the ask list. Otherwise it
+   gets the fix you would recommend.
+2. Fix it on the normal route (step 4), including the regression test and
+   the version bump. A judgment-band item is not a draft: the PR has to be
+   mergeable the moment the user says yes.
+3. Open its PR **unmerged** (step 5e), with the decision at the top of the
+   body: what changes for the user, what the alternative was, and why this
+   branch was chosen.
 
-**A P5 or P6 item's question MUST state the compatibility break in
-concrete terms** — which existing artifacts stop loading, which existing
-command lines stop working. That sentence is the entire reason the item is
-not in the auto band; omitting it turns the question back into a
-formality.
+**A P5 or P6 PR body MUST state the compatibility break in concrete
+terms** — which existing artifacts stop loading, which existing command
+lines stop working, what the user has to regenerate. That sentence is the
+entire reason the item is not in the auto band; a PR that omits it has
+turned the decision back into a rubber stamp.
+
+**The ask list, if it is non-empty, is one `AskUserQuestion`** — raised
+after the auto band has merged, so the user answers with the safe work
+already out of the way. Each entry carries **the decision itself**, not a
+request for permission: what the branches are and what each costs.
+"Delete `file_level_split` or repair it? Deleting removes its tests and a
+public name; repairing means fixing the全ロード it forces at construction"
+is a question. "May I work on D8?" is not.
+
+Answers received here are implemented in the same run and shipped as PRs
+under 5d — the answer decides the diff, it does not authorize the merge.
+The merge decision still belongs to the PR.
 
 If a selector was given in `$ARGUMENTS`, honor it: confirm the resolved
-item set in one line and skip the parts of 3b/3c it excludes. A selector
-naming judgment-band items still requires their decisions to be taken here,
-before any code changes.
+item set in one line and skip the parts of 3b/3c it excludes.
 
 ### 4. Fix, on the normal route
 
@@ -307,12 +394,17 @@ Group the selected items **by class first, then by owning path**, so each
 commit is one coherent fix and each class can ship independently (step 5).
 
 **4a. Check the scope boundary first.** If a selected item cannot be fixed
-without touching something unselected, stop and report before editing —
-that is gate **G2**, and it applies even mid-fix, after classification.
-Two legitimate resolutions: pull the neighbour in with the user's agreement,
-or re-triage the item as still-open with the coupling recorded. Silently
-widening is not one of them. An auto-band item that hits G2 leaves the auto
-band; it does not get a quiet waiver because the run had already started.
+without touching something unselected, that is gate **G2**, and it applies
+even mid-fix, after classification. An auto-band item that hits G2 leaves
+the auto band; it does not get a quiet waiver because the run had already
+started.
+
+Two legitimate resolutions, chosen by the same one-check test as any other
+judgment: **pull the neighbour in** and PR the widened fix unmerged, with
+the coupling stated at the top of the body — or **re-triage** the item as
+still-open with the coupling recorded, when the neighbour is large enough
+that guessing wrong wastes the work. Silently widening is not one of them,
+and neither is widening quietly *and* auto-merging it.
 
 **4b. Apply source fixes.** Same triage as `/audit-and-fix` step 1: contained
 and unambiguous → apply. Check the `infra → interface → app → domain` rule
@@ -368,12 +460,20 @@ exists?*
   it is the audit trail, and the next reader needs to see that a durable
   doc changed and why. Only the round-trip is skipped, and it is skipped
   because there was no alternative text to choose between.
-- **No → something is being decided.** Leave `status: pending`, present it
-  in 3c's question (or a follow-up if the drift only surfaced during 4b),
-  and take the decision: **approve** → apply, commit, `status: applied` +
-  `applied_in: <sha>`; **reject** → `status: rejected` with the reason,
-  retained as do-not-redo provenance; **defer** → leave `pending` and
-  record it as outstanding in step 6.
+- **No → something is being decided**, so the doc is **not edited**. Leave
+  `status: pending` and ship the proposal alone: the proposal already
+  contains the exact before/after text, so the PR carries the full change
+  for the user to read without the edit having been made. Do not put the
+  doc edit in the PR "ready to merge" — CLAUDE.md's gate is approval
+  *before* the edit, and the standing approval covers drift corrections
+  only. The proposal is what the user approves; a later run (this one, if
+  they answer here, or the next `/audit-backlog` or `/checkpoint-context`)
+  applies it, commits, and sets `status: applied` + `applied_in: <sha>`.
+
+  This is the one place the run deliberately leaves a second round-trip in
+  place. It is rare — most doc drift found from a re-verified backlog row
+  passes the uniqueness test — and the alternative is writing durable-doc
+  text nobody chose.
 
 The test is about the *text*, not about the size of the diff. "The doc says
 `.npy`, the writer writes `.feather`" has one correct replacement. "This
@@ -386,11 +486,10 @@ Committing is not shipping. This step turns the run's commits into review
 units the user can look at afterwards, and merges the ones that had nothing
 to decide.
 
-**5a. One PR per class, off `main`.** `P1`, `P2`, `P3`, `P4`… each becomes
-at most one PR, branched from the current `main`. That is the "ある程度の
-単位" the batching exists for: a reviewer opening the P4 PR knows every
-commit in it changes behavior and none of it breaks data, because that is
-what the class means.
+**5a. One PR per class.** `P1`, `P2`, `P3`, `P4`… each becomes at most one
+PR. That is the "ある程度の単位" the batching exists for: a reviewer
+opening the P4 PR knows every commit in it changes behavior and none of it
+breaks data, because that is what the class means.
 
 Split a class into more than one PR only when:
 - it spans unrelated scope classes (Python and Rust, say) — then split by
@@ -405,16 +504,78 @@ If the session was handed a designated branch it must develop on, that
 mandate wins: commit everything there, open the single PR from it, and say
 in the report that class-per-PR was collapsed and why.
 
-**5b. PR body — written for the user reading it after the fact.** State,
+**5b. Stack the PRs that depend on each other.** A run that consumes a
+real backlog produces several PRs at once, and left flat they arrive as an
+undifferentiated pile — the reviewer cannot tell which must land first, and
+two of them silently contain each other's diffs. Stacking makes the order
+part of the PR itself.
+
+**The dependency test, applied per PR against the ones already opened in
+this run:**
+
+> Does this PR's diff touch a file that an earlier **unmerged** PR of this
+> run also touches, or rely on a symbol, helper, or signature that PR
+> introduced?
+
+- **Yes** → base this PR on that PR's **head branch**, not `main`. GitHub
+  then shows only the incremental diff, and the base link states the
+  dependency without anyone writing it down.
+- **No** → base it on `main`, and say "independent — based on `main`" in
+  the body. Do not stack for tidiness. A stack is a merge *constraint*: an
+  independent PR stacked on a judgment-band PR cannot land until the user
+  answers a question that has nothing to do with it.
+
+Order the stack by class ascending, P1 at the bottom. That is also the
+merge order, and it puts the parts needing no decision underneath the parts
+that do — so the stack drains from the bottom as the auto band merges,
+rather than being held up from the top.
+
+**Open the judgment-band PRs after the auto band has merged** (5d). By
+then `main` already contains P1-P3, so most judgment PRs are independent
+and base cleanly on `main` — the stack exists for the cases where they are
+genuinely not.
+
+**Restacking is part of the run, not an afterthought.** When a parent
+merges, GitHub retargets its open children onto the parent's base *if the
+parent's head branch is deleted* — which is a repository setting, not a
+guarantee. Verify with `mcp__github__pull_request_read` that each child's
+base is now `main`; where it is not, set it with
+`mcp__github__update_pull_request`. Then bring the child up to date
+(`mcp__github__update_pull_request_branch`, or merge `main` in and push if
+it conflicts), because a child left on a deleted base shows a diff that no
+longer means anything.
+
+A stacked PR merges only **after its parent has merged and it has been
+retargeted to `main`**. Do not merge a child into its parent's branch to
+"unblock" it — that buries the child's review inside the parent's PR and
+loses the class boundary that made the split worth making.
+
+**5c. PR body — written for the user reading it after the fact.** State,
 for each item in the PR: the backlog row and record it came from, its class
 **and the test that decided the class**, what shipped, and the QA that ran.
-For judgment-band PRs, put the decision the user took (or the one still
-outstanding) at the top — that is what the reviewer is actually checking.
+
+For judgment-band PRs the decision goes at the **top**, because it is the
+whole reason the PR is unmerged and it is the only part the user must
+supply: what changes for them, what the alternative was, why this branch
+was taken, and — for P5/P6 — the concrete compatibility break. Write it so
+that merging is a complete answer.
+
+Every PR of the run carries the same **stack map**, marking its own
+position, so the relationship is visible from whichever PR the user opens
+first:
+
+```markdown
+## Stack (2026-08-12 /audit-backlog)
+1. #481 P1 audits/ ledger + record — merged
+2. #482 P3 behavior-preserving fixes — merged
+3. #483 P4 test-ratio / cache glob  ← このPR (base: main, independent)
+4. #484 P5 moveWinRate dtype (base: #483 — 同じ dtype 経路に触るため)
+```
 
 Follow the repository's PR template if one exists.
 
-**5c. Merge the auto band. Do not wait for the user.** P1/P2/P3 PRs with no
-gates merge as soon as both conditions hold:
+**5d. Merge the auto band, bottom-up. Do not wait for the user.** P1/P2/P3
+PRs with no gates merge as soon as all three conditions hold:
 
 1. **The QA in 4c ran here and passed.** This is the real gate. The repo
    deliberately runs no test suite on PRs — `claude-code-review.yml` is
@@ -428,22 +589,33 @@ gates merge as soon as both conditions hold:
    without this file changing. A red check blocks the merge, full stop,
    including when you believe it is unrelated: investigate, fix, or move
    the PR to the judgment band and say so.
+3. **Its base is `main`.** A PR still stacked on an unmerged parent waits
+   for the parent, then gets retargeted and refreshed per 5b. Merging up
+   the stack in any other order is what produces the "why does this PR
+   contain someone else's diff" confusion the stack exists to prevent.
 
 Prefer `mcp__github__enable_pr_auto_merge` so GitHub merges when the checks
 settle; if the repository does not allow auto-merge, read the checks and
 call `mcp__github__merge_pull_request`. Match the repository's merge style
 (currently merge commits — `git log --merges` settles it at read time).
+After each merge, restack the children before merging the next one.
 
 **MUST NOT auto-merge**: any P4/P5/P6 PR, any PR carrying a gated item, any
-PR whose classification you could not decide without hedging, and any PR
-whose checks are red or still running. When in doubt the PR stays open —
-that costs a comment, while a wrong merge costs a revert on `main`.
+PR whose classification you could not decide without hedging, any PR whose
+checks are red or still running, and any PR whose parent in the stack has
+not merged. When in doubt the PR stays open — that costs a comment, while a
+wrong merge costs a revert on `main`.
 
-**5d. Judgment-band PRs stay open**, linked in the report next to the
-question from 3c. If the user answers in this session, merge them the same
-way once their decision is applied and QA is green. If they do not, the
-PR *is* the handoff: it holds the fix, the reasoning, and the question, and
-the backlog row stays put until it merges.
+**5e. Judgment-band PRs stay open. That is the deliverable, not a
+shortfall.** They hold the fix, the QA, the reasoning, and the decision, and
+the user answers them by merging, commenting, or closing — once, on their
+own schedule. Do not chase them with a mid-session question about whether
+to merge; the one-check principle exists precisely to avoid asking the same
+thing twice.
+
+If the user *does* answer in this session, apply what they decided, re-run
+the QA, and merge under 5d's conditions. If they do not, the PR **is** the
+handoff, and the backlog row stays put until it merges (6a).
 
 ### 6. Update the ledger and write the record
 
@@ -502,9 +674,11 @@ rather than a path audit. Body:
 - **Consumed** — one row per item: source record, target, what shipped, and
   the PR it merged in.
 - **Applied** — the fixes, with `file:line` and commit SHA.
-- **In flight** — judgment-band PRs left open, with their PR number and the
-  question outstanding. Their backlog rows are still present by design
-  (6a); this section says why.
+- **In flight** — judgment-band PRs left open, with their PR number, their
+  base (`main`, or the PR they are stacked on and why), and the question
+  outstanding. Their backlog rows are still present by design (6a); this
+  section says why, and it is what step 1e of the next run reads to pick
+  them back up.
 - **Re-triaged** — items selected but left open, with the sharpened reason.
   This is the section that earns the run its keep: a second impasse on the
   same item is far more informative than the first.
@@ -538,12 +712,16 @@ copy of it; a copy would drift.
 
 Print the reconciliation as an equation in step 7, not as an assurance.
 
-**6e. Ship the record itself.** The ledger update and the record are P1 by
-construction — `audits/` ships nothing — so they go in their own PR and
-merge under 5c like any other P1 work. They must **not** ride in a
-judgment-band PR: the account of a run has to reach `main` even when the
-fixes it describes are still under review, or an unmerged PR takes the
-run's only record down with it.
+**6e. Ship the record itself, at the bottom of the stack.** The ledger
+update and the record are P1 by construction — `audits/` ships nothing — so
+they go in their own PR and merge under 5d like any other P1 work. They
+must **not** ride in a judgment-band PR: the account of a run has to reach
+`main` even when the fixes it describes are still under review, or an
+unmerged PR takes the run's only record down with it.
+
+Nothing may be stacked **on** the record PR either. It is written last but
+merges first, and a judgment PR based on it would inherit the wait it was
+built to avoid.
 
 Link the record from `coverage.md` under the backlog table so a future run
 can find the account of a row that is no longer there. Then commit:
@@ -565,7 +743,14 @@ Compact summary:
   item — so a reader can see what was kept out of the auto band and why
 - Auto band: what was fixed, which PRs, **merged or blocked** (with the
   blocking check named)
-- Judgment band: the question asked, the answer taken, PRs left open
+- Judgment band: one line per PR — number, class, the decision it carries,
+  and its base. Print the **stack map** once, in the same shape 5c puts in
+  the PR bodies, so the report and the PRs agree
+- **Whether the run asked anything, and why.** If an `AskUserQuestion` was
+  raised, name the fork that justified it under the one-check test. If not,
+  say so — "asked nothing; N PRs carry their decisions" is the expected
+  outcome, and stating it is what makes an unnecessary question visible
+  next time
 - Re-triaged / rejected, with the reason
 - Doc drift → `reviews/<file>`, its status, and which P2 branch applied
 - QA: what ran, what passed, what was blocked and why
@@ -587,9 +772,14 @@ The committed record is what carries this run forward. Do not mirror it into
 `worklog/` or `scratchpad/compass.md` — per CLAUDE.md, `audits/` and the
 campaign memory are deliberately separate systems.
 
-Open judgment-band PRs are the other half of the handoff. Leave them
-listed in the report with their questions; a later session picks them up
-from `list_pull_requests` plus the still-present backlog rows.
+Open judgment-band PRs are the other half of the handoff, and they are
+designed to be one: each holds a finished fix, its QA, and the decision it
+needs, so the user can answer whenever they get to it and a later session
+can pick it up cold. Leave them listed in the report with their stack map;
+step 1e of the next run reads them back from `list_pull_requests` plus the
+still-present backlog rows.
+
+Do not end a run by asking whether to merge them. The PR already asks.
 
 ## Extending this command
 
@@ -606,9 +796,17 @@ Keep the derive-never-enumerate property:
   whether its changes need a version bump.
 - **New durable-doc location** — verify 4d's routing test classifies it
   correctly; if it does, no edit is needed here.
-- **New CI check on PRs** — nothing to do. 5c reads the checks off the PR
+- **New CI check on PRs** — nothing to do. 5d reads the checks off the PR
   rather than naming them, so a new required check gates the auto band
   automatically. Adding its name here would be the enumeration bug.
+- **A repo that starts running tests on PRs** — 5d's first condition stops
+  being the only real gate, but it does not become redundant: it is what
+  covers the checks CI still does not run. Add nothing here; the condition
+  is already written as "the QA in 4c ran here", not "no CI exists".
+- **A stack that keeps collapsing to one PR** — that means the dependency
+  test in 5b is answering "no" every time, which is the healthy outcome:
+  class-per-PR off `main` is the cheaper shape. Do not stack to make the
+  stack look used.
 - **A class that keeps coming up empty** — that is a signal about the repo,
   not about the rubric. Leave the class; report the emptiness.
 - **A class that keeps being wrong** — that is a signal about the *ladder*,
@@ -619,13 +817,16 @@ Keep the derive-never-enumerate property:
 
 ## Usage
 
-- `/audit-backlog` — classify everything, ship the auto band unattended,
-  then ask about the rest. The intended entry point.
-- `/audit-backlog auto` — the auto band only. Stop after 5c; do not ask
-  about P4-P6 at all. Useful when the user is away.
-- `/audit-backlog P4` — take the P4 decisions and fix what they resolve.
+- `/audit-backlog` — classify everything, merge the auto band unattended,
+  and leave the judgment band as PRs to decide on. Asks nothing unless a
+  fork in the road demands it. The intended entry point.
+- `/audit-backlog auto` — the auto band only. Stop after 5d; do not build
+  judgment-band PRs at all. The narrowest run.
+- `/audit-backlog judgment` — the judgment band only, when the auto band
+  is already clear.
+- `/audit-backlog P4` — the P4 items: fix them and open their PR.
 - `/audit-backlog P3-1,P4-3 high` — two specific items, broader
   verification.
 - `/audit-backlog src/maou/interface` — everything targeting that path,
-  auto band merged and judgment band asked as usual (without auditing the
+  auto band merged and judgment band PR'd as usual (without auditing the
   path itself — use `/audit-and-fix` for that).

--- a/.claude/commands/audit-backlog.md
+++ b/.claude/commands/audit-backlog.md
@@ -1,6 +1,6 @@
 ---
-description: Consume the deferred and out-of-scope findings that /audit-and-fix left behind. Gathers them from audits/coverage.md's backlog tables, re-verifies each against HEAD, ranks them by priority, and lets the user pick which to resolve — then applies the fixes on the normal route (version bump, regression test, reviews/ proposal for durable docs), deletes the resolved backlog rows, and records the run in audits/.
-argument-hint: [item-selector or tier | omit to list everything] [effort-level: low|medium|high|max, default medium]
+description: Consume the deferred and out-of-scope findings that /audit-and-fix left behind. Gathers them from audits/coverage.md's backlog tables, re-verifies each against HEAD, then classifies each by DECISION COST on a mechanical six-class ladder — P1-P3 need no user judgment and are fixed, PR'd and merged without asking; P4-P6 need judgment and stop for the user. Applies fixes on the normal route (version bump, regression test, reviews/ proposal for durable docs), deletes the resolved backlog rows, and records the run in audits/.
+argument-hint: [item-selector or class (P1..P6 / auto / judgment) | omit to run the auto band and then ask] [effort-level: low|medium|high|max, default medium]
 ---
 
 `/audit-and-fix` deliberately leaves work behind. It defers findings that
@@ -14,10 +14,12 @@ owning-manifest version bump, regression test, `reviews/` proposal for
 durable docs, committed audit record.
 
 `$ARGUMENTS` is `[selector] [level]`, both optional:
-- **Omit the selector** to list the whole backlog, ranked, and stop for the
-  user to choose. This is the intended way to open the command.
-- A selector may name a tier (`T1`), item IDs from the listing (`T1-2,T2-1`),
-  or a target path (`src/maou/interface`) to take everything aimed at it.
+- **Omit the selector** to do the whole run: consume the auto band without
+  asking (step 3b), then stop and ask about the judgment band (step 3c).
+  This is the intended way to open the command.
+- A selector may name a class (`P4`), a band (`auto`, `judgment`), item IDs
+  from the listing (`P3-2,P4-1`), or a target path
+  (`src/maou/interface`) to take everything aimed at it.
 - Second token: effort level `low|medium|high|max`, default `medium`.
 
 ## What this command is *not*
@@ -30,7 +32,7 @@ resolves individual findings inside paths that are mostly still unaudited.
 claims the path was audited; writing one after fixing one finding inside it
 would mark unaudited code as covered, which is precisely the silent-staleness
 defect the ledger exists to prevent. This command's account lives in its own
-record file, linked from the backlog section (step 5).
+record file, linked from the backlog section (step 6).
 
 ## Standing principle: a recorded finding is a hypothesis
 
@@ -38,7 +40,7 @@ Every item in the backlog was true **as of some SHA**, written by a session
 that no longer exists. Between then and now the code may have been fixed,
 moved, renamed, or changed shape enough that the recorded fix is wrong.
 
-**MUST re-verify every candidate against HEAD before presenting it** (step
+**MUST re-verify every candidate against HEAD before classifying it** (step
 2), and again before fixing it. Read the actual `file:line`. A record that
 says "X has zero callers" is a claim to re-check, not a fact to act on.
 
@@ -54,24 +56,129 @@ that.
 
 So: trust a record for **where to look**, never for **what to do**.
 
+Verification is also what makes the classification in step 3 mean anything.
+An unverified item cannot be classified — you would be classifying the
+record's *description* of a fix rather than the fix.
+
+## Standing principle: priority is decision cost, not severity
+
+This command used to rank findings by impact and stop for the user on every
+one of them. That was wrong on the cheap end. Correcting a doc that
+contradicts the code, deleting a branch that cannot execute, fixing a log
+line that globs the wrong extension — none of these have a second version
+the user would have preferred. Asking about them buys nothing and delays
+the findings that genuinely need a decision behind a round-trip.
+
+So the ranking axis is **who has to decide**, applied mechanically:
+
+| Class | Band | The fix… |
+|---|---|---|
+| **P1** | 自動 | touches no shipped file. `.claude/`, `audits/`, `reviews/`, `.github/`, tooling config (`.pre-commit-config.yaml`, ruff/mypy settings), `tests/`, and formatting/lint-only edits. Nothing under `src/` or `rust/` — so there is nothing to version-bump. |
+| **P2** | 自動 | touches only tracked prose (`*.md` under `docs/`, the repo root, `CLAUDE.md`), **and** the corrected text follows uniquely from the code as it exists. A drift correction, not an authored opinion. |
+| **P3** | 自動 | changes code without changing behavior: for every input the program already accepts, the artifacts it writes and the values it returns are unchanged. Only diagnostics, log text, timing, and memory may differ. |
+| **P4** | 要判断 | changes observable behavior, but existing data stays readable and existing invocations stay valid. |
+| **P5** | 要判断 | breaks data compatibility: artifacts written by the current code stop being readable, or the new code cannot read what the current code wrote. Schema/dtype/field/file-layout changes live here. |
+| **P6** | 要判断 | breaks a contract callers depend on: a CLI option removed or re-meaninged, a public API deleted or re-signatured, a documented output path or format moved. |
+
+**Evaluate P6 first and descend.** An item takes the **highest** class it
+triggers, so a fix that corrects a doc *and* changes a dtype is P5, never
+P2. Classifying top-down is what makes that automatic rather than a thing
+you have to remember.
+
+**The fail-safe direction is up, and it is not negotiable.** If a class's
+question cannot be answered without reading more code than the item
+justifies — or the honest answer is "probably" — the item is **P4 at
+minimum**. A misclassification into the auto band merges without anyone
+looking at it; a misclassification into the judgment band costs one
+question. Those are not symmetric errors, so do not treat them as one.
+
+### Gates — these demote out of the auto band regardless of class
+
+A gate does not change an item's class; it removes the item from the band
+that ships unattended. Report the class *and* the gate.
+
+| Gate | Trigger |
+|---|---|
+| **G1 unverifiable here** | Correctness cannot be established in this environment — needs GPU hardware, a long measurement, or production data. |
+| **G2 scope bleed** | The fix cannot be made without touching something outside the item (step 4a). |
+| **G3 no QA** | The QA for this scope class cannot run here, so "behavior unchanged" is an assertion rather than a result. |
+| **G4 the record says so** | The row's own stated reason for deferral is a design decision (`見送り理由: …設計判断が要る`, "two directions", "keep vs delete"), and step 2 did not eliminate it. |
+
+G4 is the cheapest signal in the list and the most frequently correct: an
+earlier run already looked at this and concluded a human had to choose.
+Re-verification can retire a G4 — the decision may have been taken since,
+or the alternatives may have collapsed to one — but it must be retired
+*explicitly*, with the reason, not by forgetting to look.
+
+### Worked classifications, from rows in the current backlog
+
+These are the calibration set. When a new item's class is unclear, find the
+row here it most resembles.
+
+- **O11** — `docs/commands/pre_process.md` says pre-process writes `.npy`
+  shards; the code writes `transformed_chunk{NNNN}.feather`. The corrected
+  text is dictated by the code, and the diff touches one `.md`. → **P2**.
+- **O6** — `bq_data_source.py:483` validates the local cache with
+  `glob("*.npy")` while the writer writes `.feather`, so it always logs
+  "Created 0 local cache files". Fixing the glob changes a log line and
+  nothing else. → **P3** (log text may differ; artifacts and return values
+  do not).
+- **D12(b)** — a `try/except ImportError` nested inside a `try/except
+  Exception`, where the inner arm re-raises only to be caught by the outer.
+  Removing the nesting leaves the same exception reaching the same handler.
+  → **P3**.
+- **O4** — `learn_model.py:876` uses `test_ratio or 0.1`, so
+  `--test-ratio 0.0` silently becomes 10%. Fixing it changes what the
+  program does for an invocation that is still valid, and no artifact
+  becomes unreadable. → **P4**. Note it is *not* P3: the whole point is
+  that behavior changes.
+- **D1** — `moveWinRate` missing from `get_preprocessing_dtype()`. Adding
+  the field changes the structured dtype, so arrays and `.npy` written
+  before the change no longer match what the reader expects. → **P5**,
+  and the row also carries **G4** (the record names two opposed
+  directions, "add to the dtype" vs "drop it right after conversion").
+- **D8/D9** — `file_level_split` has zero production callers. "Delete it"
+  and "keep it and fix it" are different products; deleting also removes
+  its tests. → **P6** if deleted (a public name disappears), **P4** if
+  repaired, and **G4** either way. The class is a *consequence* of the
+  decision, which is why the decision cannot be skipped.
+
+Note what the calibration set does *not* contain: an item whose class was
+decided by how urgent it felt. A user-visible wrong result is not thereby
+auto-mergeable, and a cosmetic cleanup is not thereby safe — D2's "just add
+a default seed" is one line and lands in P4, because it changes which rows
+train and which validate.
+
+Severity has not stopped mattering; it has stopped being the *tier*. It is
+the sort key **inside** a class (step 3a).
+
 ## Hard constraints
 
 - **Never `--no-verify`.** Pre-commit runs on every commit.
-- **Durable docs are never edited before approval.** `CLAUDE.md`,
-  `AGENTS.md`, and tracked prose under `docs/` or the repo root go through a
-  `reviews/*.md` proposal reconciled in this run (step 4d) — identical to
-  `/audit-and-fix`'s routing rule. Source files, including their docstrings
-  and Japanese comments, are fixed directly.
+- **Durable docs still go through `reviews/`.** `CLAUDE.md`, `AGENTS.md`,
+  and tracked prose under `docs/` or the repo root get a `reviews/*.md`
+  proposal recording what changed and why — the audit trail is not what
+  P2 removes. What P2 removes is the *round-trip* on a pure drift
+  correction, which CLAUDE.md's standing approval covers. Anything beyond
+  a drift correction — new guidance, a restructure, a rule — fails P2's
+  second test, lands in the judgment band, and waits for a real approval
+  (step 4d).
+- **Source files, including their docstrings and Japanese comments, are
+  fixed directly.** They are code, not durable docs — but a docstring edit
+  touches `src/`, so it is classified P3 (or higher) and carries a version
+  bump, never P2.
 - **One item may not silently grow into its neighbours.** If fixing a
-  selected item requires changing something the user did not select, stop and
-  say so (step 4a). Scope creep is what makes a backlog unresumable.
+  selected item requires changing something the user did not select, stop
+  and say so (step 4a). Scope creep is what makes a backlog unresumable.
 - **Respect the Code Exploration Policy.** Verification that needs to read
   multiple unfamiliar files is delegated to an `Explore` agent.
 - **Serena MCP tools are called one at a time** — never in parallel.
 - **Every selected item ends in one of three states**: resolved (fixed +
-  committed), re-triaged (still open, with sharpened reasoning recorded), or
-  rejected (won't do, recorded as such). Silently dropping a selected item is
-  the one outcome that is not allowed.
+  merged), re-triaged (still open, with sharpened reasoning recorded), or
+  rejected (won't do, recorded as such). Silently dropping a selected item
+  is the one outcome that is not allowed.
+- **A backlog row is deleted when its fix has merged — not when it is
+  written.** An unmerged PR is an open finding (step 6a).
 
 ## Steps
 
@@ -81,11 +188,13 @@ Assume no memory of any previous run.
 
 **1a. Sync first.**
 ```bash
-git fetch origin <current-branch>
+git fetch origin main
 git status -sb
 ```
-Report if behind; do not auto-merge. A stale ledger silently re-proposes
-work another session already finished.
+Report if behind; do not auto-merge into the working branch without saying
+so. A stale ledger silently re-proposes work another session already
+finished — and with an auto band that merges unattended, it would re-open
+PRs for findings that are already on `main`.
 
 **1b. Read `audits/coverage.md` § "Open findings backlog" in full** — both
 the Deferred backlog and the Out-of-scope backlog tables. That is the
@@ -110,13 +219,19 @@ record for context is fine. Reading it for the worklist is the error.
 **1d. Reconcile, don't second-guess.** If a record documents an open
 finding that has **no row** in `coverage.md`, that is a **retrieval bug in
 the ledger**: the finding is invisible to every future run. Report it, add
-the missing row, and say so in step 5 — but treat this as a ledger repair,
+the missing row, and say so in step 6 — but treat this as a ledger repair,
 not as a licence to gather from records generally. The reverse case (a row
 whose record is gone) is a broken link worth reporting too.
 
+**1e. Check for open PRs from earlier runs.** A previous run may have left
+judgment-band PRs open. List them (`mcp__github__list_pull_requests`) and
+report them alongside the backlog — an open PR and its still-present row
+are the same finding counted once, not two units of work. Do not open a
+second PR for a row that already has one.
+
 ### 2. Re-verify each candidate against HEAD
 
-Per the standing principle above. For each item, before it reaches the user:
+Per the standing principle above. For each item, before it is classified:
 
 - Open the cited `file:line`. Does the code still look like the finding
   describes?
@@ -129,53 +244,75 @@ Per the standing principle above. For each item, before it reaches the user:
   the consumer. This is where the worked example above went wrong.
 
 Mark each item: **confirmed** (still true) / **stale** (already fixed or
-moved — delete its row in step 5 and say so) / **changed shape** (still real,
+moved — delete its row in step 6 and say so) / **changed shape** (still real,
 different fix than recorded).
 
-Do not present an unverified item as actionable. Verification is cheap
-relative to writing the wrong fix.
+Do not classify an unverified item, and do not present one as actionable.
+Verification is cheap relative to writing the wrong fix — and far cheaper
+than merging one unattended.
 
-### 3. Rank, then let the user choose
+### 3. Classify, then run the auto band before asking anything
 
-Rank every confirmed item into tiers. The rubric is **impact first, cost
-second** — a cheap fix to a cosmetic problem does not outrank a real defect:
+**3a. Assign every confirmed item a class and its gates.** Apply the ladder
+top-down (P6 → P1), then the four gates. Record, per item: ID (`P3-1`),
+source record, target path, the one-line finding, verification result from
+step 2, **class + the specific test that decided it**, gates, and expected
+blast radius.
 
-| Tier | Meaning |
-|---|---|
-| **T1** | Wrong behavior a user or an operator can see — wrong output, a CLI option that cannot work, silently corrupted results — **and** the fix is contained. |
-| **T2** | Wrong instructions that cause wrong work: agent-facing files (`.claude/`), or doc drift that a reader would act on. Cheap, high leverage. |
-| **T3** | Real but needs a decision before code can move: dead code (keep vs. delete), an unread parameter, a protocol/type gap. Contained once decided. |
-| **T4** | Large refactors — duplication spanning files, base-class extraction. Correct to do, wrong to fold into a backlog run; each deserves its own change. |
-| **T5** | Cannot be validated in this environment (needs GPU hardware, a long measurement, production data). Report as un-consumable *here* rather than guessing. |
-| **T6** | New documentation to author, or findings the original record could not confirm. |
+Sort **within** each class by severity — wrong results a user or operator
+can see, ahead of internal cleanups. That is where the old impact rubric
+went: it orders work inside a class, it no longer decides which class.
 
-Present the ranked list with, for each item: an ID (`T1-1`), the source
-record, the target path, the one-line finding, verification result from step
-2, what decision (if any) the user must make, and the expected blast radius.
+Print this table before doing anything with it. It is the user's chance to
+stop a misclassification before it merges, and it is the artifact that
+makes the classification auditable after the fact.
 
-Then **stop and ask** which to consume, via `AskUserQuestion`. Offer the
-tiers as coarse choices (e.g. "all of T1", "T1+T2") alongside individual
-IDs. Recommend a batch and say why — usually all of T1 plus any T2, since
-those are contained and their cost is dominated by the QA cycle they share.
+**3b. Consume the auto band (P1 → P2 → P3) without asking.** No
+`AskUserQuestion`, no pause. Work the classes in ascending order — P1 is
+both the cheapest and the least able to break anything, so a failure there
+surfaces before the run has spent effort on P3.
 
-If the selector was given in `$ARGUMENTS`, skip the question and confirm the
-resolved item set in one line before proceeding.
+Ungated P1/P2/P3 items are consumed in full. Gated ones are not: a gate
+moves the item into the judgment band, where it is reported in 3c with the
+gate as the reason.
 
-**T3 items need their decision taken here, before any code changes.** Ask it
-as a real question with the consequences of each branch (deleting a public
-function removes its tests too; keeping it means fixing the defects that
-made it a finding). Do not pick the default yourself.
+If the auto band is empty, say so in one line and go straight to 3c.
+
+**3c. Stop and ask about the judgment band (P4/P5/P6 + everything gated).**
+Ask via `AskUserQuestion`, after the auto band's PRs exist, so the user is
+answering with the safe work already visible and mergeable.
+
+Offer classes as coarse choices (e.g. "all of P4", "P4+P5") alongside
+individual IDs, and recommend a batch with the reason. For each item the
+question must carry **the decision itself**, not a request for permission:
+what the two branches are and what each costs. "Delete `file_level_split`
+or repair it? Deleting removes its tests and a public name; repairing means
+fixing the全ロード it forces at construction" is a question. "May I work on
+D8?" is not.
+
+**A P5 or P6 item's question MUST state the compatibility break in
+concrete terms** — which existing artifacts stop loading, which existing
+command lines stop working. That sentence is the entire reason the item is
+not in the auto band; omitting it turns the question back into a
+formality.
+
+If a selector was given in `$ARGUMENTS`, honor it: confirm the resolved
+item set in one line and skip the parts of 3b/3c it excludes. A selector
+naming judgment-band items still requires their decisions to be taken here,
+before any code changes.
 
 ### 4. Fix, on the normal route
 
-Group the selected items **by owning path** so each commit is one coherent
-fix rather than a mixed bag.
+Group the selected items **by class first, then by owning path**, so each
+commit is one coherent fix and each class can ship independently (step 5).
 
 **4a. Check the scope boundary first.** If a selected item cannot be fixed
-without touching something unselected, stop and report before editing.
+without touching something unselected, stop and report before editing —
+that is gate **G2**, and it applies even mid-fix, after classification.
 Two legitimate resolutions: pull the neighbour in with the user's agreement,
 or re-triage the item as still-open with the coupling recorded. Silently
-widening is not one of them.
+widening is not one of them. An auto-band item that hits G2 leaves the auto
+band; it does not get a quiet waiver because the run had already started.
 
 **4b. Apply source fixes.** Same triage as `/audit-and-fix` step 1: contained
 and unambiguous → apply. Check the `infra → interface → app → domain` rule
@@ -189,6 +326,11 @@ over a positional one.
   test is what stops it being re-filed a third time. Where the correct fix
   differed from the recorded one (step 2 "changed shape"), **test the trap**
   — pin the behavior that the naive fix would have broken.
+- For a **P3** item the test has a second job: it is the evidence for the
+  classification. "Behavior unchanged" is a claim about outputs, so pin the
+  output — a characterization test that passes before *and* after the fix,
+  in addition to whatever the fix needs. Without it, P3 is an assertion, and
+  an assertion is not enough to merge unattended.
 - Verify the test is non-vacuous: neuter the fix, confirm the test fails,
   restore.
 - QA per scope class: Python → `ruff format`, `ruff check --fix`, `mypy`,
@@ -198,53 +340,140 @@ over a positional one.
 - Bump the **owning** manifest (nearest ancestor `Cargo.toml` with a
   `version`, else the owning `pyproject.toml`). Semver from the change:
   `fix:` patch, `feat:` minor, breaking major. One bump per commit that
-  touches `src/` or `rust/`.
+  touches `src/` or `rust/`. P1 items touch no shipped file and so need no
+  bump — if a "P1" item wants a bump, it was misclassified.
 - Commit per group, naming the backlog origin in the body so the fix is
   traceable back to the record that filed it.
 
-If QA cannot run in this environment, say which tool was blocked and why,
-and record it in step 5's Environment notes — never report an unrun check as
-passing.
+If QA cannot run in this environment, that is gate **G3**: say which tool
+was blocked and why, record it in step 6's Environment notes, and move the
+item out of the auto band. Never report an unrun check as passing, and
+never merge on the strength of one.
 
-**4d. Durable-doc drift → propose, then reconcile in this run.** A source
-fix routinely invalidates prose: a doc that accurately described the old
-(broken) behavior becomes wrong the moment the behavior changes. Check for
-that on every fix — `docs/commands/<command>.md` when a CLI option changes,
-and any doc describing behavior the fix altered.
+**4d. Durable-doc drift → `reviews/`, with P2 deciding whether it waits.**
+A source fix routinely invalidates prose: a doc that accurately described
+the old (broken) behavior becomes wrong the moment the behavior changes.
+Check for that on every fix — `docs/commands/<command>.md` when a CLI
+option changes, and any doc describing behavior the fix altered.
 
 File one `reviews/$(TZ=Asia/Tokyo date '+%Y-%m-%d')-<kebab-title>.md`,
 `status: pending`, with exact before/after text per the shape in
-`docs/memory-architecture.md` § "Review proposal shape". Commit it
-separately from the code. Then present it and take the decision:
+`docs/memory-architecture.md` § "Review proposal shape". Then route by the
+P2 test — *does the corrected text follow uniquely from the code as it
+exists?*
 
-- **approve** → apply exactly as written, commit `docs: <title>`, then set
-  `status: applied` + `applied_in: <sha>` and commit that.
-- **reject** → `status: rejected` with the reason, retained as do-not-redo
-  provenance.
-- **defer** → leave `pending`; record it as outstanding in step 5.
+- **Yes → it is a drift correction.** CLAUDE.md's standing approval covers
+  it: apply it in this run, commit `docs: <title>`, set `status: applied` +
+  `applied_in: <sha>`. The proposal is still written and still committed —
+  it is the audit trail, and the next reader needs to see that a durable
+  doc changed and why. Only the round-trip is skipped, and it is skipped
+  because there was no alternative text to choose between.
+- **No → something is being decided.** Leave `status: pending`, present it
+  in 3c's question (or a follow-up if the drift only surfaced during 4b),
+  and take the decision: **approve** → apply, commit, `status: applied` +
+  `applied_in: <sha>`; **reject** → `status: rejected` with the reason,
+  retained as do-not-redo provenance; **defer** → leave `pending` and
+  record it as outstanding in step 6.
 
-### 5. Update the ledger and write the record
+The test is about the *text*, not about the size of the diff. "The doc says
+`.npy`, the writer writes `.feather`" has one correct replacement. "This
+section should also explain when to use streaming" has as many as there are
+authors — a one-line addition can still fail the test.
+
+### 5. Ship: one PR per class, auto band merged without waiting
+
+Committing is not shipping. This step turns the run's commits into review
+units the user can look at afterwards, and merges the ones that had nothing
+to decide.
+
+**5a. One PR per class, off `main`.** `P1`, `P2`, `P3`, `P4`… each becomes
+at most one PR, branched from the current `main`. That is the "ある程度の
+単位" the batching exists for: a reviewer opening the P4 PR knows every
+commit in it changes behavior and none of it breaks data, because that is
+what the class means.
+
+Split a class into more than one PR only when:
+- it spans unrelated scope classes (Python and Rust, say) — then split by
+  scope, because their QA and version bumps are separate anyway; or
+- it has grown past roughly ten items or a diff nobody will read in one
+  sitting.
+
+Never merge two classes into one PR. The class *is* the merge policy, so a
+mixed PR has no policy.
+
+If the session was handed a designated branch it must develop on, that
+mandate wins: commit everything there, open the single PR from it, and say
+in the report that class-per-PR was collapsed and why.
+
+**5b. PR body — written for the user reading it after the fact.** State,
+for each item in the PR: the backlog row and record it came from, its class
+**and the test that decided the class**, what shipped, and the QA that ran.
+For judgment-band PRs, put the decision the user took (or the one still
+outstanding) at the top — that is what the reviewer is actually checking.
+
+Follow the repository's PR template if one exists.
+
+**5c. Merge the auto band. Do not wait for the user.** P1/P2/P3 PRs with no
+gates merge as soon as both conditions hold:
+
+1. **The QA in 4c ran here and passed.** This is the real gate. The repo
+   deliberately runs no test suite on PRs — `claude-code-review.yml` is
+   `workflow_dispatch` only, with "PR push ごとの自動レビューはトークン
+   浪費のため廃止 — ローカルでの確認を正とする" written into it. So a
+   green PR is **not** evidence the tests ran; step 4c's output is. Do not
+   let a checkmark stand in for a check you did not run.
+2. **Every check GitHub reports on the PR is green or neutral.** Read them
+   off the PR rather than assuming which ones exist — today `main` gets
+   only `Check Version Bump` on `pull_request`, and that set changes
+   without this file changing. A red check blocks the merge, full stop,
+   including when you believe it is unrelated: investigate, fix, or move
+   the PR to the judgment band and say so.
+
+Prefer `mcp__github__enable_pr_auto_merge` so GitHub merges when the checks
+settle; if the repository does not allow auto-merge, read the checks and
+call `mcp__github__merge_pull_request`. Match the repository's merge style
+(currently merge commits — `git log --merges` settles it at read time).
+
+**MUST NOT auto-merge**: any P4/P5/P6 PR, any PR carrying a gated item, any
+PR whose classification you could not decide without hedging, and any PR
+whose checks are red or still running. When in doubt the PR stays open —
+that costs a comment, while a wrong merge costs a revert on `main`.
+
+**5d. Judgment-band PRs stay open**, linked in the report next to the
+question from 3c. If the user answers in this session, merge them the same
+way once their decision is applied and QA is green. If they do not, the
+PR *is* the handoff: it holds the fix, the reasoning, and the question, and
+the backlog row stays put until it merges.
+
+### 6. Update the ledger and write the record
 
 Three separate bookkeeping duties. All are required; the first is the one
 that keeps the backlog from growing forever.
 
-**5a. Delete the resolved rows** from `coverage.md` — from **either** the
+**6a. Delete the rows whose fixes have MERGED** — from **either** the
 Deferred backlog or the Out-of-scope backlog, whichever table held them.
 This is the step that makes consumption real; without it the finding is
 still open as far as every future run is concerned.
 
-Also delete rows that step 2 found **stale**, noting in 5c that they were
+Merged, not written. A row whose fix sits in an open judgment-band PR is
+**still open**: the PR can be rejected, reworked, or closed, and a row
+deleted on the strength of an unmerged branch would take the finding out of
+the ledger with nothing on `main` to show for it. Keep the row and append
+the PR link to its text, so the next run sees the work is already in
+flight instead of starting it again.
+
+Also delete rows that step 2 found **stale**, noting in 6c that they were
 already fixed elsewhere rather than fixed here. Do **not** delete a row that
 was merely re-triaged — sharpen its text instead, so the next run inherits
 the better reasoning rather than the original impasse.
 
 Update the `Open items` count on the affected main-table row to match.
 
-**5b. Leave the source records alone.** They are immutable accounts; their
+**6b. Leave the source records alone.** They are immutable accounts; their
 Deferred sections stay as written, describing what that run decided at that
 time. Do **not** add resolution markers, do **not** renumber, do **not**
-move an item into Applied. The row deletion in 5a is the resolution record,
-and 5c is its account.
+move an item into Applied. The row deletion in 6a is the resolution record,
+and 6c is its account.
 
 One narrow exception: when step 2 proved a record's **diagnosis or proposed
 fix wrong** (not merely resolved — *wrong*), append a short correction to
@@ -257,36 +486,46 @@ the next reader. State the correction, never the worklist state:
 ```
 
 If you find yourself wanting to write "RESOLVED" or "done" in a record,
-that is worklist state — it belongs in 5a's deletion, not here.
+that is worklist state — it belongs in 6a's deletion, not here.
 
-**5c. Write this run's record.**
+**6c. Write this run's record.**
 `audits/$(TZ=Asia/Tokyo date '+%Y-%m-%d')-backlog-<slug>.md`, where `<slug>`
-names the batch (e.g. `tier-a`, `interface-openings`). Frontmatter mirrors
+names the batch (e.g. `auto-band`, `interface-openings`). Frontmatter mirrors
 the record shape in `audits/README.md`, with `path:` naming the **targets
 touched** and a `kind: backlog` line marking it as a consumption record
 rather than a path audit. Body:
 
-- **Consumed** — one row per item: source record, target, and what shipped.
+- **Classification** — every item this run touched, with its class, the
+  test that decided the class, and its gates. This is the section a later
+  reader checks when a class turns out to have been wrong, so record the
+  *reasoning*, not just the verdict.
+- **Consumed** — one row per item: source record, target, what shipped, and
+  the PR it merged in.
 - **Applied** — the fixes, with `file:line` and commit SHA.
+- **In flight** — judgment-band PRs left open, with their PR number and the
+  question outstanding. Their backlog rows are still present by design
+  (6a); this section says why.
 - **Re-triaged** — items selected but left open, with the sharpened reason.
   This is the section that earns the run its keep: a second impasse on the
   same item is far more informative than the first.
 - **Corrections to the source records** — where step 2 found a record's
   diagnosis or proposed fix wrong. Record the *reason*, so the next reader
   learns to distrust that class of claim.
-- **Doc findings** — `reviews/<file>` and its resolved status.
+- **Doc findings** — `reviews/<file>`, its status, and whether P2's standing
+  approval or a real decision applied it.
 - **Out of scope** — anything new this run noticed; append it to
   `coverage.md`'s backlog too, or it is lost.
-- **Environment notes** — what could not be run here, and why.
+- **Environment notes** — what could not be run here, and why (the G1/G3
+  evidence).
 
-**5d. Reconcile findings to rows before committing (MUST).** Same closing
+**6d. Reconcile findings to rows before committing (MUST).** Same closing
 check as `/audit-and-fix` step 9x, and it applies here for the same
-reason: 5c tells you to *append* new out-of-scope items but never makes
+reason: 6c tells you to *append* new out-of-scope items but never makes
 you verify the mapping is total. Assign every item this run touched, and
 every new finding it noticed, exactly one disposition — **resolved** (row
-deleted, fix committed) / **re-triaged** (row kept, text sharpened) /
-**new row** (id) / **not a finding** (reason). An item you cannot assign
-is the defect the check exists to catch.
+deleted, fix merged) / **in flight** (row kept, PR linked) / **re-triaged**
+(row kept, text sharpened) / **new row** (id) / **not a finding** (reason).
+An item you cannot assign is the defect the check exists to catch.
 
 The two failure modes named in step 9x apply verbatim: consolidating
 several findings into one readable row drops the ones the merged prose
@@ -297,7 +536,14 @@ stops naming, and **this record's prose sections are not a worklist** —
 run. Read 9x for the full rationale and the worked example rather than a
 copy of it; a copy would drift.
 
-Print the reconciliation as an equation in step 6, not as an assurance.
+Print the reconciliation as an equation in step 7, not as an assurance.
+
+**6e. Ship the record itself.** The ledger update and the record are P1 by
+construction — `audits/` ships nothing — so they go in their own PR and
+merge under 5c like any other P1 work. They must **not** ride in a
+judgment-band PR: the account of a run has to reach `main` even when the
+fixes it describes are still under review, or an unmerged PR takes the
+run's only record down with it.
 
 Link the record from `coverage.md` under the backlog table so a future run
 can find the account of a row that is no longer there. Then commit:
@@ -309,30 +555,41 @@ docs(audits): record backlog consumption (<slug>)
 item must leave a record with its resume point, or it is indistinguishable
 from one never attempted.
 
-### 6. Report
+### 7. Report
 
 Compact summary:
-- Backlog size found: N deferred + M out-of-scope (from `coverage.md`)
+- Backlog size found: N deferred + M out-of-scope (from `coverage.md`),
+  plus any PRs already open from earlier runs (1e)
 - Verification: confirmed / stale / changed-shape counts
-- Selected and resolved (IDs + one line each), with commit SHAs
+- **Classification**: the count per class, and every gate applied with its
+  item — so a reader can see what was kept out of the auto band and why
+- Auto band: what was fixed, which PRs, **merged or blocked** (with the
+  blocking check named)
+- Judgment band: the question asked, the answer taken, PRs left open
 - Re-triaged / rejected, with the reason
-- Doc drift → `reviews/<file>` and its status
+- Doc drift → `reviews/<file>`, its status, and which P2 branch applied
 - QA: what ran, what passed, what was blocked and why
-- **Reconciliation (5d)**: `<items touched + new findings> = <resolved> +
-  <re-triaged> + <new rows> + <not-a-finding>`, printed as the equation.
-  Backlog rows before → after, so the ledger's movement is visible
+- **Reconciliation (6d)**: `<items touched + new findings> = <resolved> +
+  <in flight> + <re-triaged> + <new rows> + <not-a-finding>`, printed as
+  the equation. Backlog rows before → after, so the ledger's movement is
+  visible
 - Version bump(s), old → new, which manifest
 - Ledger: rows deleted (which table), rows added by 1d's repair, any
-  record correction from 5b, new record path
-- Backlog remaining, by tier — so the next run knows what is left
+  record correction from 6b, new record path
+- Backlog remaining, by class — so the next run knows what is left, and
+  how much of it will need the user
 
-### 7. Handoff
+### 8. Handoff
 
-Do **not** call `/checkpoint-context` from here; step 5 already committed.
+Do **not** call `/checkpoint-context` from here; step 6 already committed.
 
 The committed record is what carries this run forward. Do not mirror it into
 `worklog/` or `scratchpad/compass.md` — per CLAUDE.md, `audits/` and the
 campaign memory are deliberately separate systems.
+
+Open judgment-band PRs are the other half of the handoff. Leave them
+listed in the report with their questions; a later session picks them up
+from `list_pull_requests` plus the still-present backlog rows.
 
 ## Extending this command
 
@@ -344,18 +601,31 @@ Keep the derive-never-enumerate property:
   `/audit-and-fix` step 9, not in this command.
 - **New scope class** (new language, new top-level dir) — add its QA path to
   4c, keyed off a discoverable marker (a manifest, a
-  `.pre-commit-config.yaml` entry), not a hardcoded path.
+  `.pre-commit-config.yaml` entry), not a hardcoded path. Then check the P1
+  test: is the new directory shipped? That answer, not a list here, decides
+  whether its changes need a version bump.
 - **New durable-doc location** — verify 4d's routing test classifies it
   correctly; if it does, no edit is needed here.
-- **A tier that keeps coming up empty** — that is a signal about the repo,
-  not about the rubric. Leave the tier; report the emptiness.
+- **New CI check on PRs** — nothing to do. 5c reads the checks off the PR
+  rather than naming them, so a new required check gates the auto band
+  automatically. Adding its name here would be the enumeration bug.
+- **A class that keeps coming up empty** — that is a signal about the repo,
+  not about the rubric. Leave the class; report the emptiness.
+- **A class that keeps being wrong** — that is a signal about the *ladder*,
+  and it is worth acting on. If items keep being merged as P3 and turning
+  out to change behavior, sharpen P3's test with the case that fooled it
+  and add the item to the calibration set. The calibration set is the part
+  of this file designed to grow.
 
 ## Usage
 
-- `/audit-backlog` — list the whole backlog, ranked, and stop for a choice.
-  The intended entry point.
-- `/audit-backlog T1` — consume every Tier 1 item.
-- `/audit-backlog T1-1,T2-3 high` — consume two specific items, broader
+- `/audit-backlog` — classify everything, ship the auto band unattended,
+  then ask about the rest. The intended entry point.
+- `/audit-backlog auto` — the auto band only. Stop after 5c; do not ask
+  about P4-P6 at all. Useful when the user is away.
+- `/audit-backlog P4` — take the P4 decisions and fix what they resolve.
+- `/audit-backlog P3-1,P4-3 high` — two specific items, broader
   verification.
-- `/audit-backlog src/maou/interface` — consume everything targeting that
-  path (without auditing the path itself — use `/audit-and-fix` for that).
+- `/audit-backlog src/maou/interface` — everything targeting that path,
+  auto band merged and judgment band asked as usual (without auditing the
+  path itself — use `/audit-and-fix` for that).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Full spec: [docs/memory-architecture.md](docs/memory-architecture.md).
 | `.claude/commands/checkpoint-context.md` | Writer of campaign working memory (`worklog/`, `scratchpad/`). | yes |
 | `.claude/commands/resume-context.md` | Read-only resume. | yes |
 | `.claude/commands/audit-and-fix.md` | Writer of `audits/` (path 単位の監査). | yes |
-| `.claude/commands/audit-backlog.md` | Writer of `audits/` (deferred / out-of-scope の個別消化). | yes |
+| `.claude/commands/audit-backlog.md` | Writer of `audits/` (deferred / out-of-scope の個別消化)．判断コスト P1-P6 で分類し，P1-P3 (自動帯) はユーザに聞かずに修正・PR・マージする． | yes |
 
 ### MUST rules
 
@@ -98,6 +98,17 @@ Full spec: [docs/memory-architecture.md](docs/memory-architecture.md).
   — it is not tied to any one command). `/checkpoint-context` step 5 and
   `/audit-and-fix` step 8 both reconcile proposals; either may take the
   approval.
+- **Standing approval — drift corrections only.** `/audit-backlog` の
+  P2 クラス (`.claude/commands/audit-backlog.md` § "priority is decision
+  cost") が **drift correction** と判定した durable-doc 修正は，この項が
+  与える恒久承認により，その run 内で適用してよい．`reviews/*.md` の
+  提案は依然として MUST — 承認の往復だけを省く．
+  判定基準は 1 つ: **訂正後の本文が現行コードから一意に決まるか**．
+  一意なら適用 (例: doc が `.npy` と書き，writer は `.feather` を書く)．
+  一意でないなら — 新しい指針，節の再構成，規則の追加，複数の書き方が
+  あり得る記述 — P2 ではないので判断帯に落ち，通常どおり承認を待つ．
+  迷った場合は待つ側に倒す．この恒久承認は `/audit-backlog` にのみ
+  適用され，`/audit-and-fix` step 8 には及ばない (拡張は別提案とする)．
 - MUST treat `worklog/*.md` as immutable. Each `/checkpoint-context`
   creates a **new** file — never edit a previous one.
 - MUST preserve failed attempts, reasoning, and uncertainty in every

--- a/reviews/2026-08-12-audit-backlog-standing-doc-approval.md
+++ b/reviews/2026-08-12-audit-backlog-standing-doc-approval.md
@@ -1,0 +1,142 @@
+---
+status: pending
+applied_in:
+date: 2026-08-12
+target: [CLAUDE.md]
+risk: medium
+reversibility: trivial
+---
+
+# `/audit-backlog` の自動帯に対する durable-doc standing approval
+
+## Trigger
+
+ユーザー指摘 (2026-08-12): 「`/audit-backlog` による修正ではユーザが毎回
+修正項目を決めているが，多くの部分はユーザ判断が不要に思える」．
+
+これを受けて `.claude/commands/audit-backlog.md` の優先度判定を
+**影響度 (T1-T6)** から **判断コスト (P1-P6)** に置き換え，P1-P3 を
+「ユーザ判断不要」の自動帯として無停止で修正・PR・マージするようにした．
+
+その P2 が「ドキュメント修正のみ」であり，**CLAUDE.md の現行 MUST 規則と
+正面から衝突する**．コマンド側だけを直しても，`docs/` を 1 行直すたびに
+承認待ちが発生し，「ユーザ判断不要な部分を先に終わらせる」という要求は
+docs に関して成立しない．規則側を直さない限りコマンドは規則違反の指示書
+になる．
+
+## Proposed change
+
+`CLAUDE.md` § "Repository-Centric Memory Architecture (MUST)" § "MUST
+rules" の第 1 項を差し替える．
+
+**Before**
+
+```markdown
+- MUST NOT edit `CLAUDE.md` / `docs/` without an **approved** `reviews/*.md`
+  proposal. Draft it `status: pending`; **on explicit user approval the
+  model applies the edit itself and commits**, then sets `status: applied`
+  + `applied_in: <sha>` (approval is the safeguard against *silent* edits
+  — it is not tied to any one command). `/checkpoint-context` step 5 and
+  `/audit-and-fix` step 8 both reconcile proposals; either may take the
+  approval.
+```
+
+**After**
+
+```markdown
+- MUST NOT edit `CLAUDE.md` / `docs/` without an **approved** `reviews/*.md`
+  proposal. Draft it `status: pending`; **on explicit user approval the
+  model applies the edit itself and commits**, then sets `status: applied`
+  + `applied_in: <sha>` (approval is the safeguard against *silent* edits
+  — it is not tied to any one command). `/checkpoint-context` step 5 and
+  `/audit-and-fix` step 8 both reconcile proposals; either may take the
+  approval.
+- **Standing approval — drift corrections only.** `/audit-backlog` の
+  P2 クラス (`.claude/commands/audit-backlog.md` § "priority is decision
+  cost") が **drift correction** と判定した durable-doc 修正は，この項が
+  与える恒久承認により，その run 内で適用してよい．`reviews/*.md` の
+  提案は依然として MUST — 承認の往復だけを省く．
+  判定基準は 1 つ: **訂正後の本文が現行コードから一意に決まるか**．
+  一意なら適用 (例: doc が `.npy` と書き，writer は `.feather` を書く)．
+  一意でないなら — 新しい指針，節の再構成，規則の追加，複数の書き方が
+  あり得る記述 — P2 ではないので判断帯に落ち，通常どおり承認を待つ．
+  迷った場合は待つ側に倒す．この恒久承認は `/audit-backlog` にのみ
+  適用され，`/audit-and-fix` step 8 には及ばない (拡張は別提案とする)．
+```
+
+加えて，同 § の `/audit-backlog` の行 (Files 表) に自動帯の存在を書き足す．
+
+**Before**
+
+```markdown
+| `.claude/commands/audit-backlog.md` | Writer of `audits/` (deferred / out-of-scope の個別消化). | yes |
+```
+
+**After**
+
+```markdown
+| `.claude/commands/audit-backlog.md` | Writer of `audits/` (deferred / out-of-scope の個別消化)．判断コスト P1-P6 で分類し，P1-P3 (自動帯) はユーザに聞かずに修正・PR・マージする． | yes |
+```
+
+## Motivation
+
+現行規則は「durable doc への *silent* な編集」を防ぐために作られている．
+`/audit-backlog` P2 が行うのはその逆で，
+
+- 変更は `reviews/*.md` 提案として残る (silent ではない)，
+- 変更は PR として残り，後からユーザーが読める (silent ではない)，
+- 変更内容はコードから一意に決まる (選択肢がないので「承認」に意味がない)．
+
+承認が守っているのは *可視性* であって，*一意に決まる訂正の再確認* では
+ない．O11 (`docs/commands/pre_process.md` が pre-process の出力を `.npy`
+と説明しているが実体は `.feather`) が典型で，ここでユーザーに問える質問は
+「コードに合わせますか」しかない．
+
+実害も出ている: O11 は 2026-08-10 の run で見つかりながら「durable doc
+なので `reviews/` 提案 + 承認が必要」という理由だけで未修正のまま
+out-of-scope backlog に積まれている．承認の往復コストが，訂正そのものの
+コストを上回っている状態である．
+
+## Alternatives considered
+
+1. **規則を変えず，P2 を「提案は出すが承認を待つ」にする．**
+   コマンド側だけで完結し CLAUDE.md を触らないので最も安全だが，ユーザー
+   要求「ドキュメント修正のみ = ユーザ判断不要」を満たさない．doc drift は
+   backlog に最も溜まりやすい種類で，そこが自動化から外れると今回の変更の
+   効果が大きく削がれる．却下．
+
+2. **durable-doc の承認ゲートを全面撤廃する．**
+   一貫はするが，守るべきものまで捨てる．`CLAUDE.md` の規則追加や
+   `docs/design/` の設計判断は，コードから一意に決まらない「著述」であり，
+   ここに承認が要るのは正しい．P2 の第 2 テスト (一意性) はまさにこの線を
+   引くために置かれている．却下．
+
+3. **`/audit-and-fix` step 8 にも同じ恒久承認を広げる．**
+   整合性は上がるが，`/audit-and-fix` は path 全体を新規に走査する run で，
+   drift の判定が「その場で読んだ理解」に依存する．`/audit-backlog` は
+   **既に別 run が記録し，step 2 で HEAD に対して再検証した** finding しか
+   扱わないため，一意性判定の土台が違う．今回は範囲を絞り，必要になったら
+   別提案とする．
+
+## What this enables
+
+- doc drift が「一意な訂正」である限り，発見と同じ run で消える．backlog に
+  残るのは**判断が要る doc 変更だけ**になり，`coverage.md` の残件が
+  「本当にユーザーを待っているもの」を意味するようになる．
+- ユーザーへの質問が，判断のあるものだけに絞られる．
+
+## What this constrains
+
+- P2 判定を誤ると durable doc が未確認のままマージされる．そのため
+  コマンド側で fail-safe を「上に倒す」(迷ったら判断帯) と明記し，判定の
+  根拠を `audits/` の record § Classification に残すことを必須にしている．
+  誤りは PR 履歴と record の両方から追える．
+- 「一意に決まる」の判定は毎回書き残す義務が生じる (record に「どのテストで
+  P2 と判定したか」を書く)．黙って P2 にすることはできない．
+
+## Rollback plan
+
+`CLAUDE.md` の当該 2 箇所を revert し，`.claude/commands/audit-backlog.md`
+の 4d を「常に承認を待つ」1 分岐に戻す (P2 クラス自体は残してよい —
+自動帯から外れるだけ)．コードは一切影響を受けない．既に適用済みの doc
+訂正はコードと一致しているので，revert しても訂正を戻す必要はない．

--- a/reviews/2026-08-12-audit-backlog-standing-doc-approval.md
+++ b/reviews/2026-08-12-audit-backlog-standing-doc-approval.md
@@ -1,6 +1,6 @@
 ---
-status: pending
-applied_in:
+status: applied
+applied_in: 9ac52cf
 date: 2026-08-12
 target: [CLAUDE.md]
 risk: medium


### PR DESCRIPTION
## 背景

`/audit-backlog` は confirmed な finding を毎回ユーザーに提示して選択を待っていた．しかし backlog の実物を見ると「選ぶ余地がないもの」が相当数を占める — コードと食い違う doc の訂正，到達不能な分岐の削除，誤った拡張子を glob するログ行の修正．ユーザーが別の版を選びようがない修正である．これらを質問の後ろに並べると，本当に判断が要る finding が往復 1 回分遅れる．

加えて，判断が要る finding についても**チェックが 2 回**発生していた: セッション中の質問 (コードがまだ存在しない状態での説明文レビュー) と，その後の PR レビュー．

## 変更点

### 1. ランク付けの軸を影響度から判断コストへ

旧 T1-T6 (影響度) を廃止し，**誰が判断しなければならないか**で分類する:

| Class | 帯 | 判定 |
|---|---|---|
| **P1** | 自動 | 出荷物に触れない (`.claude/`, `audits/`, `reviews/`, `.github/`, tooling config, `tests/`, formatting) — version bump 不要 |
| **P2** | 自動 | tracked prose のみ **かつ** 訂正後の本文が現行コードから一意に決まる (drift correction) |
| **P3** | 自動 | 挙動を変えないコード修正 — 受理する全入力について書き出す artifact と戻り値が不変，差は診断・ログ・時間・メモリのみ |
| **P4** | 要判断 | 挙動は変わるが既存データも既存起動方法も生き残る |
| **P5** | 要判断 | データ互換性が壊れる (schema/dtype/レイアウト) |
| **P6** | 要判断 | 契約が壊れる (CLI オプション，public API，出力パス) |

機械的にするための規則:

- **P6 から降順に評価し，高い方が勝つ．** doc も dtype も触る修正は自動的に P5 になり P2 に落ちない．
- **迷ったら上に倒す (最低 P4)．** 自動帯の誤判定は無人で `main` に入り，判断帯の誤判定は質問 1 回で済む — 非対称なので同列に扱わない．
- **クラスと直交する 4 ゲート** (G1 環境で検証不能 / G2 スコープ外への波及 / G3 QA が動かない / G4 record 自身が設計判断と書いている) はクラスに関係なく自動帯から降ろす．G4 は現行 backlog の「見送り理由: …設計判断が要る」をそのまま拾える最も安価な信号．
- **較正セット**を同梱．現行 backlog の実物で判定根拠つきに: O11→P2, O6→P3, D12(b)→P3, O4→P4, D1→P5+G4, D8/D9→P6 or P4+G4．

影響度は捨てず，**クラス内のソートキー**として残している．

### 2. チェックは PR の 1 回だけ

P4-P6 は「人が判断する」としか言っておらず，「セッション中に，コードが存在しない状態で判断する」ことは要求していない．既定を **PR のみ**に変更:

判断帯の item も回帰テストと version bump まで済ませて PR を開き，**マージしない**．判断は body の先頭に置く (何が変わるか / 代替案 / なぜこちらを選んだか，P5・P6 は具体的な互換性の破れ)．PR がそのまま質問になる．

セッション中に聞いてよい条件は危険度ではなく **答えが書くコードを変えるか**:

> 分岐が実質的に異なる diff を生み，**かつ** 外した場合にユーザーがレビューして捨てる作業が無駄になるとき

- D8/D9 (削除 vs 修復) — 共有する行がゼロ → **聞く**
- D1 (dtype に足す vs 変換直後に捨てる) — 対立する設計，どちらも複数層 → **聞く**
- O4 (`test_ratio or 0.1`) — 修復は 1 通り，判断は「0.0 を渡していた人の結果が変わるのを受け入れるか」だけ → **聞かずに PR**

分岐は違うが diff が小さいなら推奨案を実装し代替案を body に書く．聞く場合も run 全体で 1 回にまとめる．report には「何も聞かなかった」ことを明記させ，不要な質問が次回可視化されるようにした．

### 3. Stacked PR

判断帯 PR が溜まるので，依存を PR 自体に持たせる．判定は機械的:

> この PR の diff が，この run で先に開いた**未マージ**の PR も触るファイルに触るか，そこで導入された記号に依存するか

- Yes → base を親の head ブランチに (GitHub が増分 diff だけを表示し，base リンク自体が依存を表明する)
- No → base は `main`，body に independent と書く．**整頓のために積むのは禁止** — stack はマージ制約であり，無関係な PR を判断帯 PR の上に積むと無関係な質問の答えを待つことになる

stack はクラス昇順 (P1 が底)．これはマージ順でもあり，判断不要な部分が下に来るので自動帯が抜けるたび底から解ける．判断帯 PR は自動帯マージ**後**に開くので大半は independent になる．親マージ後の retarget は「親ブランチが削除されたら」という repo 設定依存なので仮定せず `pull_request_read` で確認 → 必要なら `update_pull_request` で base 張り替え → 子を更新．子を親ブランチにマージして「解消」するのは禁止 (クラス境界が消え，子のレビューが親の PR に埋もれる)．全 PR に同じ stack map を載せる．

### 4. 出荷とマージ

- **クラス単位の PR** (混在 PR はマージ方針を持てないため禁止)．分割はスコープクラスが跨るときと，10 件/読み切れない diff を超えたときのみ
- **自動帯のマージ条件は「4c のローカル QA が通った」ことが主．** 本リポジトリは PR に自動テストを流さない方針 (`claude-code-review.yml` は `workflow_dispatch` のみ，「PR push ごとの自動レビューはトークン浪費のため廃止 — ローカルでの確認を正とする」) なので，緑のチェックはテストが走った証拠にならない．PR のチェックは補助条件で，**列挙せず PR から読む** (必須チェックが増えても本文を直さずに効く)
- backlog 行の削除条件を「修正を書いた」から**「マージされた」**に変更．判断帯 PR は却下・改稿されうるので，未マージで行を消すと finding が `main` に何もない状態で台帳から消える．未マージ中は行を残し PR リンクを追記する
- run の record 自体は P1 なので独立 PR で先にマージし，修正 PR がレビュー中でも account が `main` に届くようにする．その上には何も積まない
- step 1e が前 run の在庫を回収する: stale な stack，マージ済みなのに残っている行，決着済みなのに `pending` の `reviews/` 提案

### 5. CLAUDE.md — drift correction への恒久承認

P2 (ドキュメントのみ) は CLAUDE.md の durable-doc 承認ゲートと正面から衝突していた．承認が守っているのは durable doc への *silent* な編集の防止であり，P2 が行うのはその逆 — `reviews/` 提案と PR の両方に痕跡が残り，かつ訂正後の本文がコードから一意に決まるのでユーザーに選択肢がない．

判定基準を「訂正後の本文が現行コードから一意に決まるか」の 1 点に絞った恒久承認を追加した (`reviews/2026-08-12-audit-backlog-standing-doc-approval.md`，本セッションで承認済み・`status: applied`)．一意でない変更 — 新しい指針，節の再構成，規則の追加 — は P2 に該当せず従来どおり承認を待つ．適用範囲は `/audit-backlog` のみで `/audit-and-fix` step 8 には及ばない．

実害の例: O11 (`docs/commands/pre_process.md` が pre-process の出力を `.npy` と説明しているが実体は `.feather`) は 2026-08-10 に発見されながら「durable doc なので承認が必要」という理由だけで未修正のまま out-of-scope backlog に積まれている．

なお P2 の一意性テストに**落ちる** durable-doc 変更は，doc を編集せず `reviews/` 提案だけを PR に載せる — 承認ゲートは編集の*前*の承認を要求しており，恒久承認は drift のみが対象のため．ここだけ意図的に往復を残している．

## この PR 自体の分類

新しいラダーで自己分類すると **P1 + P2**: `.claude/commands/` と `reviews/` (出荷物でない) と `CLAUDE.md` (承認済みの prose) のみで，`src/` にも `rust/` にも触れていない．したがって version bump は不要 (`Check Version Bump` も src 未変更として通るはず)．

ただし `CLAUDE.md` の変更は drift correction ではなく**規則の追加**なので P2 の一意性テストには落ちる — 本セッションで明示承認をいただいたうえで適用している．

## テスト

コード変更なし．QA 対象は pre-commit のみで，4 コミットとも `--no-verify` なしで通っている．

- `.claude/commands/audit-backlog.md` — 内部の step 参照 (5a-5e への繰り下げ，3b/3c，6a-6e) を全て追随させ，`grep` で旧番号の残りがないことを確認
- `CLAUDE.md` — 提案の before テキストが実ファイルと一字一句一致することを確認したうえで適用

## Rollback

`CLAUDE.md` の 2 箇所 (Files 表の 1 行と恒久承認の項) を revert し，`.claude/commands/audit-backlog.md` を戻せば完全に元に戻る．コードは一切影響を受けない．既に適用済みの doc 訂正があってもコードと一致しているので戻す必要はない．

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2Z88m4CU23iSJE5RHjF2X)_