### PR TITLE
fix: /audit-backlog 自動帯 (P2/P3) — 確認済み欠陥 7 件を消化

### DIFF
--- a/docs/commands/pre_process.md
+++ b/docs/commands/pre_process.md
@@ -3,7 +3,8 @@
 ## Overview
 
 - Bridges HCPE datasources (local folders, BigQuery, GCS, S3) to feature stores
-  by converting raw `.hcpe` inputs into preprocessed `.npy` shards and optional
+  by converting raw `.hcpe` inputs into preprocessed `.feather` shards (Arrow IPC)
+  and optional
   BigQuery/GCS/S3 uploads. All CLI flags are defined in
   `src/maou/infra/console/pre_process.py` and feed directly into the interface
   adapter.【F:src/maou/infra/console/pre_process.py†L1-L400】
@@ -19,7 +20,7 @@
 | --- | --- | --- |
 | Local filesystem | `--input-path PATH` (file or directory) | Walks recursively via `FileSystem.collect_files`, which returns a **sorted** list and skips cloud-download temp artifacts (`.gstmp`/`.tmp`/`.partial`/`.crc`). `--input-file-packed` is accepted but deprecated and has no effect.【F:src/maou/infra/console/pre_process.py†L16-L66】【F:src/maou/infra/file_system/path_utils.py†L31-L90】 |
 | BigQuery | `--input-dataset-id` + `--input-table-name` | Streams HCPE rows with configurable batch size, cache limits, clustering, and partition hints. Requires the `gcp` optional extra.【F:src/maou/infra/console/pre_process.py†L66-L200】 |
-| GCS | `--input-gcs` + `--input-bucket-name` + `--input-prefix` + `--input-data-name` + `--input-local-cache-dir` | Downloads `.npy` shards tagged `array_type="hcpe"`. Supports worker counts, bundling (`--input-enable-bundling`, `--input-bundle-size-gb`), and optional local caching.【F:src/maou/infra/console/pre_process.py†L200-L360】 |
+| GCS | `--input-gcs` + `--input-bucket-name` + `--input-prefix` + `--input-data-name` + `--input-local-cache-dir` | Downloads `.feather` shards (Arrow IPC) tagged `array_type="hcpe"`; any other suffix is rejected. Supports worker counts, bundling (`--input-enable-bundling`, `--input-bundle-size-gb`), and optional local caching.【F:src/maou/infra/console/pre_process.py†L200-L360】 |
 | S3 | `--input-s3` + bucket metadata | Mirrors the GCS contract using `S3DataSource`. Requires the `aws` optional extra.【F:src/maou/infra/console/pre_process.py†L318-L360】 |
 
 Exactly one datasource may be active; the CLI raises a `ValueError` when multiple
@@ -29,9 +30,9 @@ providers are requested.【F:src/maou/infra/console/pre_process.py†L360-L420�
 
 | Destination | Required flags | Data layout |
 | --- | --- | --- |
-| Local only | `--output-dir PATH` | Writes `.npy` shards tagged `array_type="preprocessing"` to disk. Directory is created automatically when missing.【F:src/maou/infra/console/pre_process.py†L16-L120】【F:src/maou/interface/preprocess.py†L17-L47】 |
+| Local only | `--output-dir PATH` | Writes `transformed_chunk{NNNN}.feather` shards (Arrow IPC) tagged `array_type="preprocessing"` to disk. Directory is created automatically when missing.【F:src/maou/infra/console/pre_process.py†L16-L120】【F:src/maou/interface/preprocess.py†L17-L47】 |
 | BigQuery | `--output-bigquery` + `--dataset-id` + `--table-name` | Streams feature rows via `BigQueryFeatureStore` with cache limits governed by `--output-max-cached-bytes`.【F:src/maou/infra/console/pre_process.py†L360-L487】 |
-| GCS | `--output-gcs` + `--output-bucket-name` + `--output-prefix` + `--output-data-name` | Uploads `.npy` shards as `array_type="preprocessing"` with configurable worker counts and queue sizes.【F:src/maou/infra/console/pre_process.py†L420-L520】 |
+| GCS | `--output-gcs` + `--output-bucket-name` + `--output-prefix` + `--output-data-name` | Uploads `batch{ID}_{N}dfs_{SIZE}MB.feather` shards (Arrow IPC) as `array_type="preprocessing"` with configurable worker counts and queue sizes.【F:src/maou/infra/console/pre_process.py†L420-L520】 |
 | S3 | `--output-s3` + bucket metadata | Same contract as GCS, requiring the AWS optional extra.【F:src/maou/infra/console/pre_process.py†L420-L540】 |
 
 Only one feature store may be selected per run; the CLI enforces mutual
@@ -63,7 +64,7 @@ exclusion and warns when extras are missing.【F:src/maou/infra/console/pre_proc
    Intermediate cache hints are passed through untouched.【F:src/maou/interface/preprocess.py†L17-L89】
 3. **Preprocessing and batching** – `PreProcess.transform` iterates over the HCPE
    batches, deduplicates board states, writes intermediate bundles to disk or a
-   temporary directory, and emits final `.npy` shards. When a feature store is
+   temporary directory, and emits final `.feather` shards. When a feature store is
    configured, each shard is reloaded and uploaded with consistent metadata.
    【F:src/maou/app/pre_process/hcpe_transform.py†L1-L205】
 4. **Result reporting** – The CLI prints the JSON mapping returned by the
@@ -87,7 +88,7 @@ exclusion and warns when extras are missing.【F:src/maou/infra/console/pre_proc
 
 ## Outputs and usage
 
-- Local runs write `.npy` shards derived from HCPE inputs into `--output-dir`
+- Local runs write `.feather` shards derived from HCPE inputs into `--output-dir`
   (if provided); otherwise the app layer uses a temporary directory purely for
   uploading to feature stores.【F:src/maou/app/pre_process/hcpe_transform.py†L93-L205】
 - Cloud-enabled runs push structured arrays with `key_columns=["id"]` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.86.0"
+version = "0.86.1"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/reviews/2026-08-12-pre-process-output-format-drift.md
+++ b/reviews/2026-08-12-pre-process-output-format-drift.md
@@ -1,0 +1,83 @@
+---
+status: pending
+date: 2026-08-12
+target: [docs/commands/pre_process.md]
+risk: low
+reversibility: trivial
+---
+
+# `docs/commands/pre_process.md` が pre-process の出力を `.npy` と説明している
+
+## Trigger
+
+`audits/coverage.md` § Out-of-scope backlog の O11 行
+([2026-08-10 infra/file_system](../audits/2026-08-10-src-maou-infra-file-system.md))．
+`/audit-backlog` (2026-08-12) で HEAD に対して再検証し，6 箇所すべてが
+現行コードと食い違っていることを確認した．
+
+`docs/adr-004-arrow-ipc-migration.md` の Arrow IPC 移行から漏れた記述で，
+2026-08-10 の承認済み提案 (`1c6a442`) は `infra/file_system` を説明する
+主張だけを対象にしていたため，pre-process 自身の出力形式は残っていた．
+
+## 現行コードが書くもの (訂正文の一意性の根拠)
+
+| 経路 | 実装 | 実際の出力 |
+|---|---|---|
+| ローカル出力 | `app/pre_process/hcpe_transform.py:574` | `transformed_chunk{NNNN}.feather` (`save_preprocessing_df`) |
+| GCS/S3 アップロード | `infra/object_storage/feature_store.py:144` | `batch{ID}_{N}dfs_{SIZE}MB.feather` (Arrow IPC bytes) |
+| GCS/S3 ダウンロード | `infra/object_storage/data_source.py:159-161` | `.feather` 以外の suffix は `ValueError` で拒否 |
+
+`.npy` を書く経路も読む経路も pre-process には存在しない．したがって
+訂正後の本文は現行コードから一意に決まる (P2 = drift correction)．
+
+## Before / After
+
+### `:6` (Overview)
+
+```diff
+-  by converting raw `.hcpe` inputs into preprocessed `.npy` shards and optional
+-  BigQuery/GCS/S3 uploads.
++  by converting raw `.hcpe` inputs into preprocessed `.feather` shards (Arrow IPC)
++  and optional BigQuery/GCS/S3 uploads.
+```
+
+### `:22` (Input selection / GCS)
+
+```diff
+-Downloads `.npy` shards tagged `array_type="hcpe"`.
++Downloads `.feather` shards (Arrow IPC) tagged `array_type="hcpe"`; any other suffix is rejected.
+```
+
+### `:32` (Feature-store outputs / Local only)
+
+```diff
+-Writes `.npy` shards tagged `array_type="preprocessing"` to disk.
++Writes `transformed_chunk{NNNN}.feather` shards (Arrow IPC) tagged `array_type="preprocessing"` to disk.
+```
+
+### `:34` (Feature-store outputs / GCS)
+
+```diff
+-Uploads `.npy` shards as `array_type="preprocessing"`
++Uploads `batch{ID}_{N}dfs_{SIZE}MB.feather` shards (Arrow IPC) as `array_type="preprocessing"`
+```
+
+### `:66` (Execution flow 3)
+
+```diff
+-   temporary directory, and emits final `.npy` shards. When a feature store is
++   temporary directory, and emits final `.feather` shards. When a feature store is
+```
+
+### `:90` (Outputs and usage)
+
+```diff
+-- Local runs write `.npy` shards derived from HCPE inputs into `--output-dir`
++- Local runs write `.feather` shards derived from HCPE inputs into `--output-dir`
+```
+
+## 承認
+
+CLAUDE.md § "Standing approval — drift corrections only" が与える恒久承認の
+範囲内 (訂正後の本文が現行コードから一意に決まる drift correction)．
+`/audit-backlog` の P2 として本 run 内で適用する．

--- a/src/maou/infra/bigquery/bq_data_source.py
+++ b/src/maou/infra/bigquery/bq_data_source.py
@@ -481,7 +481,7 @@ class BigQueryDataSource(
 
             # ローカルキャッシュファイルが正しく作成されたか確認
             cache_files = list(
-                self.local_cache_dir.glob("*.npy")
+                self.local_cache_dir.glob("*.feather")
             )
             self.logger.info(
                 f"Created {len(cache_files)} local cache files"

--- a/src/maou/infra/file_system/file_data_source.py
+++ b/src/maou/infra/file_system/file_data_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import logging
 import random
 import time
@@ -27,9 +28,7 @@ from maou.interface.data_schema import (
     convert_preprocessing_df_to_numpy,
     convert_stage1_df_to_numpy,
     convert_stage2_df_to_numpy,
-    get_preprocessing_dtype,
-    get_stage1_dtype,
-    get_stage2_dtype,
+    get_dtype,
 )
 
 if TYPE_CHECKING:
@@ -54,12 +53,6 @@ _DF_TO_COLUMNAR_CONVERTERS: dict[
     "preprocessing": convert_preprocessing_df_to_columnar,
     "stage1": convert_stage1_df_to_columnar,
     "stage2": convert_stage2_df_to_columnar,
-}
-
-_STRUCTURED_DTYPES: dict[str, Callable[[], np.dtype]] = {
-    "preprocessing": get_preprocessing_dtype,
-    "stage1": get_stage1_dtype,
-    "stage2": get_stage2_dtype,
 }
 
 
@@ -284,26 +277,26 @@ class FileDataSource(
             self._use_columnar = (
                 array_type in _DF_TO_COLUMNAR_CONVERTERS
             )
-            # structured array再構築用のdtype
+            # structured array再構築用のdtype．
+            # bit_pack は未使用 (後方互換の保持のみ) なので常に非パック版を引く．
             self._structured_dtype: np.dtype | None = None
             if self._use_columnar:
-                dtype_factory = _STRUCTURED_DTYPES.get(
-                    array_type
+                self._structured_dtype = get_dtype(
+                    array_type, bit_pack=False
                 )
-                if dtype_factory is not None:
-                    self._structured_dtype = dtype_factory()
 
-            # DF→変換関数を先に取得
-            columnar_converter = _DF_TO_COLUMNAR_CONVERTERS.get(
-                self.array_type
+            # DF→変換関数を先に取得し，ループに入る前に非 None へ確定させる．
+            # ループ内で分岐が両方とも空振りすると lengths だけが伸びて
+            # _file_entries とズレ，以降の全インデックス参照が静かに壊れる．
+            # 分岐そのものを消して構造的に起こり得なくする．
+            converter: Callable[[pl.DataFrame], Any] | None = (
+                _DF_TO_COLUMNAR_CONVERTERS.get(self.array_type)
+                if self._use_columnar
+                else _DF_TO_NUMPY_CONVERTERS.get(
+                    self.array_type
+                )
             )
-            numpy_converter = _DF_TO_NUMPY_CONVERTERS.get(
-                self.array_type
-            )
-            if (
-                not self._use_columnar
-                and numpy_converter is None
-            ):
+            if converter is None:
                 raise ValueError(
                     f"Unknown array_type: {self.array_type}"
                 )
@@ -325,102 +318,97 @@ class FileDataSource(
                             f"Only .feather files are supported. Got: {file_path.suffix}"
                         )
 
-                    try:
-                        file_size_mb = (
-                            file_path.stat().st_size
-                            / (1024 * 1024)
+                    file_size_mb = file_path.stat().st_size / (
+                        1024 * 1024
+                    )
+                    self.logger.debug(
+                        "Loading file %d/%d: %s (%.1f MB)",
+                        idx + 1,
+                        len(self.file_paths),
+                        file_path.name,
+                        file_size_mb,
+                    )
+
+                    t0 = time.perf_counter()
+                    df = self._load_feather(file_path)
+                    array_length = len(df)
+                    t_load = time.perf_counter()
+                    self.logger.debug(
+                        "Loaded %d rows in %.1fs",
+                        array_length,
+                        t_load - t0,
+                    )
+
+                    converted = converter(df)
+                    del df
+                    t_convert = time.perf_counter()
+                    self.logger.debug(
+                        "Converted to %s in %.1fs",
+                        "columnar batch"
+                        if self._use_columnar
+                        else "numpy array",
+                        t_convert - t_load,
+                    )
+
+                    if self._use_columnar:
+                        entry = FileDataSource.FileManager._FileEntry(
+                            name=file_path.name,
+                            path=file_path,
+                            dtype=np.dtype("uint8"),
+                            length=array_length,
+                            memmap=None,
+                            cached_array=None,
+                            cached_columnar=converted,
                         )
-                        self.logger.debug(
-                            "Loading file %d/%d: %s (%.1f MB)",
+                    else:
+                        entry = FileDataSource.FileManager._FileEntry(
+                            name=file_path.name,
+                            path=file_path,
+                            dtype=converted.dtype,
+                            length=array_length,
+                            memmap=None,
+                            cached_array=converted,
+                        )
+                    self._file_entries.append(entry)
+                    lengths.append(array_length)
+                    cumulative_rows += array_length
+
+                    if (
+                        idx % milestone_interval == 0
+                        or idx == n - 1
+                    ):
+                        self.logger.info(
+                            "Progress: %d/%d files, "
+                            "%d rows loaded, "
+                            "%.1fs elapsed",
                             idx + 1,
-                            len(self.file_paths),
-                            file_path.name,
-                            file_size_mb,
+                            n,
+                            cumulative_rows,
+                            time.perf_counter() - t_init_start,
                         )
 
-                        t0 = time.perf_counter()
-                        df = self._load_feather(file_path)
-                        array_length = len(df)
-                        t_load = time.perf_counter()
-                        self.logger.debug(
-                            "Loaded %d rows in %.1fs",
-                            array_length,
-                            t_load - t0,
-                        )
-
-                        if (
-                            self._use_columnar
-                            and columnar_converter is not None
-                        ):
-                            columnar_batch = columnar_converter(
-                                df
-                            )
-                            del df
-                            t_convert = time.perf_counter()
-                            self.logger.debug(
-                                "Converted to columnar batch in %.1fs",
-                                t_convert - t_load,
-                            )
-
-                            self._file_entries.append(
-                                FileDataSource.FileManager._FileEntry(
-                                    name=file_path.name,
-                                    path=file_path,
-                                    dtype=np.dtype("uint8"),
-                                    length=array_length,
-                                    memmap=None,
-                                    cached_array=None,
-                                    cached_columnar=columnar_batch,
-                                )
-                            )
-                        elif numpy_converter is not None:
-                            numpy_array = numpy_converter(df)
-                            del df
-                            t_convert = time.perf_counter()
-                            self.logger.debug(
-                                "Converted to numpy array in %.1fs",
-                                t_convert - t_load,
-                            )
-
-                            self._file_entries.append(
-                                FileDataSource.FileManager._FileEntry(
-                                    name=file_path.name,
-                                    path=file_path,
-                                    dtype=numpy_array.dtype,
-                                    length=array_length,
-                                    memmap=None,
-                                    cached_array=numpy_array,
-                                )
-                            )
-                        lengths.append(array_length)
-                        cumulative_rows += array_length
-
-                        if (
-                            idx % milestone_interval == 0
-                            or idx == n - 1
-                        ):
-                            self.logger.info(
-                                "Progress: %d/%d files, "
-                                "%d rows loaded, "
-                                "%.1fs elapsed",
-                                idx + 1,
-                                n,
-                                cumulative_rows,
-                                time.perf_counter()
-                                - t_init_start,
-                            )
-
-                    except ImportError as e:
-                        raise ImportError(
-                            f"Polars and Rust backend required for .feather files: {e}"
-                        )
-
+                except ImportError as e:
+                    self.logger.error(
+                        f"Failed to load array {file_path}: {e}"
+                    )
+                    raise ImportError(
+                        f"Polars and Rust backend required for .feather files: {e}"
+                    ) from e
                 except Exception as e:
                     self.logger.error(
                         f"Failed to load array {file_path}: {e}"
                     )
                     raise
             self.cum_lengths = np.cumsum([0] + lengths)
+            # get_item は訓練サンプル 1 件ごとに呼ばれるので，探索対象
+            # (cum_lengths[1:]) と探索そのものを Python 側に寄せておく．
+            # np.searchsorted のスカラー呼び出しは 1 件あたりの定数費用が重い．
+            self._cum_upper: list[int] = [
+                int(v) for v in self.cum_lengths[1:]
+            ]
+            self._cum_lower: list[int] = [
+                int(v) for v in self.cum_lengths[:-1]
+            ]
 
             self.total_rows = self.cum_lengths[-1]
             self.total_pages = len(self.cum_lengths) - 1
@@ -588,10 +576,8 @@ class FileDataSource(
                     self._concatenated_columnar, idx
                 )
 
-            file_idx = np.searchsorted(
-                self.cum_lengths[1:], idx, side="right"
-            )
-            local_idx = idx - self.cum_lengths[file_idx]
+            file_idx = bisect.bisect_right(self._cum_upper, idx)
+            local_idx = idx - self._cum_lower[file_idx]
             entry = self._file_entries[file_idx]
 
             if self._use_columnar:

--- a/src/maou/infra/file_system/streaming_file_source.py
+++ b/src/maou/infra/file_system/streaming_file_source.py
@@ -83,10 +83,7 @@ class StreamingFileSource:
                 f"Unsupported array_type: {array_type}. "
                 f"Supported: {list(_FEATHER_LOADERS.keys())}"
             )
-        if (
-            array_type == "hcpe"
-            and array_type not in _COLUMNAR_CONVERTERS
-        ):
+        if array_type not in _COLUMNAR_CONVERTERS:
             raise ValueError(
                 "hcpe array_type is not supported for streaming columnar conversion. "
                 "Use 'preprocessing', 'stage1', or 'stage2'."
@@ -173,11 +170,9 @@ class StreamingFileSource:
         Yields:
             1ファイル分のデータを含む ``ColumnarBatch``
         """
-        for fp in self._file_paths:
-            df = self._loader(fp)
-            batch = self._converter(df)
-            del df  # DF参照を即座に切る(GC対象にする)
-            yield batch
+        yield from self.iter_files_columnar_subset(
+            self._file_paths
+        )
 
     def iter_files_columnar_subset(
         self,
@@ -196,9 +191,7 @@ class StreamingFileSource:
         """
         n = len(file_paths)
         for i, fp in enumerate(file_paths):
-            log_level = logging.DEBUG
-            logger.log(
-                log_level,
+            logger.debug(
                 "Loading file %d/%d: %s",
                 i + 1,
                 n,
@@ -207,8 +200,7 @@ class StreamingFileSource:
             t0 = time.perf_counter()
             df = self._loader(fp)
             t_load = time.perf_counter() - t0
-            logger.log(
-                log_level,
+            logger.debug(
                 "File loaded: %d rows in %.2fs, converting...",
                 len(df),
                 t_load,

--- a/tests/maou/infra/bigquery/test_bq_local_cache_glob.py
+++ b/tests/maou/infra/bigquery/test_bq_local_cache_glob.py
@@ -1,0 +1,78 @@
+"""``BigQueryDataSource`` のローカルキャッシュ検証に関する回帰テスト．
+
+`/audit-backlog` 2026-08-12 / backlog 行 O6．
+
+`__download_all_to_local` の完了検証が `glob("*.npy")` だったのに対し，
+`__save_to_local` は `.feather` を書くため，キャッシュが正常に作られても
+常に "Created 0 local cache files" と警告が出ていた．
+
+GCP 資格情報なしで走らせるため，``PageManager`` は ``object.__new__``
+で生成し，検証が読む属性だけを差し込む (``__init__`` は BigQuery
+クライアントを要求する)．
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maou.infra.bigquery.bq_data_source import (
+    BigQueryDataSource,
+)
+
+
+def _make_page_manager(
+    cache_dir: Path, *, total_pages: int
+) -> Any:
+    """BigQuery に触れずに ``PageManager`` の検証部分だけを組み立てる．"""
+    pm = object.__new__(BigQueryDataSource.PageManager)
+    pm.local_cache_dir = cache_dir
+    pm.total_pages = total_pages
+    pm.dataset_fqn = "proj.dataset"
+    pm.table_name = "table"
+    # __get_local_cache_path が読む name-mangled 属性
+    pm._PageManager__pruning_info = []
+    return pm
+
+
+def test_local_cache_validation_counts_feather_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``__save_to_local`` が書く拡張子をキャッシュ検証が数えること．
+
+    検証は「全ページのキャッシュが既にある」場合は早期 return で
+    スキップされるので，1 ページ分をわざと欠けさせてダウンロード経路を
+    通す．``__save_to_local`` は実際の書き込みだけスタブに差し替える．
+    """
+    pm = _make_page_manager(tmp_path, total_pages=2)
+
+    paths = [
+        pm._PageManager__get_local_cache_path(page_num)
+        for page_num in range(2)
+    ]
+    assert all(path.suffix == ".feather" for path in paths)
+
+    # page 0 だけ既に存在させ，page 1 をダウンロード経路に通す
+    paths[0].write_bytes(b"")
+
+    pm._PageManager__fetch_from_bigquery = lambda page_num: (
+        page_num
+    )
+    pm._PageManager__save_to_local = lambda page_num, data: (
+        paths[page_num].write_bytes(b"")
+    )
+
+    maou_logger = logging.getLogger("maou")
+    original_propagate = maou_logger.propagate
+    maou_logger.propagate = True
+    try:
+        with caplog.at_level(logging.INFO):
+            pm._PageManager__download_all_to_local()
+    finally:
+        maou_logger.propagate = original_propagate
+
+    assert "Created 2 local cache files" in caplog.text
+    assert (
+        "No local cache files were created" not in caplog.text
+    )

--- a/tests/maou/infra/file_system/test_file_data_source.py
+++ b/tests/maou/infra/file_system/test_file_data_source.py
@@ -302,3 +302,207 @@ def test_file_data_source_progress_logging(
     assert "Loading file 2/2" in debug_text
     assert "Loaded" in debug_text
     assert "Converted to numpy array" in debug_text
+
+
+# ---------------------------------------------------------------------------
+# /audit-backlog 2026-08-12 — 回帰テスト
+#
+# characterization test: P3 (振る舞い不変) の分類そのものの根拠．
+# 修正前後の双方で通る必要がある．
+# ---------------------------------------------------------------------------
+
+
+def test_get_item_index_mapping_across_files(
+    tmp_path: Path,
+) -> None:
+    """全グローバルインデックスが正しいファイル・行へ写ること．
+
+    D13(a): ``np.searchsorted(cum_lengths[1:], ...)`` を
+    ``bisect.bisect_right`` へ置き換えた際の写像の同値性を固定する．
+
+    ファイル長は**わざと不揃い**にしてある．全ファイルが同じ行数だと
+    ``idx - upper`` の誤りが numpy の負インデックスでちょうど巻き戻り，
+    off-by-one が観測できなくなる．
+    """
+    paths_a, dfs_a = _create_preprocessing_files(
+        tmp_path / "a", file_count=2, rows_per_file=5
+    )
+    paths_b, dfs_b = _create_preprocessing_files(
+        tmp_path / "b", file_count=2, rows_per_file=3
+    )
+    file_paths = paths_a + paths_b
+    dataframes = dfs_a + dfs_b
+
+    datasource = FileDataSource(
+        file_paths=file_paths,
+        array_type="preprocessing",
+    )
+
+    # id は _columnar_to_structured_record が 0 埋めするので，
+    # ファイル境界の写像は resultValue で確認する
+    expected = [
+        value
+        for df in dataframes
+        for value in df["resultValue"].to_list()
+    ]
+    assert len(datasource) == len(expected)
+    actual = [
+        float(datasource[idx]["resultValue"])
+        for idx in range(len(datasource))
+    ]
+    assert actual == expected
+
+
+def test_get_item_rejects_out_of_range_index(
+    tmp_path: Path,
+) -> None:
+    """範囲外インデックスが IndexError で落ちること (D13(a) の境界)．"""
+    file_paths, _ = _create_preprocessing_files(
+        tmp_path, file_count=2, rows_per_file=3
+    )
+    datasource = FileDataSource(
+        file_paths=file_paths,
+        array_type="preprocessing",
+    )
+
+    with pytest.raises(IndexError):
+        datasource[len(datasource)]
+
+
+def test_structured_dtype_matches_array_type(
+    tmp_path: Path,
+) -> None:
+    """``_structured_dtype`` が array_type ごとの非パック dtype と一致すること．
+
+    D13(c): ``_STRUCTURED_DTYPES`` テーブルを
+    ``interface.data_schema.get_dtype`` へ寄せた際の characterization
+    test．置き換え前の式 (``get_preprocessing_dtype()`` などの決め打ち)
+    が返していた dtype をそのまま固定する．
+
+    ``bit_pack=True`` でも同じ dtype になることも併せて固定する
+    (現状 preprocessing の packed 版は非パック版と同一なので，この
+    表明は将来 packed 版が分岐した日に初めて差を検出する)．
+    """
+    from maou.interface.data_schema import (
+        get_preprocessing_dtype,
+        get_stage1_dtype,
+    )
+
+    file_paths, _ = _create_preprocessing_files(
+        tmp_path, file_count=1, rows_per_file=2
+    )
+    for bit_pack in (False, True):
+        manager = FileDataSource.FileManager(
+            file_paths=file_paths,
+            array_type="preprocessing",
+            bit_pack=bit_pack,
+        )
+        assert (
+            manager._structured_dtype
+            == get_preprocessing_dtype()
+        )
+        assert manager._structured_dtype != get_stage1_dtype()
+
+
+def test_lengths_and_file_entries_stay_aligned(
+    tmp_path: Path,
+) -> None:
+    """``lengths`` と ``_file_entries`` が常に同数であること．
+
+    D12(a): ローダ分岐がどちらも空振りすると ``lengths`` だけが伸びて
+    ``cum_lengths`` と ``_file_entries`` がズレ，以降の全インデックス
+    参照が例外なしに壊れる．構造的に起こり得ないことを固定する．
+
+    columnar 経路 (preprocessing) と numpy 経路 (hcpe) の**両方**を
+    通す．片方だけだと，分岐のもう一方を落とす退行を検出できない．
+    """
+    hcpe_paths, _ = _create_hcpe_files(
+        tmp_path / "hcpe", file_count=3, rows_per_file=2
+    )
+    prep_paths, _ = _create_preprocessing_files(
+        tmp_path / "prep", file_count=3, rows_per_file=2
+    )
+
+    for array_type, file_paths in (
+        ("hcpe", hcpe_paths),
+        ("preprocessing", prep_paths),
+    ):
+        manager = FileDataSource.FileManager(
+            file_paths=file_paths,
+            array_type=array_type,  # type: ignore[arg-type]
+            bit_pack=False,
+        )
+        assert len(manager._file_entries) == len(file_paths)
+        assert len(manager.cum_lengths) == len(file_paths) + 1
+        assert manager.cum_lengths[-1] == manager.total_rows
+
+
+def test_unknown_array_type_rejected(tmp_path: Path) -> None:
+    """未知の array_type は読み込み前に ValueError で落ちること．"""
+    file_paths, _ = _create_hcpe_files(
+        tmp_path, file_count=1, rows_per_file=2
+    )
+
+    with pytest.raises(ValueError, match="Unknown array_type"):
+        FileDataSource.FileManager(
+            file_paths=file_paths,
+            array_type="not_a_type",  # type: ignore[arg-type]
+            bit_pack=False,
+        )
+
+
+def test_load_failure_wraps_import_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ローダの ImportError が polars 案内つきで再送出されること．
+
+    D12(b): ``try/except ImportError`` が ``try/except Exception`` の
+    内側に入れ子で，内側が文言を変えて再 raise → 外側が即座に捕捉して
+    traceback を二重化していた．入れ子を解いても**伝播する例外の型と
+    文言が変わらない**ことを固定する．
+    """
+    file_paths, _ = _create_hcpe_files(
+        tmp_path, file_count=1, rows_per_file=2
+    )
+
+    def _boom(self: object, path: Path) -> None:
+        raise ImportError("no rust backend")
+
+    monkeypatch.setattr(
+        FileDataSource.FileManager,
+        "_load_feather",
+        _boom,
+    )
+
+    with pytest.raises(
+        ImportError,
+        match="Polars and Rust backend required for .feather files",
+    ):
+        FileDataSource(
+            file_paths=file_paths,
+            array_type="hcpe",
+        )
+
+
+def test_load_failure_propagates_other_errors_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ImportError 以外はそのまま伝播すること (D12(b) の対偶)．"""
+    file_paths, _ = _create_hcpe_files(
+        tmp_path, file_count=1, rows_per_file=2
+    )
+
+    def _boom(self: object, path: Path) -> None:
+        raise RuntimeError("corrupt footer")
+
+    monkeypatch.setattr(
+        FileDataSource.FileManager,
+        "_load_feather",
+        _boom,
+    )
+
+    with pytest.raises(RuntimeError, match="corrupt footer"):
+        FileDataSource(
+            file_paths=file_paths,
+            array_type="hcpe",
+        )

--- a/tests/maou/infra/file_system/test_streaming_file_source.py
+++ b/tests/maou/infra/file_system/test_streaming_file_source.py
@@ -550,3 +550,85 @@ class TestLazyInitialization:
             real_scan,
         )
         assert source.total_rows == 15
+
+
+# ============================================================================
+# /audit-backlog 2026-08-12 — 回帰テスト
+# ============================================================================
+
+
+class TestBacklogRegressions:
+    """backlog 行 D10(a) / D12(e) の回帰テスト．"""
+
+    def test_iter_files_columnar_matches_subset_over_all_files(
+        self, tmp_path: Path
+    ) -> None:
+        """全ファイルを渡した ``_subset`` と同じ内容を返すこと．
+
+        D10(a): ``iter_files_columnar`` は ``iter_files_columnar_subset``
+        から計測ログを抜いた二重実装だった．委譲へ寄せたので，両者が
+        同じバッチ列を返すことを固定する．
+        """
+        file_paths = _create_preprocessing_files(
+            tmp_path, file_count=3, rows_per_file=4
+        )
+        source = StreamingFileSource(
+            file_paths=file_paths,
+            array_type="preprocessing",
+        )
+
+        via_all = list(source.iter_files_columnar())
+        via_subset = list(
+            source.iter_files_columnar_subset(file_paths)
+        )
+
+        assert len(via_all) == len(via_subset) == 3
+        for a, b in zip(via_all, via_subset, strict=True):
+            assert len(a) == len(b)
+            np.testing.assert_array_equal(
+                a.board_positions, b.board_positions
+            )
+            assert a.result_value is not None
+            assert b.result_value is not None
+            np.testing.assert_array_equal(
+                a.result_value, b.result_value
+            )
+
+    def test_iter_files_columnar_is_lazy(
+        self, tmp_path: Path
+    ) -> None:
+        """委譲後も generator のまま (呼んだだけでは読まない)こと．"""
+        file_paths = _create_preprocessing_files(
+            tmp_path, file_count=2, rows_per_file=3
+        )
+        source = StreamingFileSource(
+            file_paths=file_paths,
+            array_type="preprocessing",
+        )
+
+        gen = source.iter_files_columnar()
+        for path in file_paths:
+            path.unlink()
+
+        # 遅延評価なので，生成時点ではまだ読んでいない
+        with pytest.raises((OSError, FileNotFoundError)):
+            next(iter(gen))
+
+    @pytest.mark.parametrize(
+        "array_type", ["preprocessing", "stage1", "stage2"]
+    )
+    def test_columnar_array_types_accepted(
+        self, array_type: str
+    ) -> None:
+        """columnar 変換器を持つ型は受理されること．
+
+        D12(e): 2 つ目の検証条件を
+        ``array_type not in _COLUMNAR_CONVERTERS`` へ縮約したので，
+        受理集合が変わっていないことを固定する
+        (拒否側は ``test_init_hcpe_rejected`` が押さえている)．
+        """
+        source = StreamingFileSource(
+            file_paths=[],
+            array_type=array_type,  # type: ignore[arg-type]
+        )
+        assert source.total_rows == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "maou"
-version = "0.86.0"
+version = "0.86.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
`/audit-backlog` (2026-08-12) の**自動帯**．`audits/coverage.md` の backlog 行を
HEAD に対して再検証したうえで，判断コスト P2 / P3 に分類された項目だけを consume している．
ユーザ判断を要する項目 (P4 以上) は本 PR に含めず，別 PR に載せる．

## Stack (2026-08-12 /audit-backlog)

1. **#(this) P2+P3 自動帯** ← このPR (base: `main`, independent)
2. P4 判断帯 — 本 PR マージ後に `main` ベースで別途開く
3. P1 `audits/` 記録 + ledger 更新 — 同上

> class ごとに PR を分ける規約だが，本セッションは `claude/audit-backlog-7mktqi` を
> 指定ブランチとして渡されているため P2 と P3 を 1 PR に畳んでいる．両者はマージ方針
> (無停止マージ) が同じなので，class = マージ方針という分割理由は保たれている．

## 消化した項目

| 行 | 対象 | class | class を決めたテスト |
|---|---|---|---|
| O11 | `docs/commands/pre_process.md` | **P2** | 追跡対象の散文のみ + 訂正後の本文が現行コードから一意に決まる |
| O6 | `infra/bigquery/bq_data_source.py:483` | **P3** | ログ文言のみが変わる．成果物・戻り値は不変 |
| D12(a) | `infra/file_system/file_data_source.py` | **P3** | 到達不能な分岐へのガード追加 |
| D12(b) | 同上 | **P3** | 同じ例外が同じハンドラへ届く (型・文言据え置き) |
| D12(e) | `infra/file_system/streaming_file_source.py` | **P3** | 受理集合とエラー文言が同一 |
| D12(f) | 同上 | **P3** | ログ呼び出しの形のみ |
| D13(a) | `file_data_source.py:594` | **P3** | 同じ index を返す．時間のみ変わる |
| D13(c) | `file_data_source.py:59` | **P3** | `get_dtype(bit_pack=False)` は 3 つの factory と同値 |
| D10(a) | `streaming_file_source.py:161` | **P3** | DEBUG ログが増えるだけ |

出典はいずれも [audits/2026-08-10-src-maou-infra-file-system.md](https://github.com/dousu/maou/blob/main/audits/2026-08-10-src-maou-infra-file-system.md)．

## 再検証で判明したこと (記録の訂正)

**D10(a) は "削除" が誤り (changed shape)．** backlog 行は
`iter_files_columnar` を「production は `_subset` しか呼ばない二重実装」と
書いているが，HEAD では `app/learning/streaming_dataset.py:199` の
`StreamingSource` プロトコルが宣言するメンバであり，`tests/` 側に 10 本以上の
呼び出しがある．削除すれば公開名が消える (P6) ので，**`_subset` への委譲**に
留めた — 重複は消えるがプロトコルは保たれる．

## 主な変更

- **O11**: `.npy` シャードという記述を実際の出力へ訂正．ローカルは
  `transformed_chunk{NNNN}.feather`，GCS/S3 は
  `batch{ID}_{N}dfs_{SIZE}MB.feather`，入力側は `.feather` 以外を
  `ValueError` で拒否する．`.npy` を書く経路も読む経路も pre-process には無い．
  監査証跡として `reviews/2026-08-12-pre-process-output-format-drift.md` を追加
  (CLAUDE.md の standing approval 範囲内の drift correction として本 run で適用)．
- **D12(a)**: ローダ分岐がどちらも空振りすると `lengths` だけが伸びて
  `_file_entries` とズレ，以降の全インデックス参照が**例外なしに**壊れる．
  変換器をループ前に非 None へ確定させ，分岐そのものを消した．
- **D13(a)**: `get_item` は訓練サンプル 1 件ごとに `cum_lengths[1:]` を作って
  スカラー `np.searchsorted` を呼んでいた．探索対象を `__init__` へ巻き上げ，
  `bisect.bisect_right` に置き換えた．

## テスト

回帰テスト 11 本を追加．全て **neuter 検証済み** (修正を無効化すると落ちることを確認)．

最初に書いた 3 本は vacuous だったので書き直している:

- 全ファイルが同じ行数だと `idx - upper` の off-by-one が numpy の負インデックスで
  ちょうど巻き戻り，観測できない → ファイル長を不揃いにした
- `preprocessing` の packed dtype は現状非パック版と**同一**なので
  `bit_pack` 取り違えの罠が発火しない → 置換前の式に対する
  characterization test へ書き換えた
- `lengths`/`_file_entries` の対応検査は columnar 型だけだと numpy 経路を
  落とす退行を検出できない → hcpe と preprocessing の両方を通した

## QA (このコンテナで実行)

`.pre-commit-config.yaml` の各 hook を個別コマンドとして実行した．pre-commit
フレームワーク自体は `uv-lock` hook が GPU 専用の `tensorrt-cu12-libs` を
解決しようとして本環境では bootstrap できないため，`uv.lock` の version 行は
`uv lock` が生成するのと同じ 1 行差分を直接当てている．

| hook | 結果 |
|---|---|
| `ruff format` / `ruff check` (`src/`, `tests/`) | passed |
| `mypy src/ tests/` | Success: no issues found in 287 source files |
| `pytest` (全件) | **1826 passed, 54 skipped** |
| `scripts/check-cli-docs.sh` | exit 0 |
| `cz check` | successful |
| trailing-whitespace / end-of-file / check-toml | clean |

> テスト実行のために `uv sync --extra cpu` で torch を入れている．入れる前は
> `tests/maou/infra/file_system/test_file_data_source.py` がモジュールごと
> skip され，`file_data_source.py` の変更が一切検証されない状態だった
> (gate G3)．無検証でマージしないためにインストールしている．

## バージョン

`pyproject.toml` 0.86.0 → **0.86.1** (fix: → patch)．`uv.lock` も同期．

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_