### PR TITLE
docs(commands): audit-backlog の行削除を「同一PRに載せる」規則へ改める

### DIFF
--- a/.claude/commands/audit-backlog.md
+++ b/.claude/commands/audit-backlog.md
@@ -258,8 +258,10 @@ manual pass over every diff.
   open, with sharpened reasoning recorded), or rejected (won't do, recorded
   as such). Silently dropping a selected item is the one outcome that is
   not allowed.
-- **A backlog row is deleted when its fix has merged — not when it is
-  written.** An unmerged PR is an open finding (step 6a).
+- **A backlog row is deleted in the PR that carries its fix**, whenever
+  the two cannot merge apart. A row is kept only when its fix could land
+  — or fail to land — independently of the deletion, which in practice
+  means a judgment-band PR stacked above the `audits/` PR (step 6a).
 - **Ask at most once per run, and only under the test above.** A judgment
   class is a reason to open a PR unmerged, not a reason to interrupt.
 - **Every PR of the run is chained into one stack** (step 5b), and
@@ -267,6 +269,13 @@ manual pass over every diff.
   on `main`" case: the version bump and `uv.lock` make siblings conflict by
   construction, and every merge into `main` triggers a wheel build. The run
   lands on `main` once.
+- **One merge into `main` per run — bookkeeping included.** The ledger
+  update is part of the run, not a sequel to it: a row deletion, a
+  `reviews/` status transition, and the run's record all ride in the run's
+  single PR (6a). **Never open a follow-up PR into `main` to finish the
+  paperwork** — if a decision arrives too late for this run's PR, the next
+  run picks it up through step 2 (stale) and step 1e (merged-after-the-fact)
+  at no extra cost.
 
 ## Steps
 
@@ -324,9 +333,11 @@ work an earlier run could not finish itself:
 - **Stale stacks.** A PR still based on a merged or deleted branch shows a
   meaningless diff. Retarget and refresh it per 5b before anything else
   reads it.
-- **Merged PRs whose rows are still present.** 6a deletes a row when its
-  fix *merges*, and the merge often happens after the run ended. Confirm
-  against `main` and delete the row now, noting it in this run's record.
+- **Merged PRs whose rows are still present.** A row kept under 6a's
+  separability test outlives its PR when the merge happens after the run
+  ended. Confirm against `main`, delete the row **in this run's own PR**,
+  and note it in this run's record. This is the designed recovery path —
+  it is why a late decision never justifies a bookkeeping-only PR.
 - **`reviews/` proposals left `pending` whose decision has since been
   taken** (the PR carrying them merged, or the user answered on it). Apply
   the proposal, commit, set `status: applied` + `applied_in: <sha>`. This
@@ -570,6 +581,14 @@ If the session was handed a designated branch it must develop on, that
 mandate wins: commit everything there, open the single PR from it, and say
 in the report that class-per-PR was collapsed and why.
 
+**A collapsed run is all-or-nothing, and that changes 6a.** With one PR
+there is no way for the user to accept some items and reject others — the
+whole branch merges or it does not. So the ledger update belongs *inside*
+that PR: delete the rows for everything the PR ships, in the PR that ships
+it. Keeping them "until it merges" is what forces a second PR into `main`
+afterwards, which 5b exists to prevent. The commits are the review units
+here, so make each one a coherent class and say so in the body.
+
 **5b. Chain EVERY PR of the run into one stack. Exactly one of them
 targets `main`.**
 
@@ -720,8 +739,11 @@ to merge; the one-check principle exists precisely to avoid asking the same
 thing twice.
 
 If the user *does* answer in this session, apply what they decided, re-run
-the QA, and merge under 5d's conditions. If they do not, the PR **is** the
-handoff, and the backlog row stays put until it merges (6a).
+the QA, and merge under 5d's conditions — folding the ledger update into
+the same PR **before** merging it, never into a follow-up (6a). If they do
+not, the PR **is** the handoff, and whether its row stays put is 6a's
+separability test: kept when the PR can merge apart from the ledger,
+deleted with the fix when it cannot.
 
 **5f. Hand the PRs over as a row → PR table in the conversation.** The
 second moment in the standing principle above. The moment a judgment-band
@@ -748,17 +770,48 @@ the same breath, since "one PR" otherwise reads as "one decision."
 Three separate bookkeeping duties. All are required; the first is the one
 that keeps the backlog from growing forever.
 
-**6a. Delete the rows whose fixes have MERGED** — from **either** the
-Deferred backlog or the Out-of-scope backlog, whichever table held them.
-This is the step that makes consumption real; without it the finding is
-still open as far as every future run is concerned.
+**6a. Delete the rows in the PR that carries their fix** — from **either**
+the Deferred backlog or the Out-of-scope backlog, whichever table held
+them. This is the step that makes consumption real; without it the finding
+is still open as far as every future run is concerned.
 
-Merged, not written. A row whose fix sits in an open judgment-band PR is
-**still open**: the PR can be rejected, reworked, or closed, and a row
-deleted on the strength of an unmerged branch would take the finding out of
-the ledger with nothing on `main` to show for it. Keep the row and append
-the PR link to its text, so the next run sees the work is already in
-flight instead of starting it again.
+**The test is separability, not merge timing.** The reason a row is not
+deleted on the strength of an unmerged branch is that the PR can be
+rejected, reworked, or closed — leaving the ledger claiming a fix that
+`main` does not have. That risk exists only when the deletion and the fix
+can **diverge**: when they sit in different PRs that merge independently.
+
+So apply this test, not a calendar:
+
+- **The deletion rides in the same PR as its fix** → delete the row **in
+  that PR**. Merging accepts both; closing discards both. They cannot
+  diverge, so there is nothing to protect against. This is always the case
+  for a run collapsed into one PR (the designated-branch case in 5a), and
+  it is the normal case.
+- **The deletion would ride in a PR that can merge without its fix** →
+  keep the row and append the PR link to its text, so the next run sees
+  the work is in flight instead of starting it again. In a stack this is
+  the bottom (`audits/`) PR versus a judgment-band PR above it: the user
+  can close the upper PR and the bottom one still merges. Write those
+  deletions into the bottom branch only once the item is accepted, before
+  the single merge into `main`.
+
+**MUST NOT open a PR into `main` whose only content is ledger
+bookkeeping.** A row deletion is not worth a merge commit and a wheel
+build (5b), and it never needs one — when a decision lands after the run
+has ended, the **next** run collects it for free: step 2 re-verifies every
+row and marks one whose fix already shipped as **stale**, and step 1e
+deletes rows for PRs that merged after the fact. Both fold the deletion
+into that run's own single PR.
+
+A row that is one run stale costs one re-verification, which step 2
+performs anyway. A second merge into `main` costs a wheel build and
+breaks the one-merge-per-run property outright. Those are not close.
+
+The failure this prevents is concrete: the run of 2026-08-13 was collapsed
+into a single PR, kept its rows because that PR was unmerged, and so
+needed a **second** PR after the merge purely to delete them — two merges
+into `main` and two wheel builds for one run's worth of work.
 
 Also delete rows that step 2 found **stale**, noting in 6c that they were
 already fixed elsewhere rather than fixed here. Do **not** delete a row that
@@ -802,9 +855,10 @@ rather than a path audit. Body:
 - **Applied** — the fixes, with `file:line` and commit SHA.
 - **In flight** — judgment-band PRs left open, with their PR number, their
   base (`main`, or the PR they are stacked on and why), and the question
-  outstanding. Their backlog rows are still present by design (6a); this
-  section says why, and it is what step 1e of the next run reads to pick
-  them back up.
+  outstanding. Say for each whether its row was deleted here (the PR
+  carries both) or kept (the PR can merge apart from the ledger) — that is
+  6a's test, and this section is what step 1e of the next run reads to
+  pick the work back up.
 - **Re-triaged** — items selected but left open, with the sharpened reason.
   This is the section that earns the run its keep: a second impasse on the
   same item is far more informative than the first.
@@ -823,9 +877,15 @@ check as `/audit-and-fix` step 9x, and it applies here for the same
 reason: 6c tells you to *append* new out-of-scope items but never makes
 you verify the mapping is total. Assign every item this run touched, and
 every new finding it noticed, exactly one disposition — **resolved** (row
-deleted, fix merged) / **in flight** (row kept, PR linked) / **re-triaged**
-(row kept, text sharpened) / **new row** (id) / **not a finding** (reason).
+deleted in the PR that carries its fix) / **in flight** (row kept because
+its PR can merge apart from the ledger, PR linked) / **re-triaged** (row
+kept, text sharpened) / **new row** (id) / **not a finding** (reason).
 An item you cannot assign is the defect the check exists to catch.
+
+Note that **resolved** is decided by 6a's separability test, not by
+whether the merge button has been pressed yet. A collapsed single-PR run
+resolves its items *in that PR*; expecting to come back later and delete
+the rows is what produces a second merge into `main`.
 
 The two failure modes named in step 9x apply verbatim: consolidating
 several findings into one readable row drops the ones the merged prose
@@ -936,7 +996,14 @@ Keep the derive-never-enumerate property:
 - **A run that produces exactly one PR** — fine, and it is already the
   shape 5b converges on: one chain, one merge into `main`. Do not split a
   single coherent change into a stack to make the stack look used; do not
-  un-chain a multi-class run to avoid a stack.
+  un-chain a multi-class run to avoid a stack. Remember that a single PR
+  is all-or-nothing, so its ledger deletions go **in** it (6a) — the one
+  way to turn a one-PR run into a two-merge run is to leave the paperwork
+  for afterwards.
+- **A new kind of bookkeeping** (a new status file, a new index) — route
+  it by 6a's separability test, not by adding a case here: if it can only
+  be correct once the run's fixes land, it ships in the same PR as those
+  fixes. Bookkeeping never earns its own merge into `main`.
 - **A repo that stops building a wheel on `push: main`** — 5b's second
   reason weakens but the first does not. The version-bump rule alone still
   makes siblings off `main` conflict pairwise, so keep the chain.


### PR DESCRIPTION
## 直した欠陥

2026-08-13 の `/audit-backlog` run が **`main` へ 2 回マージ**しました — [#495](https://github.com/dousu/maou/pull/495) (run 本体) と [#496](https://github.com/dousu/maou/pull/496) (backlog 行の削除だけ)。5b の「1 run = 1 マージ」が破れ、最も重い wheel ビルドも 2 回走っています。

原因は step 6a の **「マージされてから削除」を無条件の規則として書いていた**ことです。

## なぜその規則が空回りしたか

6a が守っているのは「行の削除だけが先に `main` に載り、fix の方は拒否されて**台帳が嘘をつく**」状態です。

しかしその危険は、削除と fix が**別々にマージされうる**ときにしか存在しません。両方が同じ PR に載るなら、マージすれば両方通り、閉じれば両方消えるので、乖離しようがありません。

指定ブランチで 1 本に潰れた run は**常に**後者です。にもかかわらず「PR が未マージだから行は残す」と判断した結果、マージ後に行を消すためだけの 2 本目が構造的に強制されました。

## 変更内容

判定軸を **merge timing から separability へ**移しました。

| 状況 | 処理 |
|---|---|
| 削除と fix が**同じ PR** に載る | **その PR で行を削除する** (通常ケース。単一 PR run は常にこれ) |
| 削除が fix 抜きでマージされうる PR に載る | 行を残し PR リンクを付ける (stack の底の `audits/` PR と、その上の判断帯 PR の関係) |

併せて **「台帳の後片付けだけの PR を `main` に開くこと」を明示的に禁止**しました。

判断が run 終了後に来た場合の回収経路は**既に存在します**:
- **step 2** が全行を HEAD に対して再検証し、fix 済みの行を **stale** として落とす
- **step 1e** が後からマージされた PR の行を消す

どちらも次の run の**単一 PR に入る**ので、追加のマージは発生しません。1 run 分 stale な行のコストは再検証 1 回で、step 2 はどのみち全行に対してそれを実行します。これに対し `main` への 2 回目のマージは wheel ビルドを 1 本増やし、one-merge-per-run の性質そのものを壊します。

## 整合のため更新した箇所

単一の規則変更が矛盾を残さないよう、同じ前提に依存していた記述をすべて追随させました。

- **Hard constraints** — 「行はマージされたら削除」の箇条を separability の表現へ。bookkeeping 専用 PR の禁止を追加
- **5a** — 指定ブランチで collapse した run は all-or-nothing であり、それが 6a の適用を変えることを明記
- **5e** — セッション内で回答を得た場合、台帳更新を**同じ PR に入れてからマージ**する
- **6a** — 見出しを含めて全面改訂。今回の失敗を具体例として記録
- **6c** — `## In flight` 節に、行を削除したか残したかとその理由を書かせる
- **6d** — **resolved** の定義を「マージボタンが押されたか」ではなく separability で判定すると明記
- **1e** — 後からマージされた PR の行削除が「設計された回収経路」であることを明示
- **Extending** — 新種の bookkeeping が増えたときも同じテストで振り分ける旨を追加

## 検証

`grep` で残存する矛盾記述 (「unmerged branch」「until it merges」「not when it is written」) を洗い出し、すべて改訂済みか、新しい規則の説明文脈であることを確認しました。

`pre-commit run` 全 hook Passed (`test` 含む)。`.claude/` のみの変更なので version bump は不要です (P1 相当 — 出荷ファイルに触れない)。

---
_Generated by [Claude Code](https://claude.ai/code/session_0171MXtdv4yJbvKyruDyNoah)_