### PR TITLE
ci: cargo clippy を pre-commit の local hook に追加する

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,23 @@ repos:
     types_or: [rust]
     pass_filenames: false
     require_serial: true
+# clippy も cargo fmt と同じく local hook (toolchain の版と二重化しない)．
+# `-D warnings` で回す．2026-08-12 時点の workspace は `--all-targets` で
+# warning 0 なので，初回コストは無い (計測して確認済み)．
+# 0 を維持できなくなったら `-D warnings` を外すのではなく，warning を
+# 消すか `#[allow]` に理由コメントを付けて明示すること — 閾値を緩めると
+# 「warning はあるもの」に戻り，ゲートとして機能しなくなる．
+# `--all-targets` はテストコードも対象にする．過去 3 件の warning は
+# すべてテスト側にあった (lib だけ見ていると気付けない)．
+- repo: local
+  hooks:
+  - id: cargo-clippy
+    name: cargo-clippy
+    entry: cargo clippy --workspace --all-targets -- -D warnings
+    language: system
+    types_or: [rust]
+    pass_filenames: false
+    require_serial: true
 - repo: local
   hooks:
   - id: ruff-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "maou_index"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "polars",
  "pyo3",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "maou_shogi"
-version = "5.14.1"
+version = "5.14.2"
 dependencies = [
  "arrayvec",
  "rustc-hash",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "maou_usi"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "maou_search",
  "maou_shogi",

--- a/rust/maou_index/Cargo.toml
+++ b/rust/maou_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_index"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/rust/maou_index/src/index.rs
+++ b/rust/maou_index/src/index.rs
@@ -505,7 +505,7 @@ mod tests {
         drop(out);
 
         // 前提: File 形式ではない (判定が効いていることの確認)
-        assert!(!super::read_feather(&path).is_err());
+        assert!(super::read_feather(&path).is_ok());
 
         let mut index = DataIndex::new(ArrayType::HCPE, vec![path.clone()]);
         index.build_from_files().unwrap();

--- a/rust/maou_shogi/Cargo.toml
+++ b/rust/maou_shogi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_shogi"
-version = "5.14.1"
+version = "5.14.2"
 edition = "2021"
 description = "Shogi (Japanese chess) engine library for the maou project"
 

--- a/rust/maou_shogi/src/dfpn/tt/mod.rs
+++ b/rust/maou_shogi/src/dfpn/tt/mod.rs
@@ -1072,10 +1072,12 @@ mod warm_tests {
         // size = clamp(NODES * 2, 1<<18, 1<<23) = 600_000
         const NODES: u64 = 300_000;
         const SIZE: usize = 600_000;
-        assert!(
-            SIZE > (1 << 18) && SIZE < (1 << 23),
-            "clamp に掛からない前提"
-        );
+        const {
+            assert!(
+                SIZE > (1 << 18) && SIZE < (1 << 23),
+                "clamp に掛からない前提"
+            )
+        };
 
         assert_eq!(
             regular_pooled_count(SIZE),

--- a/rust/maou_usi/Cargo.toml
+++ b/rust/maou_usi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maou_usi"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 description = "USI (Universal Shogi Interface) game-playing agent for maou (protocol / agent / stdio layers)"
 

--- a/rust/maou_usi/src/agent.rs
+++ b/rust/maou_usi/src/agent.rs
@@ -1355,8 +1355,8 @@ mod tests {
     type Calls = Rc<RefCell<Vec<(String, Vec<String>, SearchBudget)>>>;
     type RulesLog = Rc<RefCell<Vec<GoRules>>>;
 
-    #[allow(clippy::type_complexity)] // impl Fn を含むタプル返却は alias 化不能 (TAIT 未安定)
     /// `solve_mate` の応答を指定して agent を組む (`go mate` テスト用)．
+    // impl Fn を含むタプル返却は alias 化不能 (TAIT 未安定)
     #[allow(clippy::type_complexity)]
     fn agent_with_mate(
         mate: CheckmateResult,
@@ -1375,6 +1375,8 @@ mod tests {
         })
     }
 
+    // 同上
+    #[allow(clippy::type_complexity)]
     fn agent_with_fake(
         outcome: SearchOutcome,
     ) -> (


### PR DESCRIPTION
`/audit-backlog` (2026-08-12, `cz2r2u`)．**base は #488 — stack の最上段**です。#479 の作り直し。

**この段だけ落としても下は無傷です。** 一番不確実な項目を最上段に置く，という
新しい規則 (#485) に従っています．要らなければ親にマージせず close してください．

## ご質問への回答: Actions の時間は増えません

**clippy は GitHub Actions では動きません．** これは `repo: local` の
pre-commit hook で，開発機のコミット時にだけ走ります．

CI の現状を確認しました:

| workflow | trigger | cargo を使うか |
|---|---|---|
| `build-wheel.yml` | `push: branches: [main]` + 手動 | **使う**．`maturin-action` に `sccache: "true"` 設定済み |
| `check-version-bump.yml` | `pull_request` | 使わない |
| `claude-code-review.yml` | `workflow_dispatch` のみ | 使わない |

つまり **PR でも push でも clippy は 1 秒も走りません**．追加される Actions
時間はゼロです．

**ローカルのコストは実測しました**: 既存の `target/` を共有して
**warm で約 5 秒**．ただし clippy は rustc とは別の成果物を出すので，
普通の `cargo build` のキャッシュは再利用できず，**clippy 初回だけ約 2 分**
かかります (以降は clippy 自身のキャッシュが効きます)．
`cargo fmt` の hook が既に同じ条件 (`types_or: [rust]`) で走っているので，
Rust を触るコミットで増えるのはこの分だけです．

wheel ビルドと同程度か，それより軽い範囲です．

## 決めてほしいこと

Rust を触るコミットのたびに
`cargo clippy --workspace --all-targets -- -D warnings` が走るようにするか．

backlog 行 (NEW-2) は「入れると既存 warning の数だけ初回コストが出る．
**まず計測してから可否を決めること**」として保留されていました．計測結果:

> **workspace 全体 (`--all-targets`) の warning は 3 件のみ．すべてテストコード．**

初回コストは実質ゼロです．3 件はこの PR で潰してあります．

**代替案**: `-D warnings` を付けず警告表示だけにする案 — 採りませんでした．
落ちないゲートは守られないためです．

## 潰した warning

| 場所 | lint | 修正 |
|---|---|---|
| `maou_usi/src/agent.rs` | `duplicated_attributes` | 同じ `#[allow]` が doc コメントを挟んで 2 つあった |
| `maou_usi/src/agent.rs` | `type_complexity` | `agent_with_fake` だけ `#[allow]` 漏れ |
| `maou_shogi/src/dfpn/tt/mod.rs` | `assertions_on_constants` | `const { assert!(..) }` に |
| `maou_index/src/index.rs` | `nonminimal_bool` | `assert!(!x.is_err())` → `assert!(x.is_ok())` |

**4 件目は，この hook が実際に捕まえたものです．** #478 で入れた回帰テストに
含まれていて，hook を有効にした瞬間に落ちました — ゲートが機能している証拠として
そのまま残してあります．

## この PR が消化する backlog 行

| 行 | 由来 | 対象 |
|---|---|---|
| **NEW-2** | [2026-08-12 backlog auto-band-and-n1](https://github.com/dousu/maou/blob/main/audits/2026-08-12-backlog-auto-band-and-n1.md) | `.pre-commit-config.yaml` |

## クラス判定

コード部分は **P3** — 変更はすべてテストコードで，実行時の挙動は変わりません．
ただし **G4** (行自身が「可否を決めること」と書いている) を保持したため
自動マージしていません．計測は G4 の**理由**を消しますが，
「入れるか」の決めはユーザのものです．

## QA (ローカルで実行・全て通過)

- `pre-commit run --all-files`: 全 hook Passed
  (pytest 全件 **1856 passed / 54 skipped**, 新 hook の `cargo-clippy` 含む)
- `cargo clippy --workspace --all-targets -- -D warnings`: **exit 0**
- `cargo test -p maou_index`: 14 passed

## バージョン

| manifest | old → new |
|---|---|
| `rust/maou_shogi/Cargo.toml` | 5.14.1 → 5.14.2 |
| `rust/maou_usi/Cargo.toml` | 0.29.0 → 0.29.1 |
| `rust/maou_index/Cargo.toml` | 0.1.2 → 0.1.3 (4 件目の warning 修正の分) |

## Stack (2026-08-12 /audit-backlog) — main へのマージは #485 の 1 回だけ

1. #485 P1 stack ルールの修正 (base: `main`) — 最後に `main` へ
2. #486 docs `reviews/` 提案 2 件 (base: #485)
3. #487 P5 `moveWinRate` を dtype に載せる (base: #486)
4. #488 P6 `file_level_split` 削除 (base: #487)
5. **#489 clippy hook (base: #488) ← このPR / 最上段**

上から順に親へマージし，最後に #485 を `main` へ 1 回だけマージしてください．


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4i1c4n32RdEqJr2bB2Wqx)_