### PR TITLE
perf(usi): dfpn の TT プールを isready で前払いする（N5 候補1）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.13.0"
+version = "5.14.0"
 dependencies = [
  "arrayvec",
  "rustc-hash",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.13.0"
+version = "5.14.0"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/mod.rs
+++ b/rust/maou_shogi/src/dfpn/mod.rs
@@ -35,6 +35,38 @@ pub use api::{
 };
 pub use solver::{DfPnSolver, ProgressSample, SearchReport, StopReason, TsumeResult};
 
+/// 探索より前に TT バッファプールを温める (USI `isready` から呼ぶ想定)．
+///
+/// **なぜ要るか**: TT は `solve` ごとに確保され，`Entry::null()` が全ゼロで
+/// ないため `alloc_zeroed` に落ちず**確保時に全バイトを書く**．そのため
+/// **プロセス最初の探索だけ**が数百 MB 分の first-touch を負担し，
+/// `byoyomi 1000` の初手が予算を超えることがある (実測 0.5〜3.5 秒)．
+/// プール ([`tt`] の `BufferPool`) は 2 回目以降を安くするが，1 回目は救えない．
+///
+/// TensorRT のエンジンビルドを `isready` で前払いするのと同じ理屈で，
+/// ここを `readyok` の前に寄せると初手が定常時と同じ速さになる
+/// (実測: warm なし 1.889s → warm あり 0.502s = 2 手目以降と同値)．
+/// USI は `isready` が長引くことを想定しており，maou_usi 側には
+/// `--keep-alive-ms` の生存通知もある．
+///
+/// # 使い方
+///
+/// **実際に使うノード予算ごとに呼ぶこと．** プールはサイズ別バケットなので，
+/// 予算が違えば別バケットになり温めた分は効かない．USI では攻め方向 root dfpn
+/// (`root_dfpn_nodes`) と，**並行に走る**受け方向 dfpn
+/// (`root_defensive_mate_nodes`) が別サイズで同時に生存するため両方要る．
+///
+/// 冪等 — 2 回目以降はプールから借りて返すだけなので安価．
+pub fn warm_tt_pool(budget_nodes: u64) {
+    // production 既定の floor (DfPnSolver::with_timeout と同じ)．leaf-mate の
+    // 小 TT は per-leaf に作り捨てる規模なので温める価値がない．
+    const DEFAULT_MIN_TT_ENTRIES: usize = 1 << 18;
+    let size = search::tt_entries_for(budget_nodes, DEFAULT_MIN_TT_ENTRIES);
+    // 確保して即 drop する — drop でプールへ戻るので，次の solve は pool hit
+    // になり first-touch を払わない．
+    drop(tt::TranspositionTable::new(size, size));
+}
+
 // sibling module から `super::<name>` で参照するための再エクスポート．
 use heuristics::{init_pn_dn_and, init_pn_dn_or, move_brief_eval};
 use movegen::check_cache::CheckCache;

--- a/rust/maou_shogi/src/dfpn/search/mod.rs
+++ b/rust/maou_shogi/src/dfpn/search/mod.rs
@@ -28,6 +28,25 @@
 pub(crate) mod expansion;
 mod pv;
 
+/// solve 1 回で確保する主 TT の要素数を決める (`TTSIZE` env で上書き可)．
+///
+/// **サイズの元は「どれだけノードを置く見込みか」であって「どこで打ち切るか」
+/// ではない．** 時間でだけ止める用途 (USI `go mate`) は `max_nodes` に
+/// `u64::MAX` を置くしかないので，呼び出し側は
+/// [`super::DfPnSolver::set_tt_nodes_hint`] で切り離せる．
+///
+/// `warm_tt_pool` が**同じ式**を使う必要があるため関数に括り出してある —
+/// ずれると温めたバケットと実際に要求されるバケットが食い違い，
+/// warm が丸ごと無駄になる (プールはサイズ別バケットなので静かに外れる)．
+pub(super) fn tt_entries_for(budget_nodes: u64, min_tt_entries: usize) -> usize {
+    if let Ok(s) = std::env::var("TTSIZE") {
+        return s.parse::<usize>().unwrap_or(1 << 23).max(1 << 12);
+    }
+    // floor は既定 1<<18 (production)．leaf-mate ソルバは min_tt_entries を
+    // 小さくして per-leaf の TT 確保コストを下げる (new_leaf_mate)．
+    ((budget_nodes as usize).saturating_mul(2)).clamp(min_tt_entries, 1 << 23)
+}
+
 use super::heuristics::{check_order_key, evasion_order_key};
 use super::mate_len::{MateLen, DEPTH_MAX_MATE_LEN, ZERO_MATE_LEN};
 use super::movegen::delayed_move_list::DelayedMoveList;
@@ -552,19 +571,10 @@ impl DfPnSolver {
 
         // len-aware TT (local; 再帰へ &mut で渡す)．サイズは budget 比例で確保し，満杯時は
         // GC (maybe_collect_garbage) で低 amount entry を間引く．`TTSIZE` で entry 数を上書き可．
-        let size = if let Ok(s) = std::env::var("TTSIZE") {
-            s.parse::<usize>().unwrap_or(1 << 23).max(1 << 12)
-        } else {
-            // floor は既定 1<<18 (production)．leaf-mate ソルバは min_tt_entries を
-            // 小さくして per-leaf の TT 確保コストを下げる (new_leaf_mate)．
-            //
-            // サイズの元は「どれだけノードを置く見込みか」であって「どこで
-            // 打ち切るか」ではない．時間でだけ止める用途 (USI `go mate`) は
-            // max_nodes に u64::MAX を置くしかないので，そのまま使うと難易度に
-            // 関係なく上限を確保してしまう．set_tt_nodes_hint で切り離せる．
-            let budget = self.tt_nodes_hint.unwrap_or(self.max_nodes);
-            ((budget as usize).saturating_mul(2)).clamp(self.min_tt_entries, 1 << 23)
-        };
+        let size = tt_entries_for(
+            self.tt_nodes_hint.unwrap_or(self.max_nodes),
+            self.min_tt_entries,
+        );
         // 千日手テーブルも固定サイズ (generation GC で bound)．既定は主 TT と同数
         // (24 byte/entry ≒ 主 TT の 37.5% メモリ)．`REPSIZE` で上書き可．
         let rep_size = if let Ok(s) = std::env::var("REPSIZE") {

--- a/rust/maou_shogi/src/dfpn/tt/mod.rs
+++ b/rust/maou_shogi/src/dfpn/tt/mod.rs
@@ -1048,3 +1048,40 @@ mod tests {
         assert_eq!((rb.pn(), rb.dn()), (2, 3));
     }
 }
+
+#[cfg(test)]
+mod warm_tests {
+    use super::regular_pooled_count;
+
+    /// [`crate::dfpn::warm_tt_pool`] が該当サイズのバケットを埋める．
+    ///
+    /// USI `isready` から呼んで初手の first-touch を前払いする機構なので，
+    /// **温めたサイズと実際に要求されるサイズが一致すること**が要 —
+    /// プールはサイズ別バケットなので，式がずれると warm は静かに空振りし
+    /// 初手のコストがそのまま残る (症状が出ないので気づけない)．
+    ///
+    /// プールはプロセス global なので，他テストと衝突しない要素数を選ぶ．
+    #[test]
+    fn test_warm_tt_pool_populates_matching_bucket() {
+        // size = clamp(NODES * 2, 1<<18, 1<<23) = 600_000
+        const NODES: u64 = 300_000;
+        const SIZE: usize = 600_000;
+        assert!(
+            SIZE > (1 << 18) && SIZE < (1 << 23),
+            "clamp に掛からない前提"
+        );
+
+        assert_eq!(
+            regular_pooled_count(SIZE),
+            0,
+            "前提: このサイズはまだプールに無い",
+        );
+
+        crate::dfpn::warm_tt_pool(NODES);
+
+        assert!(
+            regular_pooled_count(SIZE) > 0,
+            "warm 後は同じサイズのバケットがプールに載っていること",
+        );
+    }
+}

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -65,6 +65,27 @@ pub(crate) fn build_evaluator(config: &EngineConfig) -> Result<EngineEvaluator, 
     }
 }
 
+/// dfpn の TT バッファプールを前払いで温める (USI では `isready` 中)．
+///
+/// TT は `solve` ごとに確保され，`Entry::null()` が全ゼロでないため確保時に
+/// 全バイトを書く．そのため**プロセス最初の探索だけ**が数百 MB の first-touch
+/// を負担し，`byoyomi 1000` の初手が予算を超えることがある (実測 0.5〜3.5 秒 —
+/// 実戦なら時間切れのリスク)．評価器の warmup と同じ理屈で `readyok` の前へ
+/// 寄せる (実測: warm なし 1.889s → warm あり 0.502s = 2 手目以降と同値)．
+///
+/// **温めるのは実際に使う予算ごと**．プールはサイズ別バケットなので，予算が
+/// 違えば別バケットになり効かない．攻め方向 root dfpn と受け方向 dfpn は
+/// `search.rs` で**同時に spawn される**ので，どちらも生存しうる — 両方温める．
+/// leaf-mate は 512〜65536 entries と小さく per-leaf に作り捨てるので対象外．
+fn warmup_dfpn_tt(options: &SearchOptions) {
+    if options.root_dfpn {
+        maou_shogi::dfpn::warm_tt_pool(options.root_dfpn_nodes);
+    }
+    if options.defensive_mate {
+        maou_shogi::dfpn::warm_tt_pool(options.root_defensive_mate_nodes);
+    }
+}
+
 /// 平手初期局面を 1 回評価して初回推論の固定費 (TensorRT エンジンビルド/
 /// CUDA 初期化) を前払いする (USI では `isready` 中，自己対局では起動時)．
 pub(crate) fn warmup_evaluator(evaluator: &EngineEvaluator) -> Result<(), String> {
@@ -141,9 +162,11 @@ impl MaouSearchBackend {
     pub fn build(config: &EngineConfig) -> Result<MaouSearchBackend, String> {
         let evaluator = build_evaluator(config)?;
         warmup_evaluator(&evaluator)?;
+        let options = search_options(config);
+        warmup_dfpn_tt(&options);
         Ok(MaouSearchBackend::from_shared(
             Arc::new(evaluator),
-            search_options(config),
+            options,
             config.subtree_reuse,
         ))
     }


### PR DESCRIPTION
N5 の **候補1**（`isready` 前払い）です。3 本のうち最小リスクで、**実戦の事故
（初手の時間切れ）を今日止められる**ものなので先に出します。

## 問題

TT は `solve` ごとに確保され、`Entry::null()` が全ゼロでないため確保時に
**全バイトを書く**。そのため**プロセス最初の探索だけ**が数百 MB の first-touch を
負担し、`byoyomi 1000` の初手が予算を超えていました（実測 0.5〜3.5 秒）。

バッファプール（`37129ba`）は 2 回目以降を安くしますが、**1 回目は救えません**。

## 変更

評価器の warmup / TensorRT のエンジンビルドを `isready` で前払いするのと同じ理屈で、
この固定費も `readyok` の前へ寄せます。`backend.rs` 冒頭が既に「TensorRT の
エンジンビルドも warmup としてここで済ませ、初手の `go` を遅らせない」と書いており、
`--keep-alive-ms` の生存通知もあるので、`isready` が長引くことは想定内です。

- **`maou_shogi`**: `pub fn warm_tt_pool(budget_nodes)` を追加。該当サイズの
  `TranspositionTable` を作って即 drop することでプールに載せる。
- TT サイズ算出を **`tt_entries_for()` に括り出し**、warm と solve が同じ式を使う
  ようにした。**ずれるとバケットが食い違い warm が静かに空振りする**（症状が出ない
  ので気づけない）ため、関数化して同期を強制しています。
- **`maou_usi`**: `build`（= `isready`）が `warmup_dfpn_tt` を呼ぶ。攻め方向
  root dfpn と、`search.rs` で**同時に spawn される**受け方向 dfpn
  (`root_defensive_mate_nodes`) は**別サイズ**なので両方温めます。

## 効果（実測）

`RootDfpnNodes=30,000,000`（TT 704 MB）で効果を増幅して測定:

| | isready | **go#1** | go#2 | go#3 |
|---|---|---|---|---|
| 実装前 | 0.05 s | **1.889 s** | 0.502 s | 0.502 s |
| **実装後** | 0.60 s | **0.503 s** | 0.503 s | 0.502 s |

既定 2,000,000 でも `isready` 0.35 s / **go#1 = 0.503 s = 定常時と同値**（3 回試行）。

**初手の超過が消え、コストは `isready` 側へ移りました。**

## この PR の限界

- ❌ 常駐メモリは減りません（むしろ早く確保して持ち続ける）
- ❌ 貸し出し時の `fill`（N5(b)、既定 352 MB 相当で 0.043 s/探索）は残ります

`fill` まで消すのは**候補3（世代スタンプ）**の仕事です。次に出します。

なお候補3 で `alloc_zeroed` に載れば確保コスト自体が消えるので、本 PR の warm は
その時点で不要になります（害はありませんが、候補3 マージ時に整理を検討します）。

## 候補3 の設計について（先行報告）

調査で、**世代スタンプより簡単な形**が使えることが分かりました。
`NULL_HAND = [0xFF; 7]` なので、**`hand` をビット反転して保持**すれば全ゼロ = null に
なります。判別子 1 つの変更で済み、世代の巻き戻り処理も不要です。
`look_up_parent` が `e.is_null()` を最初に見て `break` する構造も確認済みなので、
ゼロ済みメモリから `pn`/`dn` が読まれる経路はありません（全読み出し箇所の監査は
候補3 の PR で行います）。

## テスト

`test_warm_tt_pool_populates_matching_bucket` を追加。**neuter 検証済み**
（warm のサイズ式を 1 ずらすとバケット不一致で落ちる）。

## バージョン

- `rust/maou_shogi` 5.13.0 → **5.14.0**（公開 API 追加 = feat）
- `rust/maou_usi` 0.28.0 → **0.28.1**（挙動改善のみ = perf）

## QA

| 項目 | 結果 |
|---|---|
| `cargo test --release -p maou_shogi -- --test-threads=1` | **212 passed** |
| `cargo test -p maou_usi -p maou_search` | **253 passed** |
| `cargo fmt --check --all` | clean |
| `uv run pre-commit run --all-files` | **全 hook Passed** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_