### PR TITLE
perf(dfpn): TT サイズを停止条件から切り離し RootDfpnNodes を USI に公開する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.12.0"
+version = "5.13.0"
 dependencies = [
  "arrayvec",
  "rustc-hash",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -134,6 +134,7 @@ Declared in the `usi` response; defaults reflect the CLI flags above.
 | `OpeningScript` | string | Forced opening move sequence in USI notation (empty = disabled). |
 | `USI_Ponder` | check | Enable pondering (default on). Declared so the GUI sends `go ponder`; `bestmove` carries the predicted reply (PV's 2nd move). |
 | `RootDfpn` / `LeafMate` | check | Mate search toggles. |
+| `RootDfpnNodes` | spin | Node budget for the root dfpn mate search (default `2000000`). For `go` it is the search cutoff; for `go mate` it only **sizes the transposition table** — that search stops on time/`stop` as the USI spec requires. The table holds `clamp(nodes * 2, 2^18, 2^23)` entries and is written in full on allocation (≈7 ms/MB; the default is ≈352 MB), so this is a fixed cost paid per search, not just at startup. Raise it only to chase long mates; an undersized table is collected by GC rather than losing the mate, so it costs time, not correctness. |
 
 ## Example
 

--- a/reviews/2026-08-12-root-dfpn-nodes-usi-option.md
+++ b/reviews/2026-08-12-root-dfpn-nodes-usi-option.md
@@ -1,6 +1,6 @@
 ---
 status: applied
-applied_in: 0fb7363
+applied_in: c0fa2c4
 date: 2026-08-12
 target: [docs/commands/usi.md]
 risk: low

--- a/reviews/2026-08-12-root-dfpn-nodes-usi-option.md
+++ b/reviews/2026-08-12-root-dfpn-nodes-usi-option.md
@@ -1,0 +1,59 @@
+---
+status: applied
+applied_in: 0fb7363
+date: 2026-08-12
+target: [docs/commands/usi.md]
+risk: low
+reversibility: trivial
+---
+
+# `RootDfpnNodes` を USI オプション表に追加する
+
+## Trigger
+
+ユーザ指示 (2026-08-12):
+
+> root_dfpn_nodes は setoption に追加してください。停止条件に関しては時間の
+> ままでヒントとして扱ってください。TT サイズが満杯になっても GC があるので
+> 全く無意味ではないので USI 経由は時間で止まる仕様にしましょう。
+
+背景は `audits/coverage.md` の N5 — `go mate` が `max_nodes = u64::MAX` を
+渡すため TT が常に上限 (1<<23 = 704MB) になり，1 手詰でも初回応答が数秒
+かかっていた (実測 4.856s)．ノード予算を **TT サイズのヒント**として
+切り離し，ノブを USI に公開した．
+
+## 承認について
+
+CLAUDE.md § MUST rules は durable doc の編集に承認済み `reviews/*.md` を
+要求する．本件は**ユーザが機能追加そのものを明示的に指示している**ため，
+その指示を承認として扱い本 run 内で適用した．P2 の standing approval
+(drift correction) ではない — 新規オプションの記述なのでドリフトではなく，
+承認の根拠は上記のユーザ指示である．
+
+記述内容は実装から一意に決まる: オプション名・型・既定値は
+`rust/maou_usi/src/agent.rs` の `OptionDecl`，TT サイズ式は
+`rust/maou_shogi/src/dfpn/search/mod.rs:560`，`go mate` が時間でのみ止まる
+ことは `rust/maou_usi/src/backend.rs` の `solve_mate` による．
+
+## Before / After
+
+`docs/commands/usi.md` の USI options 表に 1 行追加する
+(`RootDfpn` / `LeafMate` の行の直後)．
+
+```diff
+ | `RootDfpn` / `LeafMate` | check | Mate search toggles. |
++| `RootDfpnNodes` | spin | Node budget for the root dfpn mate search (default `2000000`). For `go` it is the search cutoff; for `go mate` it only **sizes the transposition table** — that search stops on time/`stop` as the USI spec requires. The table holds `clamp(nodes * 2, 2^18, 2^23)` entries and is written in full on allocation (≈7 ms/MB; the default is ≈352 MB), so this is a fixed cost paid per search, not just at startup. Raise it only to chase long mates; an undersized table is collected by GC rather than losing the mate, so it costs time, not correctness. |
+```
+
+## 記述の根拠 (実測)
+
+| 主張 | 根拠 |
+|---|---|
+| 既定 2000000 | `agent.rs` の `OptionDecl` (`c.root_dfpn_nodes.unwrap_or(2_000_000)`) |
+| `clamp(nodes*2, 2^18, 2^23)` | `dfpn/search/mod.rs:560` |
+| 確保時に全バイト書き込む | `dfpn/tt/mod.rs:65` が明記 (`Entry::null()` が全ゼロでないため) |
+| 約 7 ms/MB | 実測: 22MB:0.205s / 88MB:0.741s / 352MB:2.485s / 704MB:4.856s |
+| 既定は約 352MB | 2,000,000 × 2 = 4,194,304 entries × (64+24)B |
+| **毎探索**の固定費 | プールは貸し出し時に初期値で `fill` するため 2 回目以降も O(size) (2^23 で 0.091s / 2^18 で 0.003s) |
+| 小さくても解けなくならない | 実測: `RootDfpnNodes=1000` でも mate-29 (約 40 万ノード) を 29 手で解く．Rust 側は `test_tt_nodes_hint_does_not_limit_search` が固定 |
+| `go mate` は時間で止まる | `backend.rs` の `solve_mate` は `max_nodes = u64::MAX` のまま，ヒントのみ設定 |

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.12.0"
+version = "5.13.0"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/search/mod.rs
+++ b/rust/maou_shogi/src/dfpn/search/mod.rs
@@ -557,7 +557,13 @@ impl DfPnSolver {
         } else {
             // floor は既定 1<<18 (production)．leaf-mate ソルバは min_tt_entries を
             // 小さくして per-leaf の TT 確保コストを下げる (new_leaf_mate)．
-            ((self.max_nodes as usize).saturating_mul(2)).clamp(self.min_tt_entries, 1 << 23)
+            //
+            // サイズの元は「どれだけノードを置く見込みか」であって「どこで
+            // 打ち切るか」ではない．時間でだけ止める用途 (USI `go mate`) は
+            // max_nodes に u64::MAX を置くしかないので，そのまま使うと難易度に
+            // 関係なく上限を確保してしまう．set_tt_nodes_hint で切り離せる．
+            let budget = self.tt_nodes_hint.unwrap_or(self.max_nodes);
+            ((budget as usize).saturating_mul(2)).clamp(self.min_tt_entries, 1 << 23)
         };
         // 千日手テーブルも固定サイズ (generation GC で bound)．既定は主 TT と同数
         // (24 byte/entry ≒ 主 TT の 37.5% メモリ)．`REPSIZE` で上書き可．

--- a/rust/maou_shogi/src/dfpn/solver.rs
+++ b/rust/maou_shogi/src/dfpn/solver.rs
@@ -185,6 +185,20 @@ pub struct DfPnSolver {
     /// (例 1<<10) TT 確保・初期化コストを下げる．既定値では既存挙動と同一．
     /// [`Self::new_leaf_mate`] が小さい値を設定する．
     pub(super) min_tt_entries: usize,
+    /// TT サイズ算出に使うノード数 (未設定なら [`Self::max_nodes`])．
+    ///
+    /// **なぜ分けるか**: TT サイズは「どれだけのノードを置く見込みか」で決まるが，
+    /// `max_nodes` は「どこで打ち切るか」という別の問いに答えている．USI の
+    /// `go mate` のように**時間と stop でだけ止める** (規約上ノード数で止めては
+    /// ならない) 用途では `max_nodes = u64::MAX` を置くしかなく，そのまま
+    /// TT サイズに使うと局面の難易度に関係なく上限 (1<<23 = 704MB) を確保して
+    /// しまう．確保は `Entry::null()` が全ゼロでないため全バイト書き込みになり，
+    /// 1 手詰でも数秒かかる (実測: 既定 4.9s / 22MB なら 0.2s)．
+    ///
+    /// ヒントを外しても**探索は不変**: TT が溢れても
+    /// `maybe_collect_garbage` が低 amount entry を間引くので，小さすぎる TT は
+    /// 「解けなくなる」ではなく「遅くなる」に落ちる．
+    pub(super) tt_nodes_hint: Option<u64>,
     /// 王手生成キャッシュ．
     pub(super) check_cache: CheckCache,
     /// mid 探索パス上の board.hash → ply (千日手検出 + 参照祖先 ply 特定用)．
@@ -270,6 +284,7 @@ impl DfPnSolver {
             check_cache: CheckCache::new(),
             tt_gc_threshold: 0,
             min_tt_entries: 1 << 18,
+            tt_nodes_hint: None,
             path_depths: super::path_stack::PathStack::new(),
             nodes: 0,
             expansion_stack: Vec::new(),
@@ -294,6 +309,18 @@ impl DfPnSolver {
     /// (最短保証なしのノード数削減)．デフォルトは true．
     pub fn set_find_shortest(&mut self, v: bool) -> &mut Self {
         self.find_shortest = v;
+        self
+    }
+
+    /// TT サイズ算出に使うノード数を `max_nodes` と切り離して与える．
+    ///
+    /// 停止条件 (`max_nodes` / timeout / stop フラグ) には**一切影響しない**．
+    /// 「時間でだけ止めたいが TT は難易度相応に確保したい」という
+    /// USI `go mate` のような用途のためにある — そこでは `max_nodes` に
+    /// `u64::MAX` を置く必要があり，それをそのまま TT サイズに使うと
+    /// 常に上限を確保してしまう ([`Self::tt_nodes_hint`] 参照)．
+    pub fn set_tt_nodes_hint(&mut self, nodes: u64) -> &mut Self {
+        self.tt_nodes_hint = Some(nodes);
         self
     }
 

--- a/rust/maou_shogi/src/dfpn/tests.rs
+++ b/rust/maou_shogi/src/dfpn/tests.rs
@@ -2253,11 +2253,15 @@ fn test_losing_move_discrimination_before_mate() {
 /// 小予算・小 TT (leaf 用) でも詰みを申告してはならない．
 #[test]
 fn test_defensive_no_false_proof_ply131() {
-    const PLY131: &str = "l2kb1p+R1/5s3/3g5/p1ppp2p1/1N3L3/1pn6/3PPPN2/SPG1sG1+r1/LN1KGs+l2 b b7p 131";
+    const PLY131: &str =
+        "l2kb1p+R1/5s3/3g5/p1ppp2p1/1N3L3/1pn6/3PPPN2/SPG1sG1+r1/LN1KGs+l2 b b7p 131";
     // (a) 通常予算
     let rep = solve_tsume_defense(PLY131, Some(500_000), Some(60)).expect("正当な SFEN");
     assert!(
-        !matches!(rep.result, TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. }),
+        !matches!(
+            rep.result,
+            TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. }
+        ),
         "偽の被詰み (通常予算): {:?}",
         rep.result
     );
@@ -2269,7 +2273,10 @@ fn test_defensive_no_false_proof_ply131() {
         solver.set_defensive(true);
         let r = solver.solve(&mut board);
         assert!(
-            !matches!(r, TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. }),
+            !matches!(
+                r,
+                TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. }
+            ),
             "偽の被詰み (leaf 予算 {nodes}): {r:?}"
         );
     }

--- a/rust/maou_shogi/src/dfpn/tests.rs
+++ b/rust/maou_shogi/src/dfpn/tests.rs
@@ -2274,3 +2274,60 @@ fn test_defensive_no_false_proof_ply131() {
         );
     }
 }
+
+/// `set_tt_nodes_hint` は **TT サイズだけ**を動かし，探索の停止条件に影響しない．
+///
+/// USI `go mate` は規約上 (時間 / stop) でだけ止まるので `max_nodes = u64::MAX`
+/// を置くしかない．それがそのまま TT サイズ算出に流れると，1 手詰でも上限
+/// (1<<23 entries = 704MB) を確保して全バイト書き込むため応答が数秒になる．
+/// ヒントで切り離した以上，**ヒントを極端に小さくしても解けなくなってはならない**
+/// (TT が溢れても GC が低 amount entry を間引くので「遅くなる」に落ちる)．
+///
+/// 17 手詰 (数万〜数十万ノード規模) に対して hint=1 を与える — もしヒントが
+/// 停止条件へ漏れていれば 1 ノードで打ち切られ，このテストが落ちる．
+#[test]
+fn test_tt_nodes_hint_does_not_limit_search() {
+    let sfen = "9/5Pk2/9/8R/8B/9/9/9/9 b 2Srb4g2s4n4l17p 1";
+
+    let solve = |hint: Option<u64>| {
+        let mut board = Board::new();
+        board.set_sfen(sfen).unwrap();
+        let mut solver = DfPnSolver::new(31, 5_000_000);
+        if let Some(n) = hint {
+            solver.set_tt_nodes_hint(n);
+        }
+        match solver.solve_impl(&mut board) {
+            TsumeResult::Checkmate { moves, .. } => moves.len(),
+            other => panic!("詰みを返すべき (hint={hint:?}): {other:?}"),
+        }
+    };
+
+    let baseline = solve(None);
+    assert_eq!(baseline, 17, "前提: この局面は 17 手詰");
+    // 最小ヒントでも同じ最短手数に到達する (TT の floor まで縮んでも探索は不変)．
+    assert_eq!(
+        solve(Some(1)),
+        baseline,
+        "tt_nodes_hint は探索結果を変えてはならない",
+    );
+}
+
+/// ヒント未設定なら従来どおり `max_nodes` から TT サイズが決まる (既存挙動の固定)．
+///
+/// `go` 経路や Python API はヒントを設定しないので，そちらの挙動が
+/// 変わっていないことを保証する．
+#[test]
+fn test_tt_nodes_hint_defaults_to_max_nodes() {
+    let sfen = "9/5Pk2/9/8R/8B/9/9/9/9 b 2Srb4g2s4n4l17p 1";
+    let mut board = Board::new();
+    board.set_sfen(sfen).unwrap();
+    let mut solver = DfPnSolver::new(31, 5_000_000);
+    assert!(
+        solver.tt_nodes_hint.is_none(),
+        "既定ではヒント未設定 (= max_nodes を使う)",
+    );
+    match solver.solve_impl(&mut board) {
+        TsumeResult::Checkmate { moves, .. } => assert_eq!(moves.len(), 17),
+        other => panic!("詰みを返すべき: {other:?}"),
+    }
+}

--- a/rust/maou_shogi/src/dfpn/tt/mod.rs
+++ b/rust/maou_shogi/src/dfpn/tt/mod.rs
@@ -128,9 +128,7 @@ impl<T: Clone> BufferPool<T> {
     /// **一度プールに入ったサイズを再要求して外した**場合と，返却を拒否した場合
     /// だけで，どちらも上限が実ワークロードに足りていない証拠になる．
     fn warn_once(&mut self, n: usize, reason: &'static str) {
-        if !stats_enabled()
-            || self.warned.iter().any(|(s, r)| *s == n && *r == reason)
-        {
+        if !stats_enabled() || self.warned.iter().any(|(s, r)| *s == n && *r == reason) {
             return;
         }
         self.warned.push((n, reason));
@@ -222,10 +220,8 @@ impl<T: Clone> BufferPool<T> {
     }
 }
 
-static REGULAR_POOL: std::sync::Mutex<BufferPool<Entry>> =
-    std::sync::Mutex::new(BufferPool::new());
-static REP_POOL: std::sync::Mutex<BufferPool<RepEntry>> =
-    std::sync::Mutex::new(BufferPool::new());
+static REGULAR_POOL: std::sync::Mutex<BufferPool<Entry>> = std::sync::Mutex::new(BufferPool::new());
+static REP_POOL: std::sync::Mutex<BufferPool<RepEntry>> = std::sync::Mutex::new(BufferPool::new());
 
 /// プールから借りる (lock が poison していれば借りずに新規確保へ落とす)．
 fn pool_take<T: Clone>(
@@ -268,8 +264,7 @@ impl RegularTable {
     pub(super) fn new(num_entries: usize) -> Self {
         let n = num_entries.max(1);
         let null = Entry::null();
-        let entries =
-            pool_take(&REGULAR_POOL, n, &null).unwrap_or_else(|| vec![null; n]);
+        let entries = pool_take(&REGULAR_POOL, n, &null).unwrap_or_else(|| vec![null; n]);
         RegularTable { entries }
     }
     /// 保存可能要素数．
@@ -436,8 +431,7 @@ impl RepetitionTable {
             generation: 0,
         };
         RepetitionTable {
-            entries: pool_take(&REP_POOL, size, &empty)
-                .unwrap_or_else(|| vec![empty; size]),
+            entries: pool_take(&REP_POOL, size, &empty).unwrap_or_else(|| vec![empty; size]),
             generation: 0,
             entry_count: 0,
             next_generation_update: epg as u64,
@@ -946,9 +940,7 @@ mod tests {
         );
         assert!(
             regular_pooled_count(SMALL)
-                <= BufferPool::<Entry>::max_per_size(
-                    SMALL * std::mem::size_of::<Entry>()
-                ),
+                <= BufferPool::<Entry>::max_per_size(SMALL * std::mem::size_of::<Entry>()),
             "1 サイズあたりの保持本数を超えている"
         );
     }

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -652,6 +652,21 @@ where
                 },
             },
             OptionDecl {
+                // root dfpn のノード予算．`go` では打ち切り予算そのもの，
+                // `go mate` では**TT サイズのヒント**として効く (go mate は
+                // 規約どおり時間と stop でだけ止まる)．
+                //
+                // TT は要素数 = clamp(nodes*2, 1<<18, 1<<23) で，確保時に全バイト
+                // 書き込むため予算に比例した固定費がかかる (実測 約 7ms/MB，
+                // 既定 2M ノード = 352MB)．長手数を追うときだけ上げる．
+                name: "RootDfpnNodes",
+                kind: OptionKind::Spin {
+                    default: c.root_dfpn_nodes.unwrap_or(2_000_000) as i64,
+                    min: 1,
+                    max: 1_000_000_000,
+                },
+            },
+            OptionDecl {
                 name: "LeafMate",
                 kind: OptionKind::Check {
                     default: c.leaf_mate.unwrap_or(true),
@@ -792,6 +807,11 @@ where
                 };
             }
             "RootDfpn" => self.config.root_dfpn = Some(parse_bool()),
+            "RootDfpnNodes" => {
+                if let Ok(n) = v.parse::<u64>() {
+                    self.config.root_dfpn_nodes = Some(n.max(1));
+                }
+            }
             "LeafMate" => self.config.leaf_mate = Some(parse_bool()),
             "DefensiveMate" => self.config.defensive_mate = Some(parse_bool()),
             "DefensiveMateThreads" => {
@@ -1564,6 +1584,46 @@ mod tests {
         assert_eq!(agent.config.time.network_delay_ms, 500);
         let out = agent.handle(GuiCommand::IsReady).unwrap();
         assert_eq!(out, vec![EngineCommand::ReadyOk]);
+    }
+
+    /// `RootDfpnNodes` が宣言され，`setoption` で config に反映される．
+    ///
+    /// このノブは dfpn の TT サイズを決める (`go mate` では**サイズのヒント
+    /// としてのみ**効き，停止は時間と stop のまま)．公開されていないと，
+    /// 長手数を追いたい利用者が TT を増やす手段を持たない — 実際に
+    /// 公開漏れしていたので固定する．
+    #[test]
+    fn test_root_dfpn_nodes_is_declared_and_settable() {
+        let (mut agent, _) = agent_with_fake(default_outcome());
+        let out = agent.handle(GuiCommand::Usi).unwrap();
+        let decl = out
+            .iter()
+            .find_map(|c| match c {
+                EngineCommand::OptionDecl(d) if d.name == "RootDfpnNodes" => Some(d),
+                _ => None,
+            })
+            .expect("RootDfpnNodes が宣言されていること");
+        assert!(
+            matches!(decl.kind, OptionKind::Spin { default, .. } if default == 2_000_000),
+            "既定は 2,000,000 ノード (TT 352MB 相当)",
+        );
+
+        agent
+            .handle(GuiCommand::SetOption {
+                name: "RootDfpnNodes".to_string(),
+                value: Some("30000000".to_string()),
+            })
+            .unwrap();
+        assert_eq!(agent.config.root_dfpn_nodes, Some(30_000_000));
+
+        // 0 は TT サイズ 0 を意味してしまうので下限 1 に丸める
+        agent
+            .handle(GuiCommand::SetOption {
+                name: "RootDfpnNodes".to_string(),
+                value: Some("0".to_string()),
+            })
+            .unwrap();
+        assert_eq!(agent.config.root_dfpn_nodes, Some(1));
     }
 
     #[test]

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -278,6 +278,15 @@ impl SearchBackend for MaouSearchBackend {
             u64::MAX,
             timeout_secs,
         );
+        // TT サイズだけは難易度相応に絞る．停止条件は上のとおり時間と stop の
+        // ままで，ここは**サイズのヒント**にしか効かない．
+        //
+        // これが無いと `u64::MAX` がそのまま TT サイズ算出に流れ，1 手詰でも
+        // 上限 (1<<23 = 704MB) を確保して全バイト書き込むため，探索の実費が
+        // 数 ms でも応答が数秒になる (実測: 既定 4.9s / 予算相応なら 0.2s)．
+        // 溢れても GC が低 amount entry を間引くので，足りなければ「解けない」
+        // ではなく「遅くなる」に落ちる．長手数を追うときは `RootDfpnNodes` を上げる．
+        solver.set_tt_nodes_hint(self.options.root_dfpn_nodes);
         // 詰将棋としての最短手順を返す (検討機能の用途に合う)
         solver.set_find_shortest(true);
         solver.set_stop_flag(Arc::clone(stop));


### PR DESCRIPTION
ご指示のとおり実装しました。

> root_dfpn_nodes は setoption に追加してください。停止条件に関しては時間の
> ままでヒントとして扱ってください。TT サイズが満杯になっても GC があるので
> 全く無意味ではないので USI 経由は時間で止まる仕様にしましょう。

背景は `audits/coverage.md` の N5。

## 問題

`go mate` は USI 規約上 (時間 / `stop`) でのみ止まるため `max_nodes = u64::MAX`
を置くしかないが，それが**そのまま TT サイズ算出に流れていた**
(`dfpn/search/mod.rs`: `clamp(max_nodes * 2, 1<<18, 1<<23)`)。
結果，局面の難易度に関係なく常に上限 8,388,608 エントリを確保し，
`Entry::null()` が全ゼロでないため**全バイト書き込み**になる
(主 TT 537MB + 千日手表 201MB)。

実測でこれが探索の実費を桁違いに上回っていた:

- 1手詰 `G*5b`: 初回応答 **4.856 秒** / peak RSS **745MB**（**探索の実費は 1〜5 ms**）
- 通常探索 `byoyomi 1000`: 初回 **3.487 秒**と予算の 3.5 倍 → **実戦の初手で時間超過しうる**

## 変更

- **`maou_shogi`**: `DfPnSolver` に `tt_nodes_hint` を追加し `set_tt_nodes_hint`
  で設定する。**停止条件 (`max_nodes` / timeout / stop) には一切影響しない**。
- TT サイズ算出をヒント優先にする。**未設定なら従来どおり `max_nodes`** なので
  `go` 経路と Python API の挙動は不変。
- **`maou_usi`**: `solve_mate` がヒントに `root_dfpn_nodes` を渡す。停止は時間と
  stop のまま（規約どおり）。
- **`RootDfpnNodes` を USI オプションとして宣言し `setoption` を受理**する。
  これまで Python API からしか設定できず，**対局中に増やす手段が無かった**。

## 効果（実測）

| | 修正前 | 修正後 |
|---|---|---|
| 1手詰の初回応答 | 4.856 s | **0.974 s** |
| peak RSS | 745 MB | **378 MB** |
| `RootDfpnNodes=100000` 指定時 | — | 0.022 s / 64 MB |
| `RootDfpnNodes=30000000` 指定時 | — | 3.098 s / 747 MB（上限まで伸ばせる） |
| `go mate 5000` ×20 | 1 回 timeout（最悪 7.47 s） | **20/20 正解**（最悪 2.44 s） |

宣言も確認済み:
`option name RootDfpnNodes type spin default 2000000 min 1 max 1000000000`

## 「ヒントのみ」であることの検証

ご指摘のとおり **TT が満杯でも GC が効くので無意味にはならない**ことを実測で
確認しました。`RootDfpnNodes=1000`（必要ノード数の 1/400）でも
**mate-29（約 40 万ノード）を 29 手で解きます**:

| `RootDfpnNodes` | 所要 | 結果 | RSS |
|---|---|---|---|
| 1,000 | 1.659 s | 29 手 ✓ | 65 MB |
| 100,000 | 1.601 s | 29 手 ✓ | 65 MB |
| default (2,000,000) | 1.829 s | 29 手 ✓ | 378 MB |

つまり小さすぎる TT は「解けない」ではなく「遅くなる」に落ちます。

回帰テスト `test_tt_nodes_hint_does_not_limit_search` がこれを固定しており，
**neuter 検証済み**（`set_tt_nodes_hint` が `max_nodes` も動かすように改悪すると
このテストだけが落ちる）。

## 既定値について

**既定 2,000,000 は据え置き**ました。`maou_search/src/search.rs:284-288` が
「~41 手級 (NN 盲点) の詰みまで捕捉できる予算（実測: 41te は ~1.2M ノードで
解ける）。TT 確保コストと reach のバランス点」と根拠つきで定めており，
ご提示の「実戦では mate-39 級が解ける分で十分」という上限とも整合します。
既定を動かすのは別の強さトレードオフなので，本 PR では触っていません。

## 残る課題（本 PR の範囲外）

- 既定でも**毎探索** 352MB の `fill` を払います（プールは貸し出し時に初期値で
  埋めるため 2 回目以降も O(size)）。根から消すには `Entry::null()` を全ゼロ
  表現にして `alloc_zeroed` に載せる必要があり，entry 表現を触るので別件です。
- `protocol.rs:395` が `Timeout` / `Mate(空手順)` / `CheckmateNoPv` をすべて
  `checkmate timeout` に畳むため，時間切れと「解けたが手順を復元できない」が
  区別できません。

## バージョン

- `rust/maou_shogi` 5.12.0 → **5.13.0**（`set_tt_nodes_hint` 追加 = feat）
- `rust/maou_usi` 0.27.0 → **0.28.0**（USI オプション追加 = feat）
- `src/` は未変更なので `pyproject.toml` の bump なし

## ドキュメント

`docs/commands/usi.md` の USI options 表に `RootDfpnNodes` を追加。durable doc
なので `reviews/2026-08-12-root-dfpn-nodes-usi-option.md` に監査証跡を残して
います（P2 の standing approval ではなく，**機能追加を明示的に指示された**ことを
承認根拠として本 run で適用した旨を明記）。

## QA

| 項目 | 結果 |
|---|---|
| `cargo test --release -p maou_shogi -- --test-threads=1` | **211 passed** |
| `test_29te`（`--ignored`, release） | canonical **396,516 ノード**のまま = 回帰なし |
| `cargo test -p maou_usi -p maou_search` | **253 passed** |
| `uv run pre-commit run --all-files` | **全 hook Passed** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_