### PR TITLE
fix: backlog の自動帯 (P1/P3) を消化する — cargo fmt hook・到達不能分岐・全列実体化

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,24 @@ repos:
 #  E402 抑止が 0.15.2 側で 9 件のエラーとして再燃した)．
 # local hook には rev が無いため `pre-commit autoupdate` の対象外になり，
 # ruff の版上げは pyproject.toml の編集としてのみ起きる (差分が見える)．
+# rustfmt も ruff と同じ理由で local hook にする．
+# hook 側が独自に Rust toolchain を入れると rust-toolchain の版と
+# 二重化し，ローカルの `cargo fmt` と pre-commit の結果が食い違う．
+# local hook には rev が無いので `pre-commit autoupdate` の対象外になり，
+# 版上げは toolchain の更新としてのみ起きる．
+# `--check` ではなく自動整形にするのは Python 側の ruff-format に揃えるため
+# (未整形を残すと，無関係な PR に整形差分が混ざる)．
+# `cargo fmt` はファイル引数ではなく crate 単位で動くので
+# pass_filenames: false が必須．
+- repo: local
+  hooks:
+  - id: cargo-fmt
+    name: cargo-fmt
+    entry: cargo fmt --all
+    language: system
+    types_or: [rust]
+    pass_filenames: false
+    require_serial: true
 - repo: local
   hooks:
   - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.86.2"
+version = "0.86.3"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/infra/file_system/file_data_source.py
+++ b/src/maou/infra/file_system/file_data_source.py
@@ -208,16 +208,10 @@ class FileDataSource(
         class _FileEntry:
             name: str
             path: Path
-            dtype: np.dtype[
-                Any
-            ]  # Placeholder (not used for DataFrames)
             length: int
-            memmap: (
-                Any | None
-            )  # Placeholder (not used for DataFrames)
             cached_array: (
                 Any | None
-            )  # Can be DataFrame or ndarray
+            )  # ndarray (hcpe) or None (columnar)
             cached_columnar: ColumnarBatch | None = (
                 None  # SOA representation
             )
@@ -247,7 +241,6 @@ class FileDataSource(
             )
             t_init_start = time.perf_counter()
             self.array_type = array_type
-            self.bit_pack = bit_pack
             normalized_cache_mode = cast(
                 FileDataSource.CacheMode, cache_mode.lower()
             )
@@ -256,17 +249,12 @@ class FileDataSource(
                     "cache_mode must be either 'file' or 'memory', "
                     f"got {cache_mode}"
                 )
-            self.memmap_arrays: list[
-                tuple[str, Any]
-            ] = []  # Unused (DataFrames only)
             self._file_entries: list[
                 FileDataSource.FileManager._FileEntry
             ] = []
             self.cache_mode: FileDataSource.CacheMode = (
                 normalized_cache_mode
             )
-            # 最適化: 最後にアクセスしたファイルインデックスをキャッシュ
-            self._last_file_idx = 0
             # 最適化: cache_mode="memory"の場合，全ファイルを結合した単一配列
             self._concatenated_array: np.ndarray | None = None
             self._concatenated_columnar: (
@@ -354,9 +342,7 @@ class FileDataSource(
                         entry = FileDataSource.FileManager._FileEntry(
                             name=file_path.name,
                             path=file_path,
-                            dtype=np.dtype("uint8"),
                             length=array_length,
-                            memmap=None,
                             cached_array=None,
                             cached_columnar=converted,
                         )
@@ -364,9 +350,7 @@ class FileDataSource(
                         entry = FileDataSource.FileManager._FileEntry(
                             name=file_path.name,
                             path=file_path,
-                            dtype=converted.dtype,
                             length=array_length,
-                            memmap=None,
                             cached_array=converted,
                         )
                     self._file_entries.append(entry)
@@ -875,43 +859,41 @@ class FileDataSource(
             tuple[str, pl.DataFrame]: (batch_name, polars_dataframe)
         """
         try:
-            import polars as pl
+            import polars  # noqa: F401
         except ImportError:
             raise ImportError(
                 "polars is required for DataFrame iteration. "
                 "Install with: uv add polars"
             )
 
-        # Iterate over entries (all are .feather files)
+        # `_FileEntry.cached_array` は structured ndarray (hcpe) か
+        # None (columnar) のいずれかで，DataFrame が入ることはない．
+        # 以前ここにあった `isinstance(cached_array, pl.DataFrame)` 分岐は
+        # 到達不能で，常に下の再読込へ落ちていた (docstring が述べる挙動)．
         for entry in self.__file_manager._file_entries:
-            # DataFrame already loaded and cached
-            if isinstance(entry.cached_array, pl.DataFrame):
-                yield entry.name, entry.cached_array
-            else:
-                # Load DataFrame if not cached
-                from maou.interface.data_io import (
-                    load_hcpe_df,
-                    load_preprocessing_df,
-                    load_stage1_df,
-                    load_stage2_df,
-                )
+            from maou.interface.data_io import (
+                load_hcpe_df,
+                load_preprocessing_df,
+                load_stage1_df,
+                load_stage2_df,
+            )
 
-                if self.__file_manager.array_type == "hcpe":
-                    df = load_hcpe_df(entry.path)
-                elif (
-                    self.__file_manager.array_type
-                    == "preprocessing"
-                ):
-                    df = load_preprocessing_df(entry.path)
-                elif self.__file_manager.array_type == "stage1":
-                    df = load_stage1_df(entry.path)
-                elif self.__file_manager.array_type == "stage2":
-                    df = load_stage2_df(entry.path)
-                else:
-                    raise ValueError(
-                        f"Unsupported array_type: {self.__file_manager.array_type}"
-                    )
-                yield entry.name, df
+            if self.__file_manager.array_type == "hcpe":
+                df = load_hcpe_df(entry.path)
+            elif (
+                self.__file_manager.array_type
+                == "preprocessing"
+            ):
+                df = load_preprocessing_df(entry.path)
+            elif self.__file_manager.array_type == "stage1":
+                df = load_stage1_df(entry.path)
+            elif self.__file_manager.array_type == "stage2":
+                df = load_stage2_df(entry.path)
+            else:
+                raise ValueError(
+                    f"Unsupported array_type: {self.__file_manager.array_type}"
+                )
+            yield entry.name, df
 
     def total_pages(self) -> int:
         """Return the total number of pages (batches) in the data source."""

--- a/src/maou/interface/preprocess.py
+++ b/src/maou/interface/preprocess.py
@@ -179,7 +179,16 @@ def resize_input_files(
         try:
             import polars as pl
 
-            row_count = len(pl.scan_ipc(fp).collect())
+            # 行数だけが要るので全列を実体化しない．
+            # preprocessing の 1496 幅リスト列では
+            # `len(scan_ipc(fp).collect())` がファイル1本を丸ごと
+            # メモリに載せる (Stream 形式で例外になる挙動は同じ)．
+            row_count = (
+                pl.scan_ipc(fp)
+                .select(pl.len())
+                .collect()
+                .item()
+            )
         except Exception:
             ok_files.append(fp)
             continue

--- a/tests/maou/domain/data/test_split_feather.py
+++ b/tests/maou/domain/data/test_split_feather.py
@@ -498,3 +498,82 @@ class TestResizeInputFiles:
         )
 
         assert result == []
+
+
+class TestResizeInputFilesRowCounting:
+    """`resize_input_files` の行数判定に関する回帰テスト．"""
+
+    def test_unreadable_file_passes_through_unchunked(
+        self, tmp_path: Path
+    ) -> None:
+        """行数を読めないファイルは束ねずにそのまま通す．
+
+        回帰の罠: 行数取得を `len(scan_ipc(fp).collect())` から
+        `scan_ipc(fp).select(pl.len())` へ替える際，Stream 形式
+        (`scan_ipc` が扱えない) のファイルで例外が出なくなると，
+        これまで `ok_files` へ素通ししていたファイルが「小さい」と
+        判定されて束ねられ，出力ファイルの構成が変わる．
+        両式が同じく送出することを固定する．
+        """
+        import io
+
+        from maou.interface.preprocess import (
+            resize_input_files,
+        )
+
+        input_dir = tmp_path / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+        work_dir = tmp_path / "work"
+
+        # Stream 形式は scan_ipc で読めない (拡張子は .feather)．
+        stream_df = create_empty_hcpe_df(2)
+        buf = io.BytesIO()
+        stream_df.write_ipc_stream(buf)
+        stream_path = input_dir / "stream.feather"
+        stream_path.write_bytes(buf.getvalue())
+
+        # 束ねる相手を 1 本用意する．これが無いと small_files が
+        # 1 本以下になり，誤判定しても結果が変わらず素通りする．
+        readable = _create_hcpe_file(
+            input_dir, "small.feather", 5
+        )
+
+        result = resize_input_files(
+            file_paths=[stream_path, readable],
+            rows_per_file=100,
+            work_dir=work_dir,
+        )
+
+        # stream は 2 行 < threshold(50) だが行数を読めないので
+        # small_files に入らず，そのままのパスで返る．
+        # readable だけでは small_files が 1 本なのでこれも束ねられない．
+        assert stream_path in result
+        assert result == [stream_path, readable]
+
+    def test_small_files_are_still_chunked(
+        self, tmp_path: Path
+    ) -> None:
+        """読めるファイルの「小さい」判定は従来どおり効く．"""
+        from maou.interface.preprocess import (
+            resize_input_files,
+        )
+
+        input_dir = tmp_path / "input"
+        work_dir = tmp_path / "work"
+
+        fps = [
+            _create_hcpe_file(
+                input_dir, f"small_{i}.feather", 5
+            )
+            for i in range(3)
+        ]
+
+        result = resize_input_files(
+            file_paths=fps,
+            rows_per_file=100,
+            work_dir=work_dir,
+        )
+
+        # 5 行 < threshold(50) なので 3 本が 1 本に束ねられる．
+        assert len(result) == 1
+        assert sum(len(load_hcpe_df(p)) for p in result) == 15

--- a/tests/maou/infra/file_system/test_file_data_source.py
+++ b/tests/maou/infra/file_system/test_file_data_source.py
@@ -506,3 +506,64 @@ def test_load_failure_propagates_other_errors_unchanged(
             file_paths=file_paths,
             array_type="hcpe",
         )
+
+
+def test_iter_batches_df_yields_every_file_in_full(
+    tmp_path: Path,
+) -> None:
+    """`iter_batches_df` は全ファイルを完全な DataFrame として返す．
+
+    回帰の罠: ここには以前 `isinstance(entry.cached_array,
+    pl.DataFrame)` の分岐があった．`cached_array` は structured
+    ndarray (hcpe) か None (columnar) にしかならないので分岐は
+    到達不能で，常に下のディスク再読込へ落ちていた．
+    「キャッシュを返す」側を生かす方向へ直すと，columnar では
+    None が，hcpe では ndarray が yield され，戻り値の型が壊れる．
+    このテストは *再読込した DataFrame* が返ることを固定する．
+    """
+    file_paths, expected_dfs = _create_hcpe_files(
+        tmp_path, file_count=3, rows_per_file=4
+    )
+
+    datasource = FileDataSource(
+        file_paths=file_paths,
+        array_type="hcpe",
+    )
+
+    yielded = list(datasource.iter_batches_df())
+
+    assert [name for name, _ in yielded] == [
+        p.name for p in file_paths
+    ]
+    for (_, df), expected in zip(yielded, expected_dfs):
+        assert isinstance(df, pl.DataFrame)
+        assert len(df) == len(expected)
+        assert df["id"].to_list() == expected["id"].to_list()
+        assert (
+            df["eval"].to_list() == expected["eval"].to_list()
+        )
+
+
+def test_iter_batches_df_yields_dataframes_for_columnar_types(
+    tmp_path: Path,
+) -> None:
+    """columnar 系 (preprocessing) でも DataFrame が返る．
+
+    columnar 経路では `cached_array` が常に None なので，
+    到達不能分岐を生かす修正をするとここが None を yield する．
+    """
+    file_paths, expected_dfs = _create_preprocessing_files(
+        tmp_path, file_count=2, rows_per_file=3
+    )
+
+    datasource = FileDataSource(
+        file_paths=file_paths,
+        array_type="preprocessing",
+    )
+
+    yielded = list(datasource.iter_batches_df())
+
+    assert len(yielded) == 2
+    for (_, df), expected in zip(yielded, expected_dfs):
+        assert isinstance(df, pl.DataFrame)
+        assert df["id"].to_list() == expected["id"].to_list()


### PR DESCRIPTION
`/audit-backlog` の自動帯 (判断コスト P1/P3) の消化．
ユーザ判断を要する項目は含まない．

> **クラス毎 PR の collapse について**: このセッションは開発ブランチが
> `claude/audit-backlog-pxai5v` 1 本に固定されているため，P1 と P3 を
> 1 PR にまとめている．両者とも自動帯 (無停止マージ) で **merge policy が
> 同一**なので，クラス境界はコミット単位で保っている
> (`195bafa` = P1 / `cb4a78e` = P3)．

## Stack (2026-08-12 /audit-backlog)

1. **このPR** P1+P3 自動帯 (base: `main`, independent)
2. 判断帯 (P4) — このPRのマージ後に同じブランチを `main` から切り直して別PRで出す

---

## `195bafa` — P1: pre-commit に `cargo fmt` の local hook を追加

- **backlog 行**: out-of-scope N6 ([2026-08-12 backlog auto-band-and-p4](https://github.com/dousu/maou/blob/main/audits/2026-08-12-backlog-auto-band-and-p4.md))
- **クラス判定**: 出荷ファイルに触れない (`.pre-commit-config.yaml` のみ) → **P1**．バージョン bump 不要．
- **G4 の解除**: 行は判断点を 3 つ挙げていた．再検証で 2 つが解消し，1 つは切り離した．
  - (a) `--check` か自動整形か → 行自身が「Python 側 (`ruff-format`) は自動整形なので揃えるなら後者」と書いており，一意に決まる．**自動整形**を採用．
  - (c) `pass_filenames: false` は `cargo fmt` が crate 単位で動くことによる技術的要請で，判断ではない．
  - (b) `cargo clippy` を同時に入れるか → **入れない**．別のツールの別の初回コストで，N6 の「やること」(fmt hook) の外．backlog に新規行として残した．
- **検証**: `pre-commit run cargo-fmt --all-files` → Passed．未整形の `.rs` を仕込むと Failed して自動整形することを確認 (hook が空振りしていないことの確認)．`cargo fmt --all -- --check` は HEAD 時点で既に clean (PR #464) なので，この PR に整形差分は出ない．

## `cb4a78e` — P3: 到達不能な分岐と未読の状態，行数取得の全列実体化

- **backlog 行**: deferred D6+D7，out-of-scope O8 (前半) ([2026-08-10 infra/file_system](https://github.com/dousu/maou/blob/main/audits/2026-08-10-src-maou-infra-file-system.md))
- **クラス判定**: **P3** — 受け付ける入力に対し，書き出す成果物と返す値は不変．差が出るのはメモリと診断のみ．公開シグネチャは変えていない (`bit_pack` 引数は後方互換のため残置)．

| 変更 | 中身 |
|---|---|
| D6 | `_FileEntry.dtype` / `.memmap` を削除 (どこからも読まれず，columnar 分岐では `np.dtype("uint8")` という嘘の値が入っていた)．`FileManager.memmap_arrays` / `_last_file_idx` / `bit_pack` も未読なので削除 |
| D7 | `iter_batches_df` の `isinstance(entry.cached_array, pl.DataFrame)` は到達不能 (`cached_array` は ndarray か None)．**分岐だけを消し，再読込は残す** — docstring が述べるとおりの挙動 |
| O8 前半 | `len(pl.scan_ipc(fp).collect())` → `select(pl.len())`．1496 幅リスト列の preprocessing でファイル 1 本が丸ごとメモリに載っていた |

### 記録の見立てと違えた点

D7 の「キャッシュ側を生かす」向きの修正は**戻り値の型を壊す**．columnar では `None`，hcpe では ndarray が yield され，`Generator[tuple[str, pl.DataFrame]]` の契約が破れる．そのため分岐の削除に留めた．回帰テストはこの罠を固定している (誤った修正で落ちることを確認済み)．

O8 の `select(pl.len())` 化は，Stream 形式で `ComputeError` になる挙動が旧式と**同一**であることを実測で確認したうえで入れている (差があれば「小さいファイル」の判定が変わり P3 ではなくなる)．裸の `except Exception` が Stream 形式を握り潰す件は **O8 後半として backlog に残す** (振る舞いが変わるので判断帯)．

### 回帰テスト (いずれも非空振りを確認)

| テスト | 固定している罠 |
|---|---|
| `test_iter_batches_df_yields_every_file_in_full` | キャッシュを yield する誤修正で落ちる |
| `test_iter_batches_df_yields_dataframes_for_columnar_types` | columnar で `None` が yield されると落ちる |
| `test_unreadable_file_passes_through_unchunked` | Stream を「小さい」と誤判定すると merge が落ちる．**束ねる相手を 1 本置いてある** — 相手が無いと `small_files` が 1 本以下になり，誤判定しても結果が変わらず素通りする |
| `test_small_files_are_still_chunked` | 読めるファイルの「小さい」判定が従来どおり効くことの characterization |

## QA (このコンテナで実行済み)

- `uv run ruff format src/ tests/` / `uv run ruff check src/ tests/ --fix` → All checks passed
- `uv run mypy src/ tests/` → Success: no issues found in 290 source files
- `uv run pytest tests/maou/infra/file_system/ tests/maou/domain/data/test_split_feather.py tests/maou/interface/` → **331 passed**
- pre-commit (full `pytest -v -s` を含む) が両コミットで通過

> **環境メモ (N4 の裏取り)**: `test_file_data_source.py` は torch 未導入だとモジュールごと skip される (base 環境で 57 passed + 3 skipped，`uv sync --extra cpu` で 90 passed)．`file_data_source.py` の唯一のテストなので，この PR の QA のために CPU extra を入れてから実行している．入れずに回すと本 PR の変更は**無検証**で緑に見える (backlog 行 N4 として残置)．

## バージョン

`pyproject.toml` 0.86.2 → **0.86.3** (`fix:` → patch)．P1 コミットは出荷ファイルに触れないので bump 対象外．

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxiTWr29hNVeyegg8LuJMf)_