### PR TITLE
fix: --test-ratio 未指定時の既定値を層で一致させる (backlog N1 / P4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maou"
-version = "0.86.3"
+version = "0.86.4"
 description = "Shogi AI"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}

--- a/src/maou/infra/console/learn_model.py
+++ b/src/maou/infra/console/learn_model.py
@@ -884,7 +884,7 @@ def learn_model(
                 effective_ratio = (
                     test_ratio
                     if test_ratio is not None
-                    else 0.1
+                    else learn.DEFAULT_TEST_RATIO
                 )
                 n_val = max(
                     1, int(len(shuffled) * effective_ratio)

--- a/src/maou/interface/learn.py
+++ b/src/maou/interface/learn.py
@@ -46,6 +46,13 @@ from maou.app.learning.streaming_dataset import (
 
 SUPPORTED_MODEL_ARCHITECTURES = BACKBONE_ARCHITECTURES
 
+# ``--test-ratio`` 未指定時の検証割合．
+# 行単位分割 (この層) と Stage 3 のファイル単位分割
+# (`infra/console/learn_model.py`) の両方がこれを引く．
+# 層ごとに直値を置くと `--no-streaming` に切り替えた瞬間に
+# 検証割合が黙って変わるので，定数を 1 つに寄せてある．
+DEFAULT_TEST_RATIO = 0.2
+
 
 @dataclass(frozen=True)
 class StageDataConfig:
@@ -303,9 +310,9 @@ def learn(
             f"got {model_architecture}"
         )
 
-    # テスト割合設定 (デフォルト0.2)
+    # テスト割合設定 (デフォルトは DEFAULT_TEST_RATIO)
     if test_ratio is None:
-        test_ratio = 0.2
+        test_ratio = DEFAULT_TEST_RATIO
     elif not 0.0 < test_ratio < 1.0:
         raise ValueError(
             f"test_ratio must be between 0 and 1, got {test_ratio}"

--- a/tests/maou/interface/test_test_ratio_defaults.py
+++ b/tests/maou/interface/test_test_ratio_defaults.py
@@ -101,3 +101,57 @@ def test_no_falsy_or_default_on_ratio_arguments() -> None:
         "`test_ratio or DEFAULT` silently rewrites 0.0:\n"
         + "\n".join(offenders)
     )
+
+
+def test_default_test_ratio_matches_documented_value() -> None:
+    """``--test-ratio`` の既定値が doc の値と一致すること．
+
+    `docs/commands/learn_model.md` は ``interface default 0.2`` と
+    明記している．定数を動かすと doc が黙って嘘になるので固定する．
+    """
+    assert learn_interface.DEFAULT_TEST_RATIO == 0.2
+
+
+def test_stage3_file_split_uses_the_shared_default() -> None:
+    """Stage 3 のファイル単位分割が直値の既定を持たないこと．
+
+    `/audit-backlog` 2026-08-12 / backlog 行 N1．
+
+    console 側は ``--test-ratio`` 未指定時に 0.1，interface 側は 0.2 を
+    使っていた．streaming 経路では分割済みソースを console が作るので
+    interface 側の値は使われず，``--no-streaming`` に切り替えた瞬間に
+    検証割合が 10% から 20% へ黙って変わる．
+
+    値ベースで固定できない: この分岐は S3/GCS の streaming 経路の
+    奥にあり，到達させるにはクラウド資格情報が要る．そこで
+    「既定を引く側が共有定数を参照していること」をソースで固定する
+    (同ファイルの `test_no_falsy_or_default_on_ratio_arguments` と
+    同じ方針)．
+    """
+    from maou.infra.console import learn_model
+
+    source = inspect.getsource(learn_model)
+    lines = source.splitlines()
+
+    offenders: list[str] = []
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        # `test_ratio if test_ratio is not None else <直値>` の
+        # else 側に数値が直接置かれていないこと．
+        if stripped.startswith("else ") and any(
+            "test_ratio is not None" in prev.strip()
+            for prev in lines[max(0, lineno - 3) : lineno]
+        ):
+            tail = stripped[len("else ") :].strip()
+            if tail and tail[0].isdigit():
+                offenders.append(
+                    f"learn_model:{lineno}: {stripped}"
+                )
+
+    assert not offenders, (
+        "Stage 3 の分割が interface と別の既定値を持っている "
+        "(learn.DEFAULT_TEST_RATIO を参照すること):\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## 決めていただきたいこと

**`--test-ratio` を指定しない Stage 3 の streaming 学習で，検証に回るファイルが 10% から 20% へ増えます．** これを受け入れるかどうかがこの PR です．

- **今どうなっているか**: console 側 (`learn_model.py:887`) が Stage 3 のファイル単位分割で **0.1**，interface 側 (`learn.py:308`) が行単位分割で **0.2** を使っていました．streaming 経路では分割済みソースを console が作るので interface 側の値は使われず，**`--no-streaming` に切り替えた瞬間に検証割合が 10% → 20% へ黙って変わります**．どちらが「既定」なのか，コードだけからは決まりません．
- **この PR がとった向き**: **0.2 に寄せる**．`docs/commands/learn_model.md` の `--test-ratio` 行が `interface default 0.2` と明記しており，**doc に書かれている側を契約とみなしました**．結果としてこの doc は両経路について正しくなります (doc の編集は不要です)．
- **もう一方の選択肢**: console の 0.1 に寄せる．こちらは「実際に多くの利用者が踏んでいる既定値は 0.1 (streaming が主経路のため)」という理由づけになります．**この向きを選ぶ場合は doc の修正が必要**です — その場合は `reviews/` 提案が要るので，このPRにコメントいただければ差し替えます．
- **互換性**: 破壊はありません．既存の成果物は読めるまま，既存のコマンドラインも有効なままです．変わるのは `--test-ratio` を**渡していない** streaming Stage 3 の分割比だけで，明示指定している場合は無変化です．

**クラス判定**: **P4** — 観測可能な振る舞いが変わるが，既存データは読めたままで既存の呼び出しも有効なまま．P5 ではない (スキーマ・dtype・ファイル配置は不変)．P6 でもない (CLI オプションの意味も公開 API のシグネチャも変えていない)．

**なぜ質問ではなく PR か**: 判断の分岐は「0.1 か 0.2 か」の定数 1 つで，どちらを選んでも diff の形は同じです (`/audit-backlog` の split test — 分岐が実質的に異なる diff を生むときだけ中断して聞く — に当たらない)．推奨する側を実装し，もう一方をこの本文に書いてあります．

## Stack (2026-08-12 /audit-backlog)

1. #474 P1+P3 自動帯 — **merged** (`f4eb9a0`)
2. **このPR** P4 判断帯 (base: `main`, independent — #474 とファイルの重なりなし)
3. P1 台帳 + 記録 — 別PRで後続 (このPRには積まない)

## 変更

- **backlog 行**: out-of-scope N1 ([2026-08-12 backlog auto-band-and-p4](https://github.com/dousu/maou/blob/main/audits/2026-08-12-backlog-auto-band-and-p4.md))
- 直値を両層から消し，`learn.DEFAULT_TEST_RATIO` 1 つに寄せました．**片側だけ直すと必ずまた食い違う**ので，定数を共有する形にしないと同じ欠陥が戻ります (「同じ形で二度回帰しない修正を選ぶ」)．
- `infra/console` → `interface` の参照は既存の module-level import (`from maou.interface import learn`) を使っており，重い任意依存を新たに持ち込んでいません (CLAUDE.md の console 遅延解決ルール)．

## 回帰テスト

| テスト | 内容 |
|---|---|
| `test_default_test_ratio_matches_documented_value` | 定数が doc の 0.2 と一致することを固定 |
| `test_stage3_file_split_uses_the_shared_default` | console 側が直値の既定を持たないことをソース検査で固定 |

値ベースで固定できないのは，この分岐が S3/GCS streaming 経路の奥にあり到達にクラウド資格情報が要るためです．同ファイルの既存テスト `test_no_falsy_or_default_on_ratio_arguments` (backlog O4 の回帰) と同じ方針をとりました．**非空振りの確認**: console 側を `0.1` に戻すと `test_stage3_file_split_uses_the_shared_default` が落ちることを確認済みです．

## QA (このコンテナで実行済み)

- `uv run ruff format` / `ruff check --fix` → All checks passed
- `uv run mypy src/ tests/` → Success: no issues found in 290 source files
- `uv run pytest tests/maou/interface/` → **219 passed**
- pre-commit (full `pytest -v -s` を含む) 通過

## バージョン

`pyproject.toml` 0.86.3 → **0.86.4** (`fix:` → patch)．

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxiTWr29hNVeyegg8LuJMf)_