### PR TITLE
docs(audits): correct a wrong environment note in the backlog record

### DIFF
--- a/audits/2026-08-12-backlog-auto-band-and-p4.md
+++ b/audits/2026-08-12-backlog-auto-band-and-p4.md
@@ -182,13 +182,39 @@ backlog に行を追加した．
 
 ## Environment notes
 
-- **pre-commit フレームワークが本環境で bootstrap できない．** `uv-lock`
-  hook が GPU 専用の `tensorrt-cu12-libs` を解決しようとして失敗する
-  (`maou[tensorrt-infer]` 経由)．`.pre-commit-config.yaml` の各 hook を
-  個別コマンドとして実行して代替した: `ruff format` / `ruff check` /
-  `mypy src/ tests/` / `pytest` 全件 / `scripts/check-cli-docs.sh` /
-  `cz check` / trailing-whitespace・end-of-file・check-toml 相当．
+- **~~pre-commit フレームワークが本環境で bootstrap できない．~~** `uv-lock`
+  hook が GPU 専用の `tensorrt-cu12-libs` を解決しようとして失敗したため，
+  `.pre-commit-config.yaml` の各 hook を個別コマンドとして実行して代替した:
+  `ruff format` / `ruff check` / `mypy src/ tests/` / `pytest` 全件 /
+  `scripts/check-cli-docs.sh` / `cz check` /
+  trailing-whitespace・end-of-file・check-toml 相当．
   `uv.lock` の version 行は `uv lock` が生成するのと同じ 1 行差分を直接当てた．
+
+  **Correction** (2026-08-12, 本 run 内): 上の「bootstrap できない」は
+  **誤り** — 環境の恒久的な制約ではなく，一度きりの転送失敗だった．
+  ユーザの指摘 (「特定ドメインにアクセスできなかったからか」) を受けて
+  切り分けた結果:
+
+  | 検査 | 結果 |
+  |---|---|
+  | `pypi.nvidia.com` への到達性 | **HTTP 200** (proxy 経由，ブロックされていない) |
+  | wheel 本体の完全性 (curl, 全体) | 4,276,636,826 B = `Content-Length` 一致，sha256 **一致** |
+  | wheel_stub と同一経路の再現 (urllib + 16KiB ループ, proxy 経由) | 同上，sha256 **一致** |
+  | `/tmp` に 4.5GB 書き込み | 成功 (109 MB/s) |
+  | `uv lock --no-cache --upgrade-package tensorrt-cu12-libs` 再実行 | **成功** (`Built tensorrt-cu12-libs==10.15.1.29`) |
+  | `uv run pre-commit run --all-files` | **全 hook Passed** (`uv-lock` 含む) |
+
+  真因は **4.28GB の wheel の転送が途中で切れたこと**．`wheel_stub` は
+  読み取りバイト数を `Content-Length` と突き合わせないので
+  (`wheel_stub/wheel.py:202-210` のループは空読みで抜けるだけ)，短いファイル
+  を書いたまま次行の sha256 assert で落ちる．`urlopen_with_retry` は接続の
+  確立しか再試行しないため，ストリーム途中の切断は再試行されない．
+  **環境設定 (ドメイン許可リスト等) に修正すべき点はない．**
+
+  したがって本 run の QA は「pre-commit が動かないので代替した」のではなく，
+  「代替手段で同等のものを実行した」が正しい — 事後に
+  `uv run pre-commit run --all-files` を判断帯ブランチで実行し，
+  **全 hook Passed** を確認済み (PR #457 に反映)．
 - **torch を入れないと自動帯が無検証になる (G3)．** run 開始時点で
   `test_file_data_source.py` はモジュールごと skip されていた．
   `uv sync --extra cpu` で torch を入れて 52 passed + 3 skipped →


### PR DESCRIPTION
#458 でマージした `/audit-backlog` 2026-08-12 の記録に，**事実として誤った
Environment note** が入っていたので訂正する．`audits/` のみ触るので **P1**．

## 何が誤っていたか

記録は「**pre-commit フレームワークが本環境で bootstrap できない**」と
書いていた．これは環境の恒久的な制約のように読めるが，実際は
**4.28GB の wheel (`tensorrt-cu12-libs`) の転送が一度きり途中で切れただけ**
だった．

ユーザからの指摘 (「特定のドメインにアクセスできなかったからか，そうなら
環境設定を直す」) を受けて切り分けた結果:

| 検査 | 結果 |
|---|---|
| `pypi.nvidia.com` への到達性 | **HTTP 200** (proxy 経由，ブロックされていない) |
| wheel 本体の完全性 (curl, 全体ストリーム) | 4,276,636,826 B = `Content-Length` 一致，sha256 **一致** |
| wheel_stub と同一経路の再現 (urllib + 16KiB ループ, proxy 経由) | 同上，sha256 **一致** |
| `/tmp` に 4.5GB 書き込み | 成功 (109 MB/s) |
| `uv lock --no-cache --upgrade-package tensorrt-cu12-libs` 再実行 | **成功** (`Built tensorrt-cu12-libs==10.15.1.29`) |
| `uv run pre-commit run --all-files` | **全 hook Passed** (`uv-lock` 含む) |

## 真因

`wheel_stub` は読み取りバイト数を `Content-Length` と突き合わせない:

```python
# wheel_stub/wheel.py:202-214
with open(wheel_directory / wheel_filename, "wb") as f:
    CHUNK = 16 * 1024
    while True:
        data = wheel_response.read(CHUNK)
        if not data:          # ← 途中で切れても「終わり」として抜ける
            break
        if file_hash is not None:
            file_hash.update(data)
        f.write(data)
if file_hash is not None:
    assert file_hash.hexdigest() == hash, ...   # ← ここで初めて気づく
```

ストリームが途中で切れると短いファイルを書いたまま抜け，次行の sha256
assert で落ちる — 「ハッシュ不一致」という表示になるので**改竄や
ポリシー遮断のように見える**が，実体は転送の打ち切りである．
`urlopen_with_retry` は**接続の確立**しか再試行しないため，ストリーム
途中の切断は救われない．4.28GB という大きさがこれを引きやすくしている．

## 結論

**環境設定 (ドメイン許可リスト等) に修正すべき点はない．**

本 run の QA の位置づけも「pre-commit が動かないので代替した」ではなく
「代替手段で同等のものを実行した」が正確なので，そう書き直した．事後に
判断帯ブランチ (#457) で `uv run pre-commit run --all-files` を実行し，
**全 hook Passed** を確認済み (#457 の QA 節にも反映)．

## 記録の扱い

CLAUDE.md / `.claude/commands/audit-backlog.md` step 6b は記録を immutable と
定めるが，**診断が誤りだった場合の訂正だけは例外**として認めている．
本 PR はその例外に該当する (worklist state ではなく，次の読者が誤った
環境制約を信じ込まないための訂正)．元の記述は取り消し線で残し，
`**Correction**` を追記する形にした．

`coverage.md` の行には影響しない — N4 (torch 未導入で
`test_file_data_source.py` がモジュールごと skip される) は別件で，
そちらは今も有効な finding．

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_