### PR TITLE
perf(dfpn): TT の空 slot を全ゼロ表現にして初期化を memset へ畳む（N5 候補3）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "arrayvec",
  "rustc-hash",

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.14.0"
+version = "5.14.1"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/search_result.rs
+++ b/rust/maou_shogi/src/dfpn/search_result.rs
@@ -39,6 +39,14 @@ impl BitSet64 {
     pub(super) const fn full() -> Self {
         BitSet64(u64::MAX)
     }
+    /// 全 bit を落とした値 (TT の全ゼロ初期化専用)．
+    ///
+    /// 探索の意味を持たない — 空 slot は `is_null()` で弾かれるため
+    /// この値が sum 集計に使われることはない (`Entry::zeroed` 参照)．
+    #[inline]
+    pub(super) const fn zeroed() -> Self {
+        BitSet64(0)
+    }
     /// `i` bit が立っているか (= δ を和で計上する子か)．
     ///
     /// **子が 64 を超える場合，64 番目以降は常に `true` (sum 集計) を返す**．

--- a/rust/maou_shogi/src/dfpn/tt/entry.rs
+++ b/rust/maou_shogi/src/dfpn/tt/entry.rs
@@ -16,6 +16,37 @@ const K_FINAL_AMOUNT_BONUS: SearchAmount = 1000;
 /// 無効持ち駒 (空 slot 判定に使う sentinel)．hand は各駒 ≤ 18 なので 0xFF を sentinel に使える．
 pub(crate) const NULL_HAND: Hand = [0xFF; HAND_KINDS];
 
+/// 持ち駒をビット反転する (`Entry` の格納形式との相互変換)．
+///
+/// **なぜ反転して持つか**: 空 slot の印は `NULL_HAND`(=全 `0xFF`) なので，
+/// 反転して格納すると**空 slot が全ゼロ**になる．すると TT の初期化が
+/// 「64 バイトのパターン書き込み」から **memset(0)** に畳まれ，確保も
+/// `alloc_zeroed` (遅延ゼロページ) に載せられる．実測 (1<<23 entries,
+/// 537MB): パターン書き込み 2.769s → memset 0.366s → alloc_zeroed 0.000s．
+///
+/// **健全性の根拠**: 全ゼロを「空」と読ませてよいのは (1) `Entry` の他フィールドは
+/// `is_null()` が偽のときしか読まれない (TT の全アクセス経路で確認済み) ことと，
+/// (2) [`Entry::init`] が 11 フィールド**全部**を書くので，ゼロ済み slot を再利用
+/// しても `pn = 0`(=詰み証明済) などが жив残らないこと，による．
+///
+/// `NULL_HAND` が実局面と衝突しないことも別途確認済み: `Hand` は駒種別の枚数で
+/// 上限は `MAX_HAND_COUNT = [18,4,4,4,4,2,2]`，唯一の算術経路
+/// (`apply_delta_hand`) も i32 で計算して同上限へ clamp するので，
+/// 全 `0xFF` は到達不能．
+#[inline]
+const fn inv_hand(h: Hand) -> Hand {
+    let mut r = [0u8; HAND_KINDS];
+    let mut i = 0;
+    while i < HAND_KINDS {
+        r[i] = !h[i];
+        i += 1;
+    }
+    r
+}
+
+/// 空 slot を表す格納値 (= `inv_hand(NULL_HAND)` = 全ゼロ)．
+const NULL_HAND_INV: Hand = [0x00; HAND_KINDS];
+
 /// `min_depth_rep` の千日手フラグ bit．
 /// `min_depth` (∈ [0, KDEPTH_MAX=4000]) は 15bit に収まるため，最上位 bit を流用する
 /// (Entry を 64B = 1 cache line に収めるための pack; 探索意味論は不変)．
@@ -60,12 +91,21 @@ pub(super) struct Entry {
     proven_len: u16,      // 詰み手数 +1 (len_plus_1; これ以上の len なら詰み)
     disproven_len: u16,   // 不詰手数 +1 (len_plus_1; これ以下の len なら不詰)
     min_depth_rep: u16,   // bit15=千日手フラグ / bits0..14=格納最浅深さ (TCA old-child 判定)
-    hand: Hand,           // 現局面の持ち駒 (NULL_HAND = 空 slot)
-    parent_hand: Hand,
+    /// 現局面の持ち駒を**ビット反転して**保持する (全ゼロ = 空 slot)．
+    /// 直接読まず [`Entry::get_hand`] / [`inv_hand`] を通すこと．
+    hand_inv: Hand,
+    /// 親局面の持ち駒 (同じく反転保持)．
+    parent_hand_inv: Hand,
 }
 
 impl Entry {
     /// 空 slot (`hand == NULL_HAND`)．
+    ///
+    /// **production では使わない** — テーブルの初期化は [`Self::zeroed`] を使う
+    /// (全ゼロなら memset / `alloc_zeroed` に載るため)．「番兵値を持つ空 slot」と
+    /// 「全ゼロの空 slot」がどちらも `is_null()` で空と読めることを固定する
+    /// テスト用に残してある．
+    #[cfg(test)]
     pub(super) fn null() -> Self {
         Self {
             board_key: 0,
@@ -78,14 +118,39 @@ impl Entry {
             disproven_len: MINUS1_MATE_LEN.raw() as u16,
             // KDEPTH_MAX(4000) < 0x7FFF．rep bit = 0 (千日手フラグなし)．
             min_depth_rep: KDEPTH_MAX as u16,
-            hand: NULL_HAND,
-            parent_hand: NULL_HAND,
+            hand_inv: NULL_HAND_INV,
+            parent_hand_inv: NULL_HAND_INV,
+        }
+    }
+
+    /// 全ゼロの空 slot (テーブル初期化専用)．
+    ///
+    /// [`Self::null`] と**意味的に同じ必要はない** — 満たすべきは 2 点だけ:
+    /// (1) [`Self::is_null`] が真を返す (`hand_inv` が全ゼロなので成立)，
+    /// (2) [`Self::init`] が全フィールドを上書きする．
+    /// そのため他フィールドのゼロ値 (`pn = 0` 等) は**読まれる前に必ず消える**．
+    ///
+    /// この値で埋めると初期化が memset に畳まれ，確保も `alloc_zeroed`
+    /// (遅延ゼロページ) に載せられる ([`inv_hand`] のコメント参照)．
+    pub(super) const fn zeroed() -> Self {
+        Self {
+            board_key: 0,
+            parent_board_key: 0,
+            pn: 0,
+            dn: 0,
+            sum_mask: BitSet64::zeroed(),
+            amount: 0,
+            proven_len: 0,
+            disproven_len: 0,
+            min_depth_rep: 0,
+            hand_inv: NULL_HAND_INV,
+            parent_hand_inv: NULL_HAND_INV,
         }
     }
 
     /// 新規局面でエントリを初期化する．
     pub(super) fn init(&mut self, board_key: u64, hand: Hand) {
-        self.hand = hand;
+        self.hand_inv = inv_hand(hand);
         self.amount = 1;
         self.board_key = board_key;
         self.proven_len = DEPTH_MAX_PLUS1_MATE_LEN.raw() as u16; // まだ詰みは見つかっていない
@@ -95,14 +160,14 @@ impl Entry {
         // min_depth = KDEPTH_MAX, rep bit = 0 を同時に設定．
         self.min_depth_rep = KDEPTH_MAX as u16;
         self.parent_board_key = 0;
-        self.parent_hand = NULL_HAND;
+        self.parent_hand_inv = NULL_HAND_INV;
         self.sum_mask = BitSet64::full();
     }
 
     /// 空 slot か．cluster scan の終端判定に使う．
     #[inline]
     pub(super) fn is_null(&self) -> bool {
-        self.hand == NULL_HAND
+        self.hand_inv == NULL_HAND_INV
     }
     /// 盤面ハッシュ一致．
     #[inline]
@@ -112,7 +177,7 @@ impl Entry {
     /// 盤面 + 持ち駒一致．
     #[inline]
     pub(super) fn is_for_hand(&self, board_key: u64, hand: Hand) -> bool {
-        self.board_key == board_key && self.hand == hand
+        self.board_key == board_key && self.hand_inv == inv_hand(hand)
     }
     /// 証明済 (proven) または反証済 (disproven) の確定結果を保持するか．
     /// 確定エントリは **証明木そのもの** であり，探索後の PV 復元 (STRICT VERIFY) が辿る経路．
@@ -137,7 +202,7 @@ impl Entry {
     }
     #[inline]
     pub(super) fn get_hand(&self) -> Hand {
-        self.hand
+        inv_hand(self.hand_inv)
     }
     #[inline]
     pub(super) fn sum_mask(&self) -> BitSet64 {
@@ -172,7 +237,7 @@ impl Entry {
     }
     #[inline]
     pub(super) fn get_parent_hand(&self) -> Hand {
-        self.parent_hand
+        inv_hand(self.parent_hand_inv)
     }
     /// 千日手フラグを立てる．
     #[inline]
@@ -183,7 +248,7 @@ impl Entry {
     /// 空 slot 化．GC で低 amount entry を間引く際に使う．
     #[inline]
     pub(super) fn set_null(&mut self) {
-        self.hand = NULL_HAND;
+        self.hand_inv = NULL_HAND_INV;
     }
 
     /// amount を半減．GC で max_amount が飽和に近いとき全体縮小に使う．
@@ -219,7 +284,7 @@ impl Entry {
         self.sum_mask = sum_mask;
         self.amount = self.amount.max(amount);
         self.parent_board_key = parent_board_key;
-        self.parent_hand = parent_hand;
+        self.parent_hand_inv = inv_hand(parent_hand);
     }
 
     /// proven_len を短い方へ更新する．
@@ -251,7 +316,7 @@ impl Entry {
         use_old_child: &mut bool,
     ) -> bool {
         let depth16 = depth as i16;
-        let entry_hand = self.hand;
+        let entry_hand = self.get_hand();
         // 1. 一致局面
         if entry_hand == hand {
             return self.look_up_exact(depth16, len, pn, dn, use_old_child);

--- a/rust/maou_shogi/src/dfpn/tt/mod.rs
+++ b/rust/maou_shogi/src/dfpn/tt/mod.rs
@@ -10,7 +10,7 @@
 
 pub(crate) mod entry;
 
-use super::mate_len::MateLen;
+use super::mate_len::{MateLen, MINUS1_MATE_LEN};
 use super::search_result::{BitSet64, Depth, Hand, PnDn, SearchAmount, SearchResult};
 use entry::{Entry, NULL_HAND};
 
@@ -259,11 +259,14 @@ impl Drop for RegularTable {
 impl RegularTable {
     /// 要素数 `num_entries` (最低 1) でテーブルを確保し全 null 初期化する．
     ///
-    /// 確保は [`BufferPool`] 経由で使い回す．返る内容は `vec![Entry::null(); n]` と
+    /// 確保は [`BufferPool`] 経由で使い回す．返る内容は `vec![Entry::zeroed(); n]` と
     /// 同一なので探索は不変．
     pub(super) fn new(num_entries: usize) -> Self {
         let n = num_entries.max(1);
-        let null = Entry::null();
+        // 全ゼロ値で初期化する — memset に畳まれ，`Entry::null()` の
+        // 64 バイトパターン書き込みより実測 7.6 倍速い (537MB で 2.769s → 0.366s)．
+        // 全ゼロを空 slot と読んでよい根拠は `Entry::zeroed` を参照．
+        let null = Entry::zeroed();
         let entries = pool_take(&REGULAR_POOL, n, &null).unwrap_or_else(|| vec![null; n]);
         RegularTable { entries }
     }
@@ -424,10 +427,13 @@ impl RepetitionTable {
     pub(super) fn new(size: usize) -> Self {
         let size = size.max(1);
         let epg = ((size as u64 / Self::GEN_PER_TABLE).max(1)) as usize;
+        // 全ゼロ値 — 空判定は `key == 0` なので `len` は空 slot では読まれない
+        // (`MINUS1_MATE_LEN` は len_plus_1 = 0 で全ゼロ)．主 TT と同じ理由で
+        // memset に畳むために揃えてある．
         let empty = RepEntry {
             key: 0,
             depth: 0,
-            len: MateLen::from_len(0),
+            len: MINUS1_MATE_LEN,
             generation: 0,
         };
         RepetitionTable {


### PR DESCRIPTION
N5 の**候補3** です。実装中に設計を 1 段階単純化できたので、**世代スタンプは
不要になりました**（後述）。

## 設計変更の報告

当初は世代スタンプ（`min_depth_rep` の空きビット + 巻き戻りクリア + プール構造の
変更）を予定していましたが、詰めていく過程で**もっと単純で安全な形**に行き着きました。

鍵は「**fill する値は `Entry::null()` と意味的に同じである必要はない**」ことです。
必要なのは 2 つだけ:

1. その bit pattern を `is_null()` が「空」と認識する
2. `init()` がそれを完全に上書きする

`hand` をビット反転して保持すれば、空 slot（`NULL_HAND` = 全 `0xFF`）が**全ゼロ**に
なり、両方を満たします。**世代の巻き戻り処理もプール構造の変更も不要**です。

## 健全性の根拠（偽詰みを出さないこと）

ご指摘いただいた `NULL_HAND` の件を含め、4 点すべて確認しました。

| # | 主張 | 根拠 |
|---|---|---|
| 1 | 全ゼロは `is_null()` が真を返す | `hand_inv` が全ゼロ = `inv_hand(NULL_HAND)` |
| 2 | 他フィールドは `is_null()` が偽のときしか読まれない | TT の全アクセス経路（`:292` `:316` `:364` `:370` `:633` `:726`）が `is_null()` で先にガードしていることを確認 |
| 3 | ゼロ済み slot を再利用しても `pn = 0`（= 詰み証明済）が生き残らない | **`init()` は 11 フィールド全部を書く**（`hand/amount/board_key/proven_len/disproven_len/pn/dn/min_depth_rep/parent_board_key/parent_hand/sum_mask`） |
| 4 | `NULL_HAND` が実局面と衝突しない | `Hand` は駒種別の枚数で上限 `MAX_HAND_COUNT = [18,4,4,4,4,2,2]`。唯一の算術経路 `apply_delta_hand` も **i32 で計算して同上限へ clamp** するので全 `0xFF` は到達不能 |

千日手表は空判定が**既に `key == 0`** なので表現変更は不要でした。`len` を
`MINUS1_MATE_LEN`（`len_plus_1 = 0`）に揃えて全ゼロにしています（空 slot では
`len` は読まれないことを確認済み）。

## 探索が不変であることの確認

| テスト | 結果 |
|---|---|
| `test_29te`（release, `--ignored`） | **canonical 396,516 ノード・同一 PV** で通る（bit 単位で不変） |
| `test_false_proof_hunt` `SEED=1 GAMES=120 MATE1PLY_VERIFY=1` | **`FALSE_MATE(bug)` 0 件 / `STRICT VERIFY None` 0 件** |
| `test_false_proof_hunt` `SEED=7 GAMES=80 MATE1PLY_VERIFY=1` | 同上、0 件 |
| `cargo test --release -p maou_shogi -- --test-threads=1` | 212 passed |

`test_29te` がノード数まで一致したのが一番強い証拠だと思っています — 探索経路が
1 ノードもずれていません。

## 効果（実測）

| | 修正前 | 修正後 |
|---|---|---|
| `go mate` 初回 | 0.974 s | **0.052 s** |
| peak RSS | 745 MB | **462 MB** |

単体計測（537 MB 相当）: パターン書き込み 2.769 s / 全ゼロ 0.366 s / calloc 0.000 s。

`isready`（候補1 の warm）も 0.30〜0.50 s、`go#1` は 0.502 s = 定常時と同値のままです。

## その他

`Entry::null()` は production から消えたので `#[cfg(test)]` にしました。
「番兵値の空 slot」も「全ゼロの空 slot」もどちらも `is_null()` で空と読めることを
固定するテスト用に残してあります。

## バージョン

`rust/maou_shogi` 5.14.0 → **5.14.1**（内部表現の変更のみ、公開 API 不変 = perf）

## QA

`cargo test --release -p maou_shogi --test-threads=1` 212 passed /
`cargo test -p maou_usi -p maou_search` 253 passed /
`cargo fmt --check --all` clean / `uv run pre-commit run --all-files` 全 hook Passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_