### PR TITLE
feat(usi): 詰み証明済だが PV 復元不能な checkmate timeout を info で区別する（N5 候補5）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.28.1"
+version = "0.29.0"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/docs/commands/usi.md
+++ b/docs/commands/usi.md
@@ -45,8 +45,12 @@
   (an illegal scripted move falls back to normal search); and **`go mate`**
   — dfpn mate search for the GUI's mate-search/analysis button, answering
   `checkmate <move sequence>` (shortest mate), `checkmate nomate` (only
-  when no-mate is actually *proven*), or `checkmate timeout` (budget or
-  `stop` reached without a conclusion). It runs on dfpn alone, so it works
+  when no-mate is actually *proven*), or `checkmate timeout`. The last one covers
+  **two different situations** the USI spec cannot distinguish — the budget or
+  `stop` was reached without a conclusion, *or* a mate was proven but its move
+  sequence could not be reconstructed. The second case is preceded by
+  `info string checkmate timeout reason=mate-proven-but-pv-unavailable`, so a
+  genuine solver regression can be told apart from a plain budget overrun. It runs on dfpn alone, so it works
   even without a model, and no `bestmove` is emitted (per the USI spec).
 - For in-process self-play with the same agent, see
   [`maou selfplay`](selfplay.md).

--- a/reviews/2026-08-12-checkmate-timeout-reason.md
+++ b/reviews/2026-08-12-checkmate-timeout-reason.md
@@ -1,6 +1,6 @@
 ---
 status: applied
-applied_in: pending
+applied_in: 9a14b71
 date: 2026-08-12
 target: [docs/commands/usi.md]
 risk: low

--- a/reviews/2026-08-12-checkmate-timeout-reason.md
+++ b/reviews/2026-08-12-checkmate-timeout-reason.md
@@ -1,0 +1,59 @@
+---
+status: applied
+applied_in: pending
+date: 2026-08-12
+target: [docs/commands/usi.md]
+risk: low
+reversibility: trivial
+---
+
+# `checkmate timeout` が 2 つの事象を畳んでいることを doc に書く
+
+## Trigger
+
+`audits/coverage.md` N5(c)．ユーザ指示 (2026-08-12) で N5 の候補5 として実装
+することが決まった．
+
+`rust/maou_usi/src/protocol.rs` は `CheckmateResult::Timeout` と
+「詰みは証明できたが手順を復元できない」(`TsumeResult::CheckmateNoPv` /
+`Checkmate { moves: [] }`) を**すべて** `checkmate timeout` にシリアライズする．
+USI の `checkmate` は `<手順>` / `nomate` / `timeout` の 3 種しか返せないため
+**行そのものは変えられない**が，同じ行に潰れていると外から原因を区別できず，
+真のソルバ回帰を疑ったときの切り分けが実測 50 回超に膨らんだ (本 run の N5 調査)．
+
+## 承認について
+
+CLAUDE.md § MUST rules は durable doc の編集に承認済み `reviews/*.md` を要求する．
+本件は**ユーザが候補5 の実装を明示的に指示している**ため，その指示を承認として
+扱い本 run 内で適用した．P2 の standing approval (drift correction) ではない —
+新しい挙動の記述なのでドリフトではなく，承認の根拠は上記のユーザ指示である．
+
+記述内容は実装から一意に決まる: 出力トークンが 3 種であることは
+`protocol.rs` の `serialize`，`info string` の文言は `agent.rs` の
+`handle_go_stream` (mate 分岐) による．
+
+## Before / After
+
+`docs/commands/usi.md` の `go mate` の説明 (Overview 内)．
+
+```diff
+-  `checkmate nomate` (only
+-  when no-mate is actually *proven*), or `checkmate timeout` (budget or
+-  `stop` reached without a conclusion).
++  `checkmate nomate` (only
++  when no-mate is actually *proven*), or `checkmate timeout`. The last one covers
++  **two different situations** the USI spec cannot distinguish — the budget or
++  `stop` was reached without a conclusion, *or* a mate was proven but its move
++  sequence could not be reconstructed. The second case is preceded by
++  `info string checkmate timeout reason=mate-proven-but-pv-unavailable`, so a
++  genuine solver regression can be told apart from a plain budget overrun.
+```
+
+## 根拠
+
+| 主張 | 根拠 |
+|---|---|
+| 出力は 3 種のみ | USI 規約．`protocol.rs` の `serialize` が `checkmate <手順>` / `nomate` / `timeout` にしか写像しない |
+| 2 事象が同じ行に潰れる | `backend.rs` の `solve_mate` が `Checkmate { moves: [] }` と `CheckmateNoPv` を返す枝 |
+| `info string` の文言 | `agent.rs` の mate 分岐 (`MateWithoutPv` のときだけ emit) |
+| 時間切れには付かない | 回帰テスト `test_mate_without_pv_is_distinguishable_from_timeout` の (b) が固定 |

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -919,9 +919,21 @@ where
             let moves = self.game.moves.clone();
             let stop = Arc::clone(&self.stop);
             let backend = self.backend.as_ref().expect("直前で構築済み");
-            emit(EngineCommand::Checkmate(
-                backend.solve_mate(&sfen, &moves, time_ms, &stop)?,
-            ));
+            let result = backend.solve_mate(&sfen, &moves, time_ms, &stop)?;
+            // USI の `checkmate` は `<手順>` / `nomate` / `timeout` の 3 種しか
+            // 返せないので，「詰みは証明できたが手順を復元できなかった」も
+            // 行としては `timeout` になる．**時間切れとは原因が全く違う**ので，
+            // 区別が要る側 (ログ・回帰調査) には info string で出す．
+            if matches!(result, CheckmateResult::MateWithoutPv) {
+                emit(EngineCommand::Info(Info {
+                    string: Some(
+                        "checkmate timeout reason=mate-proven-but-pv-unavailable                          (not a time budget overrun)"
+                            .to_string(),
+                    ),
+                    ..Info::default()
+                }));
+            }
+            emit(EngineCommand::Checkmate(result));
             return Ok(());
         }
 
@@ -1344,6 +1356,25 @@ mod tests {
     type RulesLog = Rc<RefCell<Vec<GoRules>>>;
 
     #[allow(clippy::type_complexity)] // impl Fn を含むタプル返却は alias 化不能 (TAIT 未安定)
+    /// `solve_mate` の応答を指定して agent を組む (`go mate` テスト用)．
+    #[allow(clippy::type_complexity)]
+    fn agent_with_mate(
+        mate: CheckmateResult,
+    ) -> Agent<FakeBackend, impl Fn(&EngineConfig) -> Result<FakeBackend, String>> {
+        let calls: Calls = Rc::new(RefCell::new(Vec::new()));
+        let rules: RulesLog = Rc::new(RefCell::new(Vec::new()));
+        let outcome = default_outcome();
+        Agent::new(EngineConfig::default(), move |_config| {
+            Ok(FakeBackend {
+                calls: Rc::clone(&calls),
+                rules_log: Rc::clone(&rules),
+                outcome: outcome.clone(),
+                nyugyoku: false,
+                mate: mate.clone(),
+            })
+        })
+    }
+
     fn agent_with_fake(
         outcome: SearchOutcome,
     ) -> (
@@ -1624,6 +1655,56 @@ mod tests {
             })
             .unwrap();
         assert_eq!(agent.config.root_dfpn_nodes, Some(1));
+    }
+
+    /// 「詰みは解けたが手順を復元できない」を時間切れと区別できること．
+    ///
+    /// USI の行は規約どおり `checkmate timeout` のままだが，直前に理由を
+    /// `info string` で出す．これが無いと，真のソルバ回帰と偽陽性 (時間切れ) が
+    /// 外から区別できず，切り分けに実測 50 回超を要した (2026-08-12)．
+    #[test]
+    fn test_mate_without_pv_is_distinguishable_from_timeout() {
+        // (a) PV 復元不能: info string が先に出て，行は checkmate timeout
+        let mut agent = agent_with_mate(CheckmateResult::MateWithoutPv);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent
+            .handle(GuiCommand::Go(GoParams {
+                mate: Some(crate::protocol::MateLimit::TimeMs(1000)),
+                ..GoParams::default()
+            }))
+            .unwrap();
+        let lines: Vec<String> = out.iter().map(crate::protocol::serialize).collect();
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("mate-proven-but-pv-unavailable")),
+            "理由が info string に出ること: {lines:?}",
+        );
+        assert!(
+            lines.iter().any(|l| l == "checkmate timeout"),
+            "行そのものは規約どおり: {lines:?}",
+        );
+
+        // (b) 本物の時間切れ: 同じ行だが理由 info は出ない
+        let mut agent = agent_with_mate(CheckmateResult::Timeout);
+        agent.handle(GuiCommand::IsReady).unwrap();
+        let out = agent
+            .handle(GuiCommand::Go(GoParams {
+                mate: Some(crate::protocol::MateLimit::TimeMs(1000)),
+                ..GoParams::default()
+            }))
+            .unwrap();
+        let lines: Vec<String> = out.iter().map(crate::protocol::serialize).collect();
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.contains("mate-proven-but-pv-unavailable")),
+            "時間切れに理由 info を付けてはならない: {lines:?}",
+        );
+        assert!(
+            lines.iter().any(|l| l == "checkmate timeout"),
+            "行そのものは同じ: {lines:?}",
+        );
     }
 
     #[test]

--- a/rust/maou_usi/src/backend.rs
+++ b/rust/maou_usi/src/backend.rs
@@ -321,10 +321,11 @@ impl SearchBackend for MaouSearchBackend {
             TsumeResult::Checkmate { ref moves, .. } if !moves.is_empty() => {
                 CheckmateResult::Mate(moves.iter().map(|m| m.to_usi()).collect())
             }
-            // 詰みだが手順を復元できない場合は手順を示せないので timeout 扱い
-            // (誤った `checkmate` 行を出さない)
+            // 詰みだが手順を復元できない．行は規約上 `checkmate timeout` に
+            // なるが，**時間切れとは原因が違う**ので別変種で返す
+            // (agent が info string で理由を出す)．
             TsumeResult::Checkmate { .. } | TsumeResult::CheckmateNoPv { .. } => {
-                CheckmateResult::Timeout
+                CheckmateResult::MateWithoutPv
             }
             TsumeResult::NoCheckmate { .. }
                 if report.stop_reason == maou_shogi::dfpn::StopReason::Disproven =>

--- a/rust/maou_usi/src/protocol.rs
+++ b/rust/maou_usi/src/protocol.rs
@@ -359,6 +359,16 @@ pub enum CheckmateResult {
     NoMate,
     /// 予算内に結論が出なかった (詰みとも不詰とも言えない)．
     Timeout,
+    /// **詰みは証明できたが手順を復元できなかった**．
+    ///
+    /// USI の `checkmate` は `<手順>` / `nomate` / `timeout` の 3 種しか返せず，
+    /// 手順を示せない以上 `timeout` を出すしかない — が，**時間切れとは原因が
+    /// 全く違う**．同じ行に潰れていると「ソルバが解けなかった」のか
+    /// 「解けたが PV 復元に失敗した」のか外から区別できず，真の回帰を疑った
+    /// ときの切り分けが実測 50 回超に膨らんだ (2026-08-12)．
+    /// 行そのものは規約どおり `checkmate timeout` にしつつ，agent が直前に
+    /// `info string` で理由を出す．
+    MateWithoutPv,
 }
 
 /// コマンドを USI の行 (改行なし) へシリアライズする．
@@ -392,7 +402,11 @@ pub fn serialize(cmd: &EngineCommand) -> String {
             CheckmateResult::Mate(moves) if !moves.is_empty() => {
                 format!("checkmate {}", moves.join(" "))
             }
-            CheckmateResult::Mate(_) | CheckmateResult::Timeout => "checkmate timeout".to_string(),
+            // 手順なしの詰み / PV 復元不能 / 時間切れ はいずれも規約上
+            // `checkmate timeout` にしか写像できない (理由は info string で出す)．
+            CheckmateResult::Mate(_)
+            | CheckmateResult::Timeout
+            | CheckmateResult::MateWithoutPv => "checkmate timeout".to_string(),
             CheckmateResult::NoMate => "checkmate nomate".to_string(),
         },
     }


### PR DESCRIPTION
N5 の**候補5**（最後の 1 本）です。

## 問題

`protocol.rs` は `CheckmateResult::Timeout` と「**詰みは証明できたが手順を復元
できない**」（`TsumeResult::CheckmateNoPv` / `Checkmate { moves: [] }`）を
**すべて** `checkmate timeout` にシリアライズしていました。

USI の `checkmate` は `<手順>` / `nomate` / `timeout` の 3 種しか返せないので
**行そのものは変えられません**。しかし同じ行に潰れていると外から原因を区別できず、
真のソルバ回帰を疑ったときの切り分けコストが跳ね上がります。実際、本 run の N5 調査は
**まさにこれを踏んで実測 50 回超**を要しました（`go mate 5000` の反復、CPU 負荷、
コマンド順序、ビルドプロファイル…と順に潰していく必要があった）。

## 変更

- `CheckmateResult` に **`MateWithoutPv`** を追加。**シリアライズは規約どおり
  `checkmate timeout` のまま**
- `backend.rs` の `solve_mate` が手順を示せない詰みをこの変種で返す
- `agent.rs` が `MateWithoutPv` のときだけ直前に
  `info string checkmate timeout reason=mate-proven-but-pv-unavailable` を出す。
  **本物の時間切れには付けない**

GUI から見た挙動は変わりません（`checkmate timeout` は同じ行）。増えるのは
`info string` だけで、USI では任意タイミングで出してよいものです。

## テスト

`test_mate_without_pv_is_distinguishable_from_timeout` が**両方向**を固定:

- (a) PV 復元不能 → 理由 `info string` が出て、行は `checkmate timeout`
- (b) 本物の時間切れ → **理由 info は出ず**、行は同じ

**neuter 検証済み**（`MateWithoutPv` を `Timeout` に戻すとこのテストだけが落ちる）。

## ドキュメント

`docs/commands/usi.md` の `go mate` の説明を更新し、「`checkmate timeout` は
2 つの異なる事象を覆っており、後者には `info string` が先行する」ことを明記。
durable doc なので `reviews/2026-08-12-checkmate-timeout-reason.md` に監査証跡を
残しています（機能追加を明示的に指示されたことを承認根拠として本 run で適用した旨を明記）。

## バージョン

`rust/maou_usi` 0.28.1 → **0.29.0**（`CheckmateResult` に変種追加 = feat）

## QA

`cargo test -p maou_usi -p maou_search` **254 passed** /
`cargo fmt --check --all` clean / `uv run pre-commit run --all-files` 全 hook Passed

---

これで N5 の候補1・3・5 が揃います。マージ後に ledger を整理し、消化分と
残り（既定 `RootDfpnNodes` の是非＝候補2、これは「下げない」判断で保留）を
反映します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1XyJJwszfDBmpujgVu73j)_